### PR TITLE
Set NamedColumnDataset name attribute to actual name.

### DIFF
--- a/swiftsimio/reader.py
+++ b/swiftsimio/reader.py
@@ -1450,7 +1450,7 @@ def generate_dataset(particle_metadata: SWIFTParticleTypeMetadata, mask):
             field_property = ThisNamedColumnDataset(
                 field_path=field_path,
                 named_columns=named_columns,
-                name=field_description,
+                name=field_name,
             )
 
         this_dataset_dict[field_name] = field_property


### PR DESCRIPTION
There seems to have been a typo in the `ThisNamedColumnDataset` code setting the `name` attribute to a verbose description instead of the actual name.