### PR TITLE
Writer: added check whether coordinates and velocities arrays have same shape

### DIFF
--- a/swiftsimio/writer.py
+++ b/swiftsimio/writer.py
@@ -136,6 +136,12 @@ class __SWIFTWriterParticleDataset(object):
             lambda x, y: x and y, [sizes[0] == x for x in sizes]
         ), f"Arrays passed to {self.particle_name} dataset are not of the same size."
 
+        # Make sure positions and velocities have the same shapes
+        if getattr(self, "coordinates").shape != getattr(self, "velocities").shape:
+            raise AttributeError(
+                f"{self.particle_name} coordinates and velocities have unequal shapes"
+            )
+
         self.n_part = sizes[0]
 
         return True


### PR DESCRIPTION
This adds a check whether the `coordinates` and `velocities` arrays of each particle have the same shape.

Currently the `coordinates` and `velocities` arrays are part of the `shared` portion of the required fields for all particles, so this should work for any particle type.

I ran into this issue when generating ICs, where the velocity fields would get filled up with random junk at times while running swift with those ICs, leading to crashes and errors that looked like race conditions / dependency issues.  