### PR TITLE
Docs conf fixes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,7 +39,6 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.napoleon",
     "sphinx.ext.mathjax",
-    "sphinx.ext.napoleon",
     "sphinx.ext.autosummary",
 ]
 
@@ -74,6 +73,9 @@ autodoc_member_order = "bysource"
 autodoc_default_flags = ["members"]
 autosummary_generate = True
 
+# must be outside run_apidoc definition to be set successfully:
+os.environ["SPHINX_APIDOC_OPTIONS"] = "members,undoc-members,show-inheritance"
+
 
 def run_apidoc(_):
     try:
@@ -91,7 +93,6 @@ def run_apidoc(_):
         os.path.join(cur_dir, "../..", "swiftsimio/metadata"),
     ]
 
-    os.environ["SPHINX_APIDOC_OPTIONS"] = "members,undoc-members,show-inheritance"
     main(["-M", "-f", "-e", "-T", "-d 0", "-o", api_doc_dir, module, *ignore])
 
 

--- a/swiftsimio/reader.py
+++ b/swiftsimio/reader.py
@@ -1450,7 +1450,7 @@ def generate_dataset(particle_metadata: SWIFTParticleTypeMetadata, mask):
             field_property = ThisNamedColumnDataset(
                 field_path=field_path,
                 named_columns=named_columns,
-                name=field_description,
+                name=field_name,
             )
 
         this_dataset_dict[field_name] = field_property


### PR DESCRIPTION
Fixes for two bugs in conf.py for sphinx.

 - There was a duplicate entry `"sphinx.ext.napoleon"` in the extensions list, removed this.
 - The call to os.environ to set `"SPHINX_APIDOC_OPTIONS"` does not actually set the environment variable (but it's setting them to default values so this had no effect). Placing the call outside the definition of run_apidoc results in the values passed here actually affecting the output as expected.