### PR TITLE
Some extensions allowing users to pass functions to define units for new particle types

### DIFF
--- a/swiftsimio/__init__.py
+++ b/swiftsimio/__init__.py
@@ -41,13 +41,22 @@ def mask(filename, spatial_only=True) -> SWIFTMask:
     return SWIFTMask(metadata=metadata, spatial_only=spatial_only)
 
 
-def load(filename, mask=None, generate_unit_func=metadata.unit_fields.generate_units, generate_cosmology_func=metadata.cosmology.cosmology_fields.generate_cosmology) -> SWIFTDataset:
+def load(
+    filename,
+    mask=None,
+    generate_unit_func=metadata.unit_fields.generate_units,
+    generate_cosmology_func=metadata.cosmology.cosmology_fields.generate_cosmology,
+) -> SWIFTDataset:
     """
     Loads the SWIFT dataset at filename.
     """
 
-    return SWIFTDataset(filename, mask=mask, generate_unit_func=generate_unit_func, 
-            generate_cosmology_func=generate_cosmology_func)
+    return SWIFTDataset(
+        filename,
+        mask=mask,
+        generate_unit_func=generate_unit_func,
+        generate_cosmology_func=generate_cosmology_func,
+    )
 
 
 # Rename this object to something simpler.

--- a/swiftsimio/__init__.py
+++ b/swiftsimio/__init__.py
@@ -41,12 +41,13 @@ def mask(filename, spatial_only=True) -> SWIFTMask:
     return SWIFTMask(metadata=metadata, spatial_only=spatial_only)
 
 
-def load(filename, mask=None) -> SWIFTDataset:
+def load(filename, mask=None, generate_unit_func=metadata.unit_fields.generate_units, generate_cosmology_func=metadata.cosmology.cosmology_fields.generate_cosmology) -> SWIFTDataset:
     """
     Loads the SWIFT dataset at filename.
     """
 
-    return SWIFTDataset(filename, mask=mask)
+    return SWIFTDataset(filename, mask=mask, generate_unit_func=generate_unit_func, 
+            generate_cosmology_func=generate_cosmology_func)
 
 
 # Rename this object to something simpler.

--- a/swiftsimio/metadata/unit/unit_fields.py
+++ b/swiftsimio/metadata/unit/unit_fields.py
@@ -84,12 +84,12 @@ def generate_units(m, l, t, I, T):
     }
 
 
-def generate_dimensions():
+def generate_dimensions(generate_unit_func = generate_units):
     """
     Gets the dimensions for the above.
     """
 
-    units = generate_units(g, cm, s, statA, K)
+    units = generate_unit_func(g, cm, s, statA, K)
 
     dimensions = {}
 

--- a/swiftsimio/metadata/unit/unit_fields.py
+++ b/swiftsimio/metadata/unit/unit_fields.py
@@ -9,6 +9,7 @@ because we don't know the units ahead of time.
 """
 
 from unyt import g, cm, s, statA, K
+from typing import Callable
 
 
 def generate_units(m, l, t, I, T):
@@ -84,7 +85,7 @@ def generate_units(m, l, t, I, T):
     }
 
 
-def generate_dimensions(generate_unit_func = generate_units):
+def generate_dimensions(generate_unit_func: Callable[..., dict] = generate_units):
     """
     Gets the dimensions for the above.
     """

--- a/swiftsimio/reader.py
+++ b/swiftsimio/reader.py
@@ -21,7 +21,7 @@ import numpy as np
 
 from datetime import datetime
 
-from typing import Union
+from typing import Union, Callable
 
 
 class SWIFTUnits(object):
@@ -42,9 +42,9 @@ class SWIFTUnits(object):
     to get it 'unyt-ified' with the correct units.
     """
 
-    def __init__(self, filename):
+    def __init__(self, filename, generate_unit_func=metadata.unit_fields.generate_units):
         self.filename = filename
-
+        self.generate_unit_func = generate_unit_func
         self.get_unit_dictionary()
         self.generate_units()
 
@@ -75,7 +75,7 @@ class SWIFTUnits(object):
         Creates the unyt system to use to reduce data.
         """
 
-        unit_fields = metadata.unit_fields.generate_units(
+        unit_fields = self.generate_unit_func(
             m=self.mass, l=self.length, t=self.time, I=self.current, T=self.temperature
         )
 
@@ -528,7 +528,9 @@ class __SWIFTParticleDataset(object):
         return
 
 
-def generate_dataset(filename, particle_type: int, file_metadata: SWIFTMetadata, mask):
+def generate_dataset(filename, particle_type: int, file_metadata: SWIFTMetadata, mask,
+                     generate_cosmology_func: Callable[...,dict] = 
+                     metadata.cosmology.cosmology_fields.generate_cosmology):
     """
     Generates a SWIFTParticleDataset _class_ that corresponds to the
     particle type given.
@@ -547,7 +549,7 @@ def generate_dataset(filename, particle_type: int, file_metadata: SWIFTMetadata,
     particle_name = metadata.particle_types.particle_name_underscores[particle_type]
     particle_nice_name = metadata.particle_types.particle_name_class[particle_type]
     unit_system = getattr(file_metadata.units, particle_name)
-    cosmology_system = metadata.cosmology.cosmology_fields.generate_cosmology(
+    cosmology_system = generate_cosmology_func(
         file_metadata.a, file_metadata.gas_gamma
     )
 
@@ -624,10 +626,12 @@ class SWIFTDataset(object):
     SWIFTDataset.metadata.
     """
 
-    def __init__(self, filename, mask=None):
+    def __init__(self, filename, mask=None, generate_unit_func=metadata.unit_fields.generate_units,
+                 generate_cosmology_func=metadata.cosmology.cosmology_fields.generate_cosmology):
         self.filename = filename
         self.mask = mask
-
+        self.generate_unit_func = generate_unit_func
+        self.generate_cosmology_func = generate_cosmology_func
         if mask is not None:
             self.mask.convert_masks_to_ranges()
 
@@ -643,7 +647,7 @@ class SWIFTDataset(object):
         but you can call this function again if you mess things up.
         """
 
-        self.units = SWIFTUnits(self.filename)
+        self.units = SWIFTUnits(self.filename, generate_unit_func=self.generate_unit_func)
 
         return
 
@@ -671,7 +675,8 @@ class SWIFTDataset(object):
             setattr(
                 self,
                 name,
-                generate_dataset(self.filename, ptype, self.metadata, self.mask),
+                generate_dataset(self.filename, ptype, self.metadata, self.mask, 
+                    self.generate_cosmology_func),
             )
 
         return

--- a/swiftsimio/reader.py
+++ b/swiftsimio/reader.py
@@ -42,9 +42,14 @@ class SWIFTUnits(object):
     to get it 'unyt-ified' with the correct units.
     """
 
-    def __init__(self, filename, generate_unit_func=metadata.unit_fields.generate_units):
+    def __init__(
+        self,
+        filename,
+        generate_unit_func: Callable[..., dict] = metadata.unit_fields.generate_units,
+    ):
         self.filename = filename
         self.generate_unit_func = generate_unit_func
+
         self.get_unit_dictionary()
         self.generate_units()
 
@@ -528,9 +533,15 @@ class __SWIFTParticleDataset(object):
         return
 
 
-def generate_dataset(filename, particle_type: int, file_metadata: SWIFTMetadata, mask,
-                     generate_cosmology_func: Callable[...,dict] = 
-                     metadata.cosmology.cosmology_fields.generate_cosmology):
+def generate_dataset(
+    filename,
+    particle_type: int,
+    file_metadata: SWIFTMetadata,
+    mask,
+    generate_cosmology_func: Callable[
+        ..., dict
+    ] = metadata.cosmology.cosmology_fields.generate_cosmology,
+):
     """
     Generates a SWIFTParticleDataset _class_ that corresponds to the
     particle type given.
@@ -549,9 +560,7 @@ def generate_dataset(filename, particle_type: int, file_metadata: SWIFTMetadata,
     particle_name = metadata.particle_types.particle_name_underscores[particle_type]
     particle_nice_name = metadata.particle_types.particle_name_class[particle_type]
     unit_system = getattr(file_metadata.units, particle_name)
-    cosmology_system = generate_cosmology_func(
-        file_metadata.a, file_metadata.gas_gamma
-    )
+    cosmology_system = generate_cosmology_func(file_metadata.a, file_metadata.gas_gamma)
 
     ThisDataset = type(
         f"{particle_nice_name}Dataset",
@@ -626,12 +635,20 @@ class SWIFTDataset(object):
     SWIFTDataset.metadata.
     """
 
-    def __init__(self, filename, mask=None, generate_unit_func=metadata.unit_fields.generate_units,
-                 generate_cosmology_func=metadata.cosmology.cosmology_fields.generate_cosmology):
+    def __init__(
+        self,
+        filename,
+        mask=None,
+        generate_unit_func: Callable[..., dict] = metadata.unit_fields.generate_units,
+        generate_cosmology_func: Callable[
+            ..., dict
+        ] = metadata.cosmology.cosmology_fields.generate_cosmology,
+    ):
         self.filename = filename
         self.mask = mask
         self.generate_unit_func = generate_unit_func
         self.generate_cosmology_func = generate_cosmology_func
+
         if mask is not None:
             self.mask.convert_masks_to_ranges()
 
@@ -647,7 +664,9 @@ class SWIFTDataset(object):
         but you can call this function again if you mess things up.
         """
 
-        self.units = SWIFTUnits(self.filename, generate_unit_func=self.generate_unit_func)
+        self.units = SWIFTUnits(
+            self.filename, generate_unit_func=self.generate_unit_func
+        )
 
         return
 
@@ -675,8 +694,13 @@ class SWIFTDataset(object):
             setattr(
                 self,
                 name,
-                generate_dataset(self.filename, ptype, self.metadata, self.mask, 
-                    self.generate_cosmology_func),
+                generate_dataset(
+                    self.filename,
+                    ptype,
+                    self.metadata,
+                    self.mask,
+                    self.generate_cosmology_func,
+                ),
             )
 
         return

--- a/swiftsimio/writer.py
+++ b/swiftsimio/writer.py
@@ -10,7 +10,7 @@ import unyt
 import h5py
 import numpy as np
 
-from typing import Union, List
+from typing import Union, List, Callable
 from functools import reduce
 
 from swiftsimio import metadata
@@ -207,7 +207,8 @@ def generate_deleter(name: str):
     return deleter
 
 
-def generate_dataset(unit_system: Union[unyt.UnitSystem, str], particle_type: int):
+def generate_dataset(unit_system: Union[unyt.UnitSystem, str], particle_type: int, 
+     unit_fields_generate_units: Callable[...,dict] = metadata.unit_fields.generate_units):
     """
     Generates a SWIFTWriterParticleDataset _class_ that corresponds to the
     particle type given.
@@ -233,7 +234,7 @@ def generate_dataset(unit_system: Union[unyt.UnitSystem, str], particle_type: in
     )
 
     # Get the unit dimensions
-    dimensions = metadata.unit_fields.generate_dimensions()
+    dimensions = metadata.unit_fields.generate_dimensions(unit_fields_generate_units)
 
     for name in getattr(metadata.required_fields, particle_name).keys():
         setattr(
@@ -271,6 +272,7 @@ class SWIFTWriterDataset(object):
         dimension=3,
         compress=True,
         extra_header: Union[None, dict] = None,
+        unit_fields_generate_units: Callable[...,dict] = metadata.unit_fields.generate_units,
     ):
         """
         Requires a unit system, either one from unyt or a string describing a
@@ -281,7 +283,7 @@ class SWIFTWriterDataset(object):
         available. If you are generating initial conditions for a dimensionality
         other than 3, you will want to set the (integer) dimension parameter.
         """
-
+        self.unit_fields_generate_units = unit_fields_generate_units
         if isinstance(unit_system, str):
             self.unit_system = unyt.unit_systems.unit_system_registry[unit_system]
         else:
@@ -308,7 +310,8 @@ class SWIFTWriterDataset(object):
 
     def create_particle_datasets(self):
         for number, name in metadata.particle_types.particle_name_underscores.items():
-            setattr(self, name, generate_dataset(self.unit_system, number))
+            setattr(self, name, generate_dataset(self.unit_system, number, 
+                    self.unit_fields_generate_units))
 
         return
 
@@ -333,9 +336,9 @@ class SWIFTWriterDataset(object):
         Writes metadata to file based on the information passed to the object
         and the information in the particle groups.
         """
-
-        number_of_particles = [0] * 6
-        mass_table = [0.0] * 6
+        part_types = max(metadata.particle.particle_name_underscores.keys())+1
+        number_of_particles = [0] * part_types
+        mass_table = [0.0] * part_types
 
         for number, name in metadata.particle_types.particle_name_underscores.items():
             if name in names_to_write:

--- a/swiftsimio/writer.py
+++ b/swiftsimio/writer.py
@@ -207,8 +207,13 @@ def generate_deleter(name: str):
     return deleter
 
 
-def generate_dataset(unit_system: Union[unyt.UnitSystem, str], particle_type: int, 
-     unit_fields_generate_units: Callable[...,dict] = metadata.unit_fields.generate_units):
+def generate_dataset(
+    unit_system: Union[unyt.UnitSystem, str],
+    particle_type: int,
+    unit_fields_generate_units: Callable[
+        ..., dict
+    ] = metadata.unit_fields.generate_units,
+):
     """
     Generates a SWIFTWriterParticleDataset _class_ that corresponds to the
     particle type given.
@@ -272,7 +277,9 @@ class SWIFTWriterDataset(object):
         dimension=3,
         compress=True,
         extra_header: Union[None, dict] = None,
-        unit_fields_generate_units: Callable[...,dict] = metadata.unit_fields.generate_units,
+        unit_fields_generate_units: Callable[
+            ..., dict
+        ] = metadata.unit_fields.generate_units,
     ):
         """
         Requires a unit system, either one from unyt or a string describing a
@@ -310,8 +317,13 @@ class SWIFTWriterDataset(object):
 
     def create_particle_datasets(self):
         for number, name in metadata.particle_types.particle_name_underscores.items():
-            setattr(self, name, generate_dataset(self.unit_system, number, 
-                    self.unit_fields_generate_units))
+            setattr(
+                self,
+                name,
+                generate_dataset(
+                    self.unit_system, number, self.unit_fields_generate_units
+                ),
+            )
 
         return
 
@@ -336,7 +348,7 @@ class SWIFTWriterDataset(object):
         Writes metadata to file based on the information passed to the object
         and the information in the particle groups.
         """
-        part_types = max(metadata.particle.particle_name_underscores.keys())+1
+        part_types = max(metadata.particle.particle_name_underscores.keys()) + 1
         number_of_particles = [0] * part_types
         mass_table = [0.0] * part_types
 

--- a/tests/test_extraparts.py
+++ b/tests/test_extraparts.py
@@ -1,0 +1,131 @@
+"""
+Test for extra particle types.
+"""
+import swiftsimio as sw
+from swiftsimio import load
+from swiftsimio import Writer
+from swiftsimio.units import cosmo_units
+import swiftsimio.metadata.particle as swp
+import swiftsimio.metadata.writer.required_fields as swmw
+import swiftsimio.metadata.unit.unit_fields as swuf
+import swiftsimio.metadata.cosmology as swcf
+
+
+import unyt
+import numpy as np
+
+import os
+
+
+def generate_units(m, l, t, I, T):
+    """
+       This function is used to override the inbuilt swiftsimio generate_units function from
+       metadata.unit.unit_fields. This allows the specification of a new particle type and 
+       the values and types associated with that type.
+    """
+    dict_out = swuf.generate_units(m, l, t, I, T)
+
+    extratype = {
+        "coordinates": l,
+        "masses": m,
+        "particle_ids": None,
+        "velocities": l / t,
+        "potential": l * l / (t * t),
+        "density": m / (l ** 3),
+        "entropy": m * l ** 2 / (t ** 2 * T),
+        "internal_energy": (l / t) ** 2,
+        "smoothing_length": l,
+        "pressure": m / (l * t ** 2),
+        "diffusion": None,
+        "sfr": m / t,
+        "temperature": T,
+        "viscosity": None,
+        "specific_sfr": 1 / t,
+        "material_id": None,
+        "diffusion": None,
+        "viscosity": None,
+        "radiated_energy": m * (l / t) ** 2,
+    }
+
+    dict_out["extratype"] = extratype
+    return dict_out
+
+
+def generate_cosmology(scale_factor: float, gamma: float):
+    """
+        This function is used to override the inbuilt swiftsimio generate_cosmology function
+        from metadata.cosmology. This allows the specification of a new particle type and 
+        affects how the type is influenced by cosmology. Required only for reading in new
+        particle types.
+    """
+    from swiftsimio.objects import cosmo_factor, a
+
+    def cosmo_factory(a_dependence):
+        return cosmo_factor(a_dependence, scale_factor)
+
+    dict_out = swcf.generate_cosmology(scale_factor, gamma)
+    no_cosmology = cosmo_factory(a / a)
+    UNKNOWN = no_cosmology
+
+    extratype = {**dict_out["gas"]}
+
+    dict_out["extratype"] = extratype
+
+    return dict_out
+
+
+def test_write():
+    """
+        Tests whether swiftsimio can handle a new particle type. If the test doesn't crash
+        this is a success.
+    """
+    # Use default units, i.e. cm, grams, seconds, Ampere, Kelvin
+    unit_system = unyt.UnitSystem(
+        name="default", length_unit=unyt.cm, mass_unit=unyt.g, time_unit=unyt.s
+    )
+    #Specify a new type in the metadata - currently done by editing the dictionaries directly.
+    swp.particle_name_underscores[6] = "extratype"
+    swp.particle_name_class[6] = "Extratype"
+    swp.particle_name_text[6] = "Extratype"
+
+    swmw.extratype = {"smoothing_length": "SmoothingLength", **swmw.shared}
+
+    boxsize = 10 * unyt.cm
+
+    x = Writer(unit_system, boxsize, unit_fields_generate_units=generate_units)
+
+    x.extratype.coordinates = np.zeros((10, 3)) * unyt.cm
+    for i in range(0, 10):
+        x.extratype.coordinates[i][0] = float(i)
+
+    x.extratype.velocities = np.zeros((10, 3)) * unyt.cm / unyt.s
+
+    x.extratype.masses = np.ones(10, dtype=float) * unyt.g
+
+    x.extratype.smoothing_length = np.ones(10, dtype=float) * (5.0 * unyt.cm)
+
+    x.write("extra_test.hdf5")
+
+
+def test_read():
+    """
+        Tests whether swiftsimio can handle a new particle type. Has a few asserts to check the
+        data is read in correctly.
+    """
+    swp.particle_name_underscores[6] = "extratype"
+    swp.particle_name_class[6] = "Extratype"
+    swp.particle_name_text[6] = "Extratype"
+
+    swmw.extratype = {"smoothing_length": "SmoothingLength", **swmw.shared}
+
+    sw.metadata.particle_fields.extratype = {**sw.metadata.particle_fields.gas}
+
+    data = sw.load(
+        "extra_test.hdf5",
+        generate_unit_func=generate_units,
+        generate_cosmology_func=generate_cosmology,
+    )
+
+    for i in range(0, 10):
+        assert data.extratype.coordinates.value[i][0] == float(i)
+    os.remove("extra_test.hdf5")


### PR DESCRIPTION
Sort of a workaround more than something massively portable, but it does allow me to add new particle types without needing to edit the files in swiftsimio.

The tests create boundary and fluid particles with some arbitrary units/cosmology.

I'll try and include some examples and document the examples later.

The examples I was using was:
writing_test.py
```
from swiftsimio import Writer
import swiftsimio.metadata.particle as swp
import swiftsimio.metadata.writer.required_fields as swmw
import swiftsimio.metadata.unit.unit_fields as swuf
import numpy as np
import unyt
import pdb


def generate_units(m, l, t, I, T):
    dict_out = swuf.generate_units(m , l, t, I, T)

    boundary = {
            "coordinates" : l,
            "masses": m,
            "particle_ids": None,
            "velocities": l / t,
            "potential": l * l / (t * t),
            "density": m / (l ** 3),
            "entropy": m * l ** 2 / (t ** 2 * T),
            "internal_energy": (l / t) ** 2,
            "smoothing_length": l,
            "pressure": m / (l * t ** 2),
            "diffusion": None,
            "sfr": m / t,
            "temperature": T,
            "viscosity": None,
            "specific_sfr": 1 / t,
            "material_id": None,
            "diffusion": None,
            "viscosity": None,
            "radiated_energy": m * (l / t) ** 2,
            }
    fluid = { **boundary }

    dict_out["boundary"] = boundary
    dict_out["fluid"] = fluid
    return dict_out


#Use default units, i.e. cm, grams, seconds, Ampere, Kelvin
unit_system = unyt.UnitSystem(name="default", length_unit=unyt.cm, mass_unit=unyt.g, time_unit=unyt.s)

#Add boundary particle type
swp.particle_name_underscores[6] = "boundary"
swp.particle_name_class[6] = "Boundary"
swp.particle_name_text[6] = "Boundary"

swp.particle_name_underscores[7] = "fluid"
swp.particle_name_class[7] = "Fluid"
swp.particle_name_text[7] = "Fluid"

swmw.fluid = {'smoothing_length' : 'SmoothingLength', **swmw.shared}
swmw.boundary = { **swmw.fluid }



n_hydro = 1
n_boundary = 6
n_p = n_hydro + n_boundary

boxsize = 100*unyt.cm

x = Writer(unit_system, boxsize, unit_fields_generate_units=generate_units)


x.boundary.coordinates = np.zeros((n_boundary,3)) * unyt.cm
for i in range(0, n_boundary // 2):
    x.boundary.coordinates[i][0] = (45.0 + float(5*i)) * unyt.cm
    x.boundary.coordinates[i][1] = 25.0 * unyt.cm
    x.boundary.coordinates[i][2] = 50.0 * unyt.cm

for i in range(0, n_boundary//2):
    x.boundary.coordinates[n_boundary//2 + i][0] = (45.0 + float(5*i)) * unyt.cm
    x.boundary.coordinates[n_boundary//2 + i][1] = 35.0 * unyt.cm
    x.boundary.coordinates[n_boundary//2 + i][2] = 50.0 * unyt.cm

x.boundary.velocities = np.zeros((n_boundary,3)) * unyt.cm/unyt.s

x.boundary.masses = np.ones(n_boundary, dtype = float) * unyt.g

x.boundary.smoothing_length = np.ones(n_boundary, dtype = float) * (5.0 * unyt.cm)



x.fluid.coordinates = np.zeros((n_hydro,3)) * unyt.cm
x.fluid.coordinates[0][0] = 50.0 * unyt.cm
x.fluid.coordinates[0][1] = 75.0 * unyt.cm
x.fluid.coordinates[0][2] = 50.0 * unyt.cm


x.fluid.velocities = np.zeros((n_hydro,3)) * unyt.cm/unyt.s

x.fluid.masses = np.ones(n_hydro, dtype = float) * unyt.g

x.fluid.smoothing_length = np.ones(n_hydro, dtype = float) * (5.0 * unyt.cm)

x.write("boundary_test.hdf5")
```

reading_test.py
```
import matplotlib.pyplot as plt
import swiftsimio as sw
import swiftsimio.metadata.particle as swp
import swiftsimio.metadata.writer.required_fields as swmw
import swiftsimio.metadata.unit.unit_fields as swuf
import swiftsimio.metadata.cosmology as swcf


def generate_units(m, l, t, I, T):
    dict_out = swuf.generate_units(m , l, t, I, T)

    boundary = {
            "coordinates" : l,
            "masses": m,
            "particle_ids": None,
            "velocities": l / t,
            "potential": l * l / (t * t),
            "density": m / (l ** 3),
            "entropy": m * l ** 2 / (t ** 2 * T),
            "internal_energy": (l / t) ** 2,
            "smoothing_length": l,
            "pressure": m / (l * t ** 2),
            "diffusion": None,
            "sfr": m / t,
            "temperature": T,
            "viscosity": None,
            "specific_sfr": 1 / t,
            "material_id": None,
            "diffusion": None,
            "viscosity": None,
            "radiated_energy": m * (l / t) ** 2,
            }
    fluid = { **boundary }

    dict_out["boundary"] = boundary
    dict_out["fluid"] = fluid
    return dict_out

def generate_cosmology(scale_factor: float, gamma: float):
    from swiftsimio.objects import cosmo_factor, a
    def cosmo_factory(a_dependence):
        return cosmo_factor(a_dependence, scale_factor)

    dict_out = swcf.generate_cosmology(scale_factor, gamma)
    no_cosmology = cosmo_factory(a / a)
    UNKNOWN = no_cosmology

    boundary = { **dict_out["gas"] }
    fluid = { **dict_out["gas"] }

    dict_out["boundary"] = boundary
    dict_out["fluid"] = fluid

    return dict_out


#Add boundary particle type
swp.particle_name_underscores[6] = "boundary"
swp.particle_name_class[6] = "Boundary"
swp.particle_name_text[6] = "Boundary"

swp.particle_name_underscores[7] = "fluid"
swp.particle_name_class[7] = "Fluid"
swp.particle_name_text[7] = "Fluid"

sw.metadata.particle_fields.boundary = { **sw.metadata.particle_fields.gas }
sw.metadata.particle_fields.fluid =  { **sw.metadata.particle_fields.gas }

swmw.fluid = {'smoothing_length' : 'SmoothingLength', **swmw.shared}
swmw.boundary = { **swmw.fluid }


data = sw.load("boundary_test.hdf5", generate_unit_func=generate_units, generate_cosmology_func=generate_cosmology)

print(type(data.boundary.coordinates.value))
#print(data.gas.coordinates.value)
#print(data.gas.coordinates.value[0][:])
#print(data.gas.coordinates.value[1][:])
# [y[0] for y in x]
plt.scatter([y[0] for y in data.boundary.coordinates.value], [y[1] for y in data.boundary.coordinates.value])
plt.scatter([y[0] for y in data.fluid.coordinates.value], [y[1] for y in data.fluid.coordinates.value])


plt.show()
```