### PR TITLE
Read perf improvements

### DIFF
--- a/tests/helper.py
+++ b/tests/helper.py
@@ -4,6 +4,7 @@ Contains helper functions for the test routines.
 
 import subprocess
 import os
+import h5py
 
 webstorage_location = "http://virgodb.cosma.dur.ac.uk/swift-webstorage/IOExamples/"
 test_data_location = "test_data/"
@@ -54,3 +55,11 @@ def requires(filename):
         return do_call_test
 
     raise Exception("You should never have got here.")
+
+
+def create_in_memory_hdf5(filename="f1"):
+    """
+    Creates an in-memory hdf5 file object.
+    """
+
+    return h5py.File(filename, driver="core", mode="a", backing_store=False)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -128,7 +128,7 @@ def test_units(filename):
 
 
 @requires("cosmological_volume.hdf5")
-def test_metadata_is_valid(filename):
+def test_cell_metadata_is_valid(filename):
     """
     Test that the metadata does what we think it does!
 
@@ -136,13 +136,20 @@ def test_metadata_is_valid(filename):
     """
 
     mask_region = mask(filename)
-    data = load(filename)
+    # Because we sort by offset if we are using the metadata we
+    # must re-order the data to be in the correct order
+    spatial_constraint = mask_region.constrain_spatial(
+        [[0 * b, b] for b in mask_region.metadata.boxsize]
+    )
+    data = load(filename, mask=mask_region)
 
     cell_size = mask_region.cell_size.to(data.gas.coordinates.units)
     boxsize = mask_region.metadata.boxsize[0].to(data.gas.coordinates.units)
     offsets = mask_region.offsets["gas"]
-    start_offset = offsets[:-1]
-    stop_offset = offsets[1:]
+    counts = mask_region.counts["gas"]
+
+    start_offset = offsets
+    stop_offset = offsets + counts
 
     for center, start, stop in zip(
         mask_region.centers.to(data.gas.coordinates.units), start_offset, stop_offset


### PR DESCRIPTION
Significant performance improvements for reading data using the spatial masks. Previously we were not using sorted offsets, and this meant that our data accesses were all over the place, causing really long latencies from the filesystem and an inability to use read-ahead caching. This MR:

+ Sorts the cell offsets and positions in a stable way.
+ Ensures that the routines to read data from hdf5 files use read_direct to avoid creating copies of data.
+ Cleans up some tests that were using numpy arrays instead of hdf5 file objects.