### PR TITLE
Added PartTypeNames to skip list in subset writer to avoid crash

### DIFF
--- a/swiftsimio/subset_writer.py
+++ b/swiftsimio/subset_writer.py
@@ -255,7 +255,7 @@ def write_datasubset(
         names of links found in the snapshot
     """
     skip_list = links_list.copy()
-    skip_list.extend(["Cells", "SubgridScheme"])
+    skip_list.extend(["Cells", "SubgridScheme", "PartTypeNames"])
     if mask is not None:
         for name in dataset_names:
             if any([substr for substr in skip_list if substr in name]):


### PR DESCRIPTION
This is a tentative fix for #108.

The problem is that somebody decided to add a dataset called `PartTypeNames` to the `Header` group, and this confuses the subset writer. If we add this name to the `skip_list` in `write_datasubset`, things work again.