### PR TITLE
Prevent deprecation warning when using astropy 5.0

### DIFF
--- a/swiftsimio/conversions.py
+++ b/swiftsimio/conversions.py
@@ -10,10 +10,11 @@ if ASTROPY_AVAILABLE:
     from astropy.cosmology import w0waCDM
     from astropy.cosmology.core import Cosmology
     import astropy.version
+
     if astropy.version.major < 5:
         from astropy.cosmology.core import a_B_c2, critdens_const
     else:
-        from astropy.cosmology.flrw import a_B_c2, critdens_const        
+        from astropy.cosmology.flrw import a_B_c2, critdens_const
     import astropy.units as astropy_units
 
     def swift_cosmology_to_astropy(cosmo: dict, units) -> Cosmology:
@@ -62,7 +63,6 @@ if ASTROPY_AVAILABLE:
             Tcmb0=Tcmb0,
             Ob0=Omega_b,
         )
-
 
 else:
 

--- a/swiftsimio/conversions.py
+++ b/swiftsimio/conversions.py
@@ -8,7 +8,12 @@ import unyt
 
 if ASTROPY_AVAILABLE:
     from astropy.cosmology import w0waCDM
-    from astropy.cosmology.core import a_B_c2, critdens_const, Cosmology
+    from astropy.cosmology.core import Cosmology
+    import astropy.version
+    if astropy.version.major < 5:
+        from astropy.cosmology.core import a_B_c2, critdens_const
+    else:
+        from astropy.cosmology.flrw import a_B_c2, critdens_const        
     import astropy.units as astropy_units
 
     def swift_cosmology_to_astropy(cosmo: dict, units) -> Cosmology:


### PR DESCRIPTION
A couple of constants used in swiftsimio/conversions.py have moved from astropy.cosmology.core to astropy.cosmology.flrw in astropy 5.0 and generate a deprecation warning when the old location is used. This just checks the astropy version and uses the new location with astropy >=5.0.