### PR TITLE
Bugfix: prevent present dimensions being overwritten later in loop.

### DIFF
--- a/swiftsimio/writer.py
+++ b/swiftsimio/writer.py
@@ -317,11 +317,13 @@ def get_dimensions(dimension: unyt.dimensions) -> dict:
 
     # Find out which dimensions and exponents are present in the base units
     for i in range(n_dims):
+        present = False
         for dim in dim_array:
             if dimensions[i] in str(dim[0]):
+                present = True
                 exp_array[str(dim[0])] = float(dim[1])
-            else:
-                exp_array[dimensions[i]] = 0.0
+        if not present:
+            exp_array[dimensions[i]] = 0.0
 
     return exp_array
 

--- a/tests/test_read_ic.py
+++ b/tests/test_read_ic.py
@@ -6,13 +6,19 @@ import unyt
 import numpy as np
 from os import remove
 
+import pytest
 
-def test_reading_ic_units():
+# File we're writing to
+test_filename = "test_write_output_units.hdf5"
+test_file_fields = ("coordinates", "velocities", "masses", "internal_energy",
+                    "smoothing_length")
+
+
+@pytest.fixture(scope='function')
+def simple_snapshot_data():
     """
-    Test to ensure we are able to correctly read ICs created with swiftsimio
+    Fixture to create and cleanup a simple snapshot for testing.
     """
-    # File we're writing to
-    test_filename = "test_write_output_units.hdf5"
 
     # Box is 100 Mpc
     boxsize = 100 * unyt.Mpc
@@ -44,14 +50,27 @@ def test_reading_ic_units():
     # If IDs are not present, this automatically generates
     x.write(test_filename)
 
-    data = load(test_filename)
+    # Yield the test data
+    yield x
 
-    assert np.array_equal(data.gas.coordinates, x.gas.coordinates)
-    assert np.array_equal(data.gas.velocities, x.gas.velocities)
-    assert np.array_equal(data.gas.masses, x.gas.masses)
-    assert np.array_equal(data.gas.internal_energy, x.gas.internal_energy)
-    assert np.array_equal(data.gas.smoothing_length, x.gas.smoothing_length)
-
+    # The file is automatically cleaned up after the test.
     remove(test_filename)
 
+
+@pytest.mark.parametrize(
+    "field",
+    test_file_fields
+)
+def test_reading_ic_units(simple_snapshot_data, field):
+    """
+    Test to ensure we are able to correctly read ICs created with swiftsimio
+    """
+
+    data = load(test_filename)
+
+    assert unyt.array.allclose_units(
+        getattr(data.gas, field),
+        getattr(simple_snapshot_data.gas, field),
+        rtol=1.e-4
+    )
     return


### PR DESCRIPTION
There was a bug present such that dimensions were not parsed correctly. The faulty loop with some print statements added:

```
>>> import unyt as u
>>> dimensions = [str(x) for x in u.dimensions.base_dimensions[:5]]
>>> dimensions[4] = "(current)"
>>> n_dims = len(dimensions)
>>> field = np.random.rand(10) * u.km / u.s
>>> dimension = field.units.dimensions
>>> dimension
(length)/(time)
>>> exp_array = {}
>>> dim_array = [x.as_base_exp() for x in dimension.as_ordered_factors()]
>>> for i in range(n_dims):
...     for dim in dim_array:
...         if dimensions[i] in str(dim[0]):
...             print(dimensions[i], 'in', str(dim[0]))
...             exp_array[str(dim[0])] = float(dim[1])
...             print('  ', str(dim[0]), 'set', float(dim[1]))
...         else:
...             print(dimensions[i], 'not in', str(dim[0]))
...             exp_array[dimensions[i]] = 0.0
...             print('  ', dimensions[i], 'set', 0)
... 
(mass) not in (length)
   (mass) set 0
(mass) not in (time)
   (mass) set 0
(length) in (length)
   (length) set 1.0
(length) not in (time)
   (length) set 0
(time) not in (length)
   (time) set 0
(time) in (time)
   (time) set -1.0
(temperature) not in (length)
   (temperature) set 0
(temperature) not in (time)
   (temperature) set 0
(angle) not in (length)
   (angle) set 0
(angle) not in (time)
   (angle) set 0
>>> exp_array  # LENGTH SHOULD BE 1.0 BUT OVERWRITTEN!
{'(mass)': 0.0, '(length)': 0.0, '(time)': -1.0, '(temperature)': 0.0, '(current)': 0.0}
```