### PR TITLE
Added support for non-square slices.

### DIFF
--- a/docs/source/visualisation/slice.rst
+++ b/docs/source/visualisation/slice.rst
@@ -29,11 +29,11 @@ Example
    data = load("cosmo_volume_example.hdf5")
 
    # This creates a grid that has units msun / Mpc^3, and can be transformed like
-   # any other unyt quantity. Note that `slice` is given in terms of the box-size,
-   # so here we are taking a slice at z = boxsize / 2.
+   # any other unyt quantity. The position of the slice along the z axis is
+   # provided in the z_slice argument.
    mass_map = slice_gas(
        data,
-       slice=0.5,
+       z_slice=0.5 * data.metadata.boxsize[2],
        resolution=1024,
        project="masses",
        parallel=True
@@ -69,7 +69,7 @@ in units of K / kpc^3 and we just want K) by dividing out by this:
    # Map in msun / mpc^3
    mass_map = slice_gas(
        data,
-       slice=0.5,
+       z_slice=0.5 * data.metadata.boxsize[2],
        resolution=1024,
        project="masses",
        parallel=True
@@ -78,7 +78,7 @@ in units of K / kpc^3 and we just want K) by dividing out by this:
    # Map in msun * K / mpc^3
    mass_weighted_temp_map = slice_gas(
        data,
-       slice=0.5,
+       z_slice=0.5 * data.metadata.boxsize[2],
        resolution=1024,
        project="mass_weighted_temps",
        parallel=True
@@ -132,9 +132,11 @@ the above example is shown below.
    matrix = rotation_matrix_from_vector(rotate_vec, axis='z')
    
    # Map in msun / mpc^3
+   # If a rotation center is provided, z_slice is taken relative to this
+   # center, resulting in a slice perpendicular to the rotated z axis
    mass_map = slice_gas(
        data,
-       slice=0.5,
+       z_slice=0. * data.metadata.boxsize[2],
        resolution=1024,
        project="masses",
        rotation_matrix=matrix,
@@ -145,7 +147,7 @@ the above example is shown below.
    # Map in msun * K / mpc^3
    mass_weighted_temp_map = slice_gas(
        data, 
-       slice=0.5,
+       z_slice=0. * data.metadata.boxsize[2],
        resolution=1024,
        project="mass_weighted_temps",
        rotation_matrix=matrix,
@@ -184,18 +186,19 @@ To use this function, you will need:
 + x-positions of all of your particles, ``x``.
 + y-positions of all of your particles, ``y``.
 + z-positions of all of your particles, ``z``.
-+ Where in the [0,1] range you wish to slice, ``z_slice``.
++ Where in the range you wish to slice, ``z_slice``.
 + A quantity which you wish to smooth for all particles, such as their
   mass, ``m``.
 + Smoothing lengths for all particles, ``h``.
 + The resolution you wish to make your square image at, ``res``.
 
-The key here is that only particles in the domain [0, 1] in x, [0, 1] in y,
-and [0, 1] in z. will be visible in the image. You may have particles outside
-of this range; they will not crash the code, and may even contribute to the
-image if their smoothing lengths overlap with [0, 1]. You will need to
-re-scale your data such that it lives within this range. Then you may use the
-function as follows:
+The key here is that only particles in the domain [0, 1] in x and y will be
+visible in the image. You may have particles outside of this range; they will
+not crash the code, and may even contribute to the image if their smoothing
+lengths overlap with [0, 1]. You will need to re-scale your data such that it
+lives within this range. Smoothing lengths and z coordinates need to be
+re-scaled in the same way (using the same scaling factor), but z coordinates do
+not need to lie in the domain [0, 1]. Then you may use the function as follows:
 
 .. code-block:: python
 

--- a/swiftsimio/visualisation/slice.py
+++ b/swiftsimio/visualisation/slice.py
@@ -358,7 +358,7 @@ def slice_gas_pixel_grid(
     x_range = x_max - x_min
     y_range = y_max - y_min
 
-    # Deal with non-square boxes:
+    # Deal with non-cubic boxes:
     # we always use the maximum of x_range and y_range to normalise the coordinates
     # empty pixels in the resulting square image are trimmed afterwards
     max_range = max(x_range, y_range)
@@ -383,10 +383,10 @@ def slice_gas_pixel_grid(
     common_parameters = dict(
         x=(x - x_min) / max_range,
         y=(y - y_min) / max_range,
-        z=z / box_z,
+        z=z / max_range,
         m=m,
         h=hsml / max_range,
-        z_slice=slice,
+        z_slice=slice * box_z / max_range,
         res=resolution,
     )
 
@@ -488,18 +488,16 @@ def slice_gas(
     if region is not None:
         x_range = region[1] - region[0]
         y_range = region[3] - region[2]
-        units = 1.0 / (x_range * y_range * data.metadata.boxsize[2])
+        max_range = max(x_range, y_range)
+        units = 1.0 / (max_range ** 3)
         # Unfortunately this is required to prevent us from {over,under}flowing
         # the units...
         units.convert_to_units(
             1.0 / (x_range.units * y_range.units * data.metadata.boxsize.units)
         )
     else:
-        units = 1.0 / (
-            data.metadata.boxsize[0]
-            * data.metadata.boxsize[1]
-            * data.metadata.boxsize[2]
-        )
+        max_range = max(data.metadata.boxsize[0], data.metadata.boxsize[1])
+        units = 1.0 / (max_range ** 3)
         # Unfortunately this is required to prevent us from {over,under}flowing
         # the units...
         units.convert_to_units(1.0 / data.metadata.boxsize.units ** 3)

--- a/swiftsimio/visualisation/slice.py
+++ b/swiftsimio/visualisation/slice.py
@@ -2,7 +2,7 @@
 Sub-module for slice plots in SWFITSIMio.
 """
 
-from typing import Union
+from typing import Union, Optional
 from math import sqrt
 from numpy import (
     float64,
@@ -271,7 +271,7 @@ def slice_scatter_parallel(
 def slice_gas_pixel_grid(
     data: SWIFTDataset,
     resolution: int,
-    z_slice: unyt_quantity = 0.0 * unyt.m,
+    z_slice: Optional[unyt_quantity] = None,
     project: Union[str, None] = "masses",
     parallel: bool = False,
     rotation_matrix: Union[None, array] = None,
@@ -335,6 +335,9 @@ def slice_gas_pixel_grid(
     render_gas_voxel_grid : Creates a 3D voxel grid from a SWIFT dataset
 
     """
+
+    if z_slice is None:
+        z_slice = 0.0 * data.gas.coordinates.units
 
     number_of_gas_particles = data.gas.coordinates.shape[0]
 
@@ -412,7 +415,7 @@ def slice_gas_pixel_grid(
 def slice_gas(
     data: SWIFTDataset,
     resolution: int,
-    z_slice: unyt_quantity = 0.0 * unyt.m,
+    z_slice: Optional[unyt_quantity] = None,
     project: Union[str, None] = "masses",
     parallel: bool = False,
     rotation_matrix: Union[None, array] = None,
@@ -480,6 +483,9 @@ def slice_gas(
     This is a wrapper function for slice_gas_pixel_grid ensuring that output units are
     appropriate
     """
+
+    if z_slice is None:
+        z_slice = 0.0 * data.gas.coordinates.units
 
     image = slice_gas_pixel_grid(
         data,

--- a/tests/test_rotate_visualisations.py
+++ b/tests/test_rotate_visualisations.py
@@ -69,17 +69,16 @@ def test_slice(filename):
     matrix = rotation_matrix_from_vector(rotate_vec, axis="z")
     boxsize = data.metadata.boxsize
 
-    z_range = boxsize[2]
-    slice_z = centre[2] / z_range
+    slice_z = centre[2]
 
     unrotated = slice_gas(
-        data, resolution=1024, slice=slice_z, project="masses", parallel=True
+        data, resolution=1024, z_slice=slice_z, project="masses", parallel=True
     )
 
     rotated = slice_gas(
         data,
         resolution=1024,
-        slice=slice_z,
+        z_slice=0 * slice_z,
         project="masses",
         rotation_center=centre,
         rotation_matrix=matrix,

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -208,18 +208,18 @@ def test_selection_render(filename):
     render_tiny = project_gas(data, 256, parallel=True, region=[0 * bs, 0.001 * bs] * 2)
 
     # Slicing
-    render_full = slice_gas(data, 256, slice=0.5, parallel=True)
+    render_full = slice_gas(data, 256, z_slice=0.5 * bs, parallel=True)
     render_partial = slice_gas(
-        data, 256, slice=0.5, parallel=True, region=[0.25 * bs, 0.75 * bs] * 2
+        data, 256, z_slice=0.5 * bs, parallel=True, region=[0.25 * bs, 0.75 * bs] * 2
     )
     render_tiny = slice_gas(
-        data, 256, slice=0.5, parallel=True, region=[0 * bs, 0.001 * bs] * 2
+        data, 256, z_slice=0.5 * bs, parallel=True, region=[0 * bs, 0.001 * bs] * 2
     )
     # Test for non-square slices
     render_nonsquare = slice_gas(
         data,
         256,
-        slice=0.5,
+        z_slice=0.5 * bs,
         parallel=True,
         region=[0 * bs, 0.001 * bs, 0.25 * bs, 0.75 * bs],
     )

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -215,6 +215,14 @@ def test_selection_render(filename):
     render_tiny = slice_gas(
         data, 256, slice=0.5, parallel=True, region=[0 * bs, 0.001 * bs] * 2
     )
+    # Test for non-square slices
+    render_nonsquare = slice_gas(
+        data,
+        256,
+        slice=0.5,
+        parallel=True,
+        region=[0 * bs, 0.001 * bs, 0.25 * bs, 0.75 * bs],
+    )
 
     # If they don't crash we're happy!
 


### PR DESCRIPTION
As discussed in #115, support for non-square images was lacking from `visualisation/slice.py`.

I have provided a minimal form of support that avoids some of the potential pitfalls: instead of normalising the pixel coordinates using the range in both the x and y dimension, the maximum of these ranges is used. A square image with the requested resolution is then produced that will contain empty pixels in the smaller dimension. These empty pixels are filtered out before returning the non-square result image.

This minimal implementation implies that
 - the image resolution argument is applied to the longer dimension only (after possible rotations) and should be interpreted as such
 - there could be a small mismatch in the pixel length of the smaller dimension because of rounding down
 - no stretching happens, because all coordinates are normalised with the same number