### PR TITLE
Remove hand-casting of units in unyt

### DIFF
--- a/swiftsimio/masks.py
+++ b/swiftsimio/masks.py
@@ -210,13 +210,13 @@ class SWIFTMask(object):
         with h5py.File(self.metadata.filename, "r") as file:
             # Surprisingly this is faster than just using the boolean
             # indexing because h5py has slow indexing routines.
-            data = (
+            data = unyt.unyt_array(
                 np.take(
                     file[f"PartType{particle_number}/{handle}"],
                     np.where(current_mask)[0],
                     axis=0,
-                )
-                * unit
+                ),
+                units=unit,
             )
 
         new_mask = np.logical_and.reduce([data > lower, data <= upper])

--- a/swiftsimio/metadata/metadata/metadata_fields.py
+++ b/swiftsimio/metadata/metadata/metadata_fields.py
@@ -20,14 +20,14 @@ metadata_fields_to_read = {
 
 # These will be unpacked to the top-level object. Be careful not to overwrite
 # things in the same namespace!
-header_unpack_variables = {
+header_unpack_arrays = {
     "BoxSize": "boxsize",
     "NumPart_ThisFile": "num_part",
     "MassTable": "mass_table",
 }
 
 
-def generate_units_header_unpack_variables(m, l, t, I, T) -> dict:
+def generate_units_header_unpack_arrays(m, l, t, I, T) -> dict:
     """
     Generates the unit dictionaries with the:
 

--- a/swiftsimio/units.py
+++ b/swiftsimio/units.py
@@ -20,8 +20,8 @@ try:
     cosmo_units = unyt.UnitSystem(
         "cosmological",
         unyt.Mpc,
-        1e10 * unyt.Solar_Mass,
-        (1.0 * unyt.s * unyt.Mpc / unyt.km).to(unyt.Gyr),
+        unyt.unyt_quantity(1e10, units=unyt.Solar_Mass),
+        unyt.unyt_quantity(1.0, units=unyt.s * unyt.Mpc / unyt.km).to(unyt.Gyr),
     )
 except RuntimeError:
     # We've already done that, oops.

--- a/swiftsimio/visualisation/projection.py
+++ b/swiftsimio/visualisation/projection.py
@@ -410,4 +410,4 @@ def project_gas(
     if project is not None:
         units *= getattr(data.gas, project).units
 
-    return image * units
+    return unyt_array(image, units=units)

--- a/swiftsimio/visualisation/slice.py
+++ b/swiftsimio/visualisation/slice.py
@@ -503,4 +503,4 @@ def slice_gas(
     if project is not None:
         units *= getattr(data.gas, project).units
 
-    return image * units
+    return unyt_array(image, units=units)

--- a/swiftsimio/visualisation/smoothing_length_generation.py
+++ b/swiftsimio/visualisation/smoothing_length_generation.py
@@ -4,7 +4,7 @@ that do not usually carry a smoothing length field (e.g. dark matter).
 """
 
 from swiftsimio.objects import cosmo_array
-from swiftsimio.optional_packages import KDTree, TREE_AVAILABLE 
+from swiftsimio.optional_packages import KDTree, TREE_AVAILABLE
 from unyt import unyt_array
 from numpy import empty, float32
 
@@ -92,8 +92,7 @@ def generate_smoothing_lengths(
 
         smoothing_lengths[starting_index:ending_index] = d[:, -1]
 
-    return (
-        smoothing_lengths
-        * (hsml_correction_fac_speedup / kernel_gamma)
-        * coordinates.units
+    return unyt_array(
+        smoothing_lengths * (hsml_correction_fac_speedup / kernel_gamma),
+        units=coordinates.units,
     )

--- a/swiftsimio/visualisation/volume_render.py
+++ b/swiftsimio/visualisation/volume_render.py
@@ -434,4 +434,4 @@ def render_gas(
     if project is not None:
         units *= getattr(data.gas, project).units
 
-    return image * units
+    return unyt_array(image, units=units)


### PR DESCRIPTION
Fixes #30 by using `unyt_quantity` and `unyt_array` rather than `* units`