### PR TITLE
Maximal array index fix

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -34,3 +34,5 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
+      env:
+        NUMBA_BOUNDSCHECK: 1

--- a/swiftsimio/visualisation/projection_backends/fast.py
+++ b/swiftsimio/visualisation/projection_backends/fast.py
@@ -121,7 +121,7 @@ def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray
                 max(0, particle_cell_x - cells_spanned),
                 # Ensure that the highest x value lies within the array bounds,
                 # otherwise we'll segfault (oops).
-                min(particle_cell_x + cells_spanned + 1, maximal_array_index),
+                min(particle_cell_x + cells_spanned + 1, maximal_array_index + 1),
             ):
                 # The distance in x to our new favourite cell -- remember that our x, y
                 # are all in a box of [0, 1]; calculate the distance to the cell centre
@@ -129,7 +129,7 @@ def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray
                 distance_x_2 = distance_x * distance_x
                 for cell_y in range(
                     max(0, particle_cell_y - cells_spanned),
-                    min(particle_cell_y + cells_spanned + 1, maximal_array_index),
+                    min(particle_cell_y + cells_spanned + 1, maximal_array_index + 1),
                 ):
                     distance_y = (float32(cell_y) + 0.5) * pixel_width - float32(y_pos)
                     distance_y_2 = distance_y * distance_y

--- a/swiftsimio/visualisation/projection_backends/fast.py
+++ b/swiftsimio/visualisation/projection_backends/fast.py
@@ -71,7 +71,7 @@ def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray
     """
     # Output array for our image
     image = zeros((res, res), dtype=float32)
-    maximal_array_index = int32(res)
+    maximal_array_index = int32(res) - 1
 
     # Change that integer to a float, we know that our x, y are bounded
     # by [0, 1].

--- a/swiftsimio/visualisation/projection_backends/gpu.py
+++ b/swiftsimio/visualisation/projection_backends/gpu.py
@@ -101,7 +101,7 @@ def scatter_gpu(x: float64, y: float64, m: float32, h: float32, img: float32):
     """
     # Output array for our image
     res = img.shape[0]
-    maximal_array_index = int32(res)
+    maximal_array_index = int32(res) - 1
 
     # Change that integer to a float, we know that our x, y are bounded
     # by [0, 1].

--- a/swiftsimio/visualisation/projection_backends/gpu.py
+++ b/swiftsimio/visualisation/projection_backends/gpu.py
@@ -160,7 +160,7 @@ def scatter_gpu(x: float64, y: float64, m: float32, h: float32, img: float32):
                 max(0, particle_cell_x - cells_spanned),
                 # Ensure that the highest x value lies within the array bounds,
                 # otherwise we'll segfault (oops).
-                min(particle_cell_x + cells_spanned + 1, maximal_array_index),
+                min(particle_cell_x + cells_spanned + 1, maximal_array_index + 1),
             ):
                 # The distance in x to our new favourite cell
                 # remember that our x, y are all in a box of [0, 1]
@@ -170,7 +170,7 @@ def scatter_gpu(x: float64, y: float64, m: float32, h: float32, img: float32):
                 distance_x_2 = distance_x * distance_x
                 for cell_y in range(
                     max(0, particle_cell_y - cells_spanned),
-                    min(particle_cell_y + cells_spanned + 1, maximal_array_index),
+                    min(particle_cell_y + cells_spanned + 1, maximal_array_index + 1),
                 ):
                     distance_y = (float32(cell_y) + 0.5) * pixel_width
                     distance_y -= float32(y_pos)

--- a/swiftsimio/visualisation/projection_backends/reference.py
+++ b/swiftsimio/visualisation/projection_backends/reference.py
@@ -113,7 +113,7 @@ def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray
                 max(0, particle_cell_x - cells_spanned),
                 # Ensure that the highest x value lies within the array bounds,
                 # otherwise we'll segfault (oops).
-                min(particle_cell_x + cells_spanned + 1, maximal_array_index),
+                min(particle_cell_x + cells_spanned + 1, maximal_array_index + 1),
             ):
                 # The distance in x to our new favourite cell -- remember that our x, y
                 # are all in a box of [0, 1]; calculate the distance to the cell centre
@@ -121,7 +121,7 @@ def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray
                 distance_x_2 = distance_x * distance_x
                 for cell_y in range(
                     max(0, particle_cell_y - cells_spanned),
-                    min(particle_cell_y + cells_spanned + 1, maximal_array_index),
+                    min(particle_cell_y + cells_spanned + 1, maximal_array_index + 1),
                 ):
                     distance_y = (float64(cell_y) + 0.5) * pixel_width - float64(y_pos)
                     distance_y_2 = distance_y * distance_y

--- a/swiftsimio/visualisation/projection_backends/reference.py
+++ b/swiftsimio/visualisation/projection_backends/reference.py
@@ -72,7 +72,7 @@ def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray
     """
     # Output array for our image
     image = zeros((res, res), dtype=float64)
-    maximal_array_index = int32(res)
+    maximal_array_index = int32(res) - 1
 
     # Change that integer to a float, we know that our x, y are bounded
     # by [0, 1].

--- a/swiftsimio/visualisation/projection_backends/renormalised.py
+++ b/swiftsimio/visualisation/projection_backends/renormalised.py
@@ -152,7 +152,7 @@ def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray
                 max(0, particle_cell_x - cells_spanned),
                 # Ensure that the highest x value lies within the array bounds,
                 # otherwise we'll segfault (oops).
-                min(particle_cell_x + cells_spanned + 1, maximal_array_index),
+                min(particle_cell_x + cells_spanned + 1, maximal_array_index + 1),
             ):
                 # The distance in x to our new favourite cell -- remember that our x, y
                 # are all in a box of [0, 1]; calculate the distance to the cell centre
@@ -160,7 +160,7 @@ def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray
                 distance_x_2 = distance_x * distance_x
                 for cell_y in range(
                     max(0, particle_cell_y - cells_spanned),
-                    min(particle_cell_y + cells_spanned + 1, maximal_array_index),
+                    min(particle_cell_y + cells_spanned + 1, maximal_array_index + 1),
                 ):
                     distance_y = (float32(cell_y) + 0.5) * pixel_width - float32(y_pos)
                     distance_y_2 = distance_y * distance_y

--- a/swiftsimio/visualisation/projection_backends/renormalised.py
+++ b/swiftsimio/visualisation/projection_backends/renormalised.py
@@ -76,7 +76,7 @@ def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray
     """
     # Output array for our image
     image = zeros((res, res), dtype=float32)
-    maximal_array_index = int32(res)
+    maximal_array_index = int32(res) - 1
 
     # Change that integer to a float, we know that our x, y are bounded
     # by [0, 1].

--- a/swiftsimio/visualisation/projection_backends/subsampled.py
+++ b/swiftsimio/visualisation/projection_backends/subsampled.py
@@ -193,9 +193,16 @@ def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray
                             )
                         )
 
-                        image[pixel_x, pixel_y] += (
-                            float_mass * dithered_kernel[x_dither_cell, y_dither_cell]
-                        )
+                        if (
+                            pixel_x >= 0
+                            and pixel_x <= maximal_array_index
+                            and pixel_y >= 0
+                            and pixel_y <= maximal_array_index
+                        ):
+                            image[pixel_x, pixel_y] += (
+                                float_mass
+                                * dithered_kernel[x_dither_cell, y_dither_cell]
+                            )
 
         else:
             # The number of times each pixel is subsampled.
@@ -214,12 +221,12 @@ def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray
                 max(0, particle_cell_x - cells_spanned),
                 # Ensure that the highest x value lies within the array bounds,
                 # otherwise we'll segfault (oops).
-                min(particle_cell_x + cells_spanned + 1, maximal_array_index),
+                min(particle_cell_x + cells_spanned + 1, maximal_array_index + 1),
             ):
                 float_cell_x = float64(cell_x)
                 for cell_y in range(
                     max(0, particle_cell_y - cells_spanned),
-                    min(particle_cell_y + cells_spanned + 1, maximal_array_index),
+                    min(particle_cell_y + cells_spanned + 1, maximal_array_index + 1),
                 ):
                     float_cell_y = float64(cell_y)
                     # Now we subsample the pixels to get a more accurate determination

--- a/swiftsimio/visualisation/projection_backends/subsampled.py
+++ b/swiftsimio/visualisation/projection_backends/subsampled.py
@@ -80,7 +80,7 @@ def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray
     """
     # Output array for our image
     image = zeros((res, res), dtype=float64)
-    maximal_array_index = int32(res)
+    maximal_array_index = int32(res) - 1
 
     # Change that integer to a float, we know that our x, y are bounded
     # by [0, 1].

--- a/swiftsimio/visualisation/projection_backends/subsampled_extreme.py
+++ b/swiftsimio/visualisation/projection_backends/subsampled_extreme.py
@@ -195,9 +195,16 @@ def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray
                             )
                         )
 
-                        image[pixel_x, pixel_y] += (
-                            float_mass * dithered_kernel[x_dither_cell, y_dither_cell]
-                        )
+                        if (
+                            pixel_x >= 0
+                            and pixel_x <= maximal_array_index
+                            and pixel_y >= 0
+                            and pixel_y <= maximal_array_index
+                        ):
+                            image[pixel_x, pixel_y] += (
+                                float_mass
+                                * dithered_kernel[x_dither_cell, y_dither_cell]
+                            )
 
         else:
             # The number of times each pixel is subsampled.
@@ -216,12 +223,12 @@ def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray
                 max(0, particle_cell_x - cells_spanned),
                 # Ensure that the highest x value lies within the array bounds,
                 # otherwise we'll segfault (oops).
-                min(particle_cell_x + cells_spanned + 1, maximal_array_index),
+                min(particle_cell_x + cells_spanned + 1, maximal_array_index + 1),
             ):
                 float_cell_x = float64(cell_x)
                 for cell_y in range(
                     max(0, particle_cell_y - cells_spanned),
-                    min(particle_cell_y + cells_spanned + 1, maximal_array_index),
+                    min(particle_cell_y + cells_spanned + 1, maximal_array_index + 1),
                 ):
                     float_cell_y = float64(cell_y)
                     # Now we subsample the pixels to get a more accurate determination

--- a/swiftsimio/visualisation/projection_backends/subsampled_extreme.py
+++ b/swiftsimio/visualisation/projection_backends/subsampled_extreme.py
@@ -82,7 +82,7 @@ def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray
     """
     # Output array for our image
     image = zeros((res, res), dtype=float64)
-    maximal_array_index = int32(res)
+    maximal_array_index = int32(res) - 1
 
     # Change that integer to a float, we know that our x, y are bounded
     # by [0, 1].

--- a/swiftsimio/visualisation/slice.py
+++ b/swiftsimio/visualisation/slice.py
@@ -163,7 +163,7 @@ def slice_scatter(
             max(0, particle_cell_x - cells_spanned),
             # Ensure that the highest x value lies within the array bounds,
             # otherwise we'll segfault (oops).
-            min(particle_cell_x + cells_spanned, maximal_array_index),
+            min(particle_cell_x + cells_spanned, maximal_array_index + 1),
         ):
             # The distance in x to our new favourite cell -- remember that our x, y
             # are all in a box of [0, 1]; calculate the distance to the cell centre
@@ -171,7 +171,7 @@ def slice_scatter(
             distance_x_2 = distance_x * distance_x
             for cell_y in range(
                 max(0, particle_cell_y - cells_spanned),
-                min(particle_cell_y + cells_spanned, maximal_array_index),
+                min(particle_cell_y + cells_spanned, maximal_array_index + 1),
             ):
                 distance_y = (float32(cell_y) + 0.5) * pixel_width - float32(y_pos)
                 distance_y_2 = distance_y * distance_y

--- a/swiftsimio/visualisation/slice.py
+++ b/swiftsimio/visualisation/slice.py
@@ -120,7 +120,7 @@ def slice_scatter(
     """
     # Output array for our image
     image = zeros((res, res), dtype=float32)
-    maximal_array_index = int32(res)
+    maximal_array_index = int32(res) - 1
 
     # Change that integer to a float, we know that our x, y are bounded
     # by [0, 1].

--- a/swiftsimio/visualisation/volume_render.py
+++ b/swiftsimio/visualisation/volume_render.py
@@ -121,9 +121,17 @@ def scatter(
 
         if kernel_width < drop_to_single_cell:
             # Easygame, gg
-            image[particle_cell_x, particle_cell_y, particle_cell_z] += (
-                mass * inverse_cell_volume
-            )
+            if (
+                particle_cell_x >= 0
+                and particle_cell_x <= maximal_array_index
+                and particle_cell_y >= 0
+                and particle_cell_y <= maximal_array_index
+                and particle_cell_z >= 0
+                and particle_cell_z <= maximal_array_index
+            ):
+                image[particle_cell_x, particle_cell_y, particle_cell_z] += (
+                    mass * inverse_cell_volume
+                )
         else:
             # Now we loop over the square of cells that the kernel lives in
             for cell_x in range(
@@ -131,7 +139,7 @@ def scatter(
                 max(0, particle_cell_x - cells_spanned),
                 # Ensure that the highest x value lies within the array bounds,
                 # otherwise we'll segfault (oops).
-                min(particle_cell_x + cells_spanned, maximal_array_index),
+                min(particle_cell_x + cells_spanned, maximal_array_index + 1),
             ):
                 # The distance in x to our new favourite cell -- remember that our x, y
                 # are all in a box of [0, 1]; calculate the distance to the cell centre
@@ -139,13 +147,13 @@ def scatter(
                 distance_x_2 = distance_x * distance_x
                 for cell_y in range(
                     max(0, particle_cell_y - cells_spanned),
-                    min(particle_cell_y + cells_spanned, maximal_array_index),
+                    min(particle_cell_y + cells_spanned, maximal_array_index + 1),
                 ):
                     distance_y = (float32(cell_y) + 0.5) * pixel_width - float32(y_pos)
                     distance_y_2 = distance_y * distance_y
                     for cell_z in range(
                         max(0, particle_cell_z - cells_spanned),
-                        min(particle_cell_z + cells_spanned, maximal_array_index),
+                        min(particle_cell_z + cells_spanned, maximal_array_index + 1),
                     ):
                         distance_z = (float32(cell_z) + 0.5) * pixel_width - float32(
                             z_pos

--- a/swiftsimio/visualisation/volume_render.py
+++ b/swiftsimio/visualisation/volume_render.py
@@ -79,7 +79,7 @@ def scatter(
     """
     # Output array for our image
     image = zeros((res, res, res), dtype=float32)
-    maximal_array_index = int32(res)
+    maximal_array_index = int32(res) - 1
 
     # Change that integer to a float, we know that our x, y are bounded
     # by [0, 1].

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -24,10 +24,10 @@ def test_scatter(save=False):
     for backend in backends.keys():
         try:
             image = backends[backend](
-                np.array([0.0, 1.0, 1.0]),
-                np.array([0.0, 0.0, 1.0]),
-                np.array([1.0, 1.0, 1.0]),
-                np.array([0.2, 0.2, 0.2]),
+                np.array([0.0, 1.0, 1.0, -0.000001]),
+                np.array([0.0, 0.0, 1.0, 1.000001]),
+                np.array([1.0, 1.0, 1.0, 1.0]),
+                np.array([0.2, 0.2, 0.2, 0.000002]),
                 256,
             )
         except CudaSupportError:
@@ -96,11 +96,11 @@ def test_scatter_parallel(save=False):
 
 def test_slice(save=False):
     image = slice(
-        np.array([0.0, 1.0, 1.0]),
-        np.array([0.0, 0.0, 1.0]),
-        np.array([0.0, 0.0, 1.0]),
-        np.array([1.0, 1.0, 1.0]),
-        np.array([0.2, 0.2, 0.2]),
+        np.array([0.0, 1.0, 1.0, -0.000001]),
+        np.array([0.0, 0.0, 1.0, 1.000001]),
+        np.array([0.0, 0.0, 1.0, 1.000001]),
+        np.array([1.0, 1.0, 1.0, 1.0]),
+        np.array([0.2, 0.2, 0.2, 0.000002]),
         0.99,
         256,
     )
@@ -159,11 +159,11 @@ def test_slice_parallel(save=False):
 
 def test_volume_render():
     image = volume_render.scatter(
-        np.array([0.0, 1.0, 1.0]),
-        np.array([0.0, 0.0, 1.0]),
-        np.array([0.0, 0.0, 1.0]),
-        np.array([1.0, 1.0, 1.0]),
-        np.array([0.2, 0.2, 0.2]),
+        np.array([0.0, 1.0, 1.0, -0.000001]),
+        np.array([0.0, 0.0, 1.0, 1.000001]),
+        np.array([0.0, 0.0, 1.0, 1.000001]),
+        np.array([1.0, 1.0, 1.0, 1.0]),
+        np.array([0.2, 0.2, 0.2, 0.000002]),
         64,
     )
 


### PR DESCRIPTION
All projection backends except "histogram" and the slicing and volume rendering functions used a wrong definition of `maximal_array_index` that occasionally causes an out-of-bounds array access, leading to very strange looking crashes. This pull request fixes this.

Should fix #98.