### PR TITLE
Cosmo array ufuncs

### DIFF
--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -3,10 +3,98 @@ Contains global objects, e.g. the superclass version of the
 unyt_array that we use, called cosmo_array.
 """
 
+from itertools import groupby
+
 from unyt import unyt_array
+from unyt.array import unary_operators, binary_operators, trigonometric_operators, multiple_output_operators
 
 import sympy
 import numpy as np
+from numpy import (
+    add,
+    subtract,
+    multiply,
+    divide,
+    logaddexp,
+    logaddexp2,
+    true_divide,
+    floor_divide,
+    negative,
+    power,
+    remainder,
+    mod,
+    absolute,
+    rint,
+    sign,
+    conj,
+    exp,
+    exp2,
+    log,
+    log2,
+    log10,
+    expm1,
+    log1p,
+    sqrt,
+    square,
+    reciprocal,
+    sin,
+    cos,
+    tan,
+    arcsin,
+    arccos,
+    arctan,
+    arctan2,
+    hypot,
+    sinh,
+    cosh,
+    tanh,
+    arcsinh,
+    arccosh,
+    arctanh,
+    deg2rad,
+    rad2deg,
+    greater,
+    greater_equal,
+    less,
+    less_equal,
+    not_equal,
+    equal,
+    logical_and,
+    logical_or,
+    logical_xor,
+    logical_not,
+    maximum,
+    minimum,
+    fmax,
+    fmin,
+    isreal,
+    iscomplex,
+    isfinite,
+    isinf,
+    isnan,
+    signbit,
+    copysign,
+    nextafter,
+    modf,
+    frexp,
+    fmod,
+    floor,
+    ceil,
+    trunc,
+    fabs,
+    spacing,
+    positive,
+    divmod as divmod_,
+    isnat,
+    heaviside,
+    matmul,
+)
+from numpy.core.umath import _ones_like
+
+try:
+    from numpy.core.umath import clip
+except ImportError:
+    clip = None
 
 # The scale factor!
 a = sympy.symbols("a")
@@ -24,6 +112,79 @@ def _propagate_cosmo_array_attributes(func):
         return ret
 
     return wrapped
+
+
+def _sqrt_cosmo_factor(cf):
+    # return 1, unit ** 0.5
+    raise NotImplementedError
+
+
+def _multiply_cosmo_factor(cf1, cf2):
+    # try:
+    #     ret = (unit1 * unit2).simplify()
+    # except SymbolNotFoundError:
+    #     # Some operators are not natively commutative when operands are
+    #     # defined within different unit registries, and conversion
+    #     # is defined one way but not the other.
+    #     ret = (unit2 * unit1).simplify()
+    # return ret.as_coeff_unit()
+    return cf1 * cf2
+
+
+def _preserve_cosmo_factor(cf1, cf2=None):
+    # if unit2 is None or unit1.dimensions is not temperature:
+    #     return 1, unit1
+    # if unit1.base_offset == 0.0 and unit2.base_offset != 0.0:
+    #     if str(unit1.expr) in ["K", "R"]:
+    #         warnings.warn(TEMPERATURE_WARNING, FutureWarning, stacklevel=3)
+    #         return 1, unit1
+    #     return 1, unit2
+    # return 1, unit1
+    raise NotImplementedError
+
+
+def _power_cosmo_factor(cf, power):
+    # return 1, unit ** power
+    raise NotImplementedError
+
+
+def _square_cosmo_factor(cf):
+    # return 1, unit * unit
+    raise NotImplementedError
+
+
+def _divide_cosmo_factor(cf1, cf2):
+    # try:
+    #     ret = (unit1 / unit2).simplify()
+    # except SymbolNotFoundError:
+    #     ret = (1 / (unit2 / unit1).simplify()).units
+    # return ret.as_coeff_unit()
+    raise NotImplementedError
+
+
+def _reciprocal_cosmo_factor(cf):
+    # return 1, unit ** -1
+    raise NotImplementedError
+
+
+def _passthrough_cosmo_factor(cf, cf2=None):
+    # return 1, unit
+    raise NotImplementedError
+
+
+def _return_without_cosmo_factor(cf, cf2=None):
+    # return 1, None
+    raise NotImplementedError
+
+
+def _arctan2_cosmo_factor(cf1, cf2):
+    # return 1, NULL_UNIT
+    raise NotImplementedError
+
+
+def _comparison_cosmo_factor(cf1, cf2=None):
+    # return 1, None
+    raise NotImplementedError
 
 
 class InvalidScaleFactor(Exception):
@@ -252,6 +413,95 @@ class cosmo_array(unyt_array):
 
     """
 
+    _cosmo_factor_ufunc_registry = {
+        add: _preserve_cosmo_factor,
+        subtract: _preserve_cosmo_factor,
+        multiply: _multiply_cosmo_factor,
+        divide: _divide_cosmo_factor,
+        logaddexp: _return_without_cosmo_factor,
+        logaddexp2: _return_without_cosmo_factor,
+        true_divide: _divide_cosmo_factor,
+        floor_divide: _divide_cosmo_factor,
+        negative: _passthrough_cosmo_factor,
+        power: _power_cosmo_factor,
+        remainder: _preserve_cosmo_factor,
+        mod: _preserve_cosmo_factor,
+        fmod: _preserve_cosmo_factor,
+        absolute: _passthrough_cosmo_factor,
+        fabs: _passthrough_cosmo_factor,
+        rint: _return_without_cosmo_factor,
+        sign: _return_without_cosmo_factor,
+        conj: _passthrough_cosmo_factor,
+        exp: _return_without_cosmo_factor,
+        exp2: _return_without_cosmo_factor,
+        log: _return_without_cosmo_factor,
+        log2: _return_without_cosmo_factor,
+        log10: _return_without_cosmo_factor,
+        expm1: _return_without_cosmo_factor,
+        log1p: _return_without_cosmo_factor,
+        sqrt: _sqrt_cosmo_factor,
+        square: _square_cosmo_factor,
+        reciprocal: _reciprocal_cosmo_factor,
+        sin: _return_without_cosmo_factor,
+        cos: _return_without_cosmo_factor,
+        tan: _return_without_cosmo_factor,
+        sinh: _return_without_cosmo_factor,
+        cosh: _return_without_cosmo_factor,
+        tanh: _return_without_cosmo_factor,
+        arcsin: _return_without_cosmo_factor,
+        arccos: _return_without_cosmo_factor,
+        arctan: _return_without_cosmo_factor,
+        arctan2: _arctan2_cosmo_factor,
+        arcsinh: _return_without_cosmo_factor,
+        arccosh: _return_without_cosmo_factor,
+        arctanh: _return_without_cosmo_factor,
+        hypot: _preserve_cosmo_factor,
+        deg2rad: _return_without_cosmo_factor,
+        rad2deg: _return_without_cosmo_factor,
+        # bitwise_and: not supported for unyt_array
+        # bitwise_or: not supported for unyt_array
+        # bitwise_xor: not supported for unyt_array
+        # invert: not supported for unyt_array
+        # left_shift: not supported for unyt_array
+        # right_shift: not supported for unyt_array
+        greater: _comparison_cosmo_factor,
+        greater_equal: _comparison_cosmo_factor,
+        less: _comparison_cosmo_factor,
+        less_equal: _comparison_cosmo_factor,
+        not_equal: _comparison_cosmo_factor,
+        equal: _comparison_cosmo_factor,
+        logical_and: _comparison_cosmo_factor,
+        logical_or: _comparison_cosmo_factor,
+        logical_xor: _comparison_cosmo_factor,
+        logical_not: _return_without_cosmo_factor,
+        maximum: _preserve_cosmo_factor,
+        minimum: _preserve_cosmo_factor,
+        fmax: _preserve_cosmo_factor,
+        fmin: _preserve_cosmo_factor,
+        isreal: _return_without_cosmo_factor,
+        iscomplex: _return_without_cosmo_factor,
+        isfinite: _return_without_cosmo_factor,
+        isinf: _return_without_cosmo_factor,
+        isnan: _return_without_cosmo_factor,
+        signbit: _return_without_cosmo_factor,
+        copysign: _passthrough_cosmo_factor,
+        nextafter: _preserve_cosmo_factor,
+        modf: _passthrough_cosmo_factor,
+        # ldexp: not supported for unyt_array
+        frexp: _return_without_cosmo_factor,
+        floor: _passthrough_cosmo_factor,
+        ceil: _passthrough_cosmo_factor,
+        trunc: _passthrough_cosmo_factor,
+        spacing: _passthrough_cosmo_factor,
+        positive: _passthrough_cosmo_factor,
+        divmod_: _passthrough_cosmo_factor,
+        isnat: _return_without_cosmo_factor,
+        heaviside: _preserve_cosmo_factor,
+        _ones_like: _preserve_cosmo_factor,
+        matmul: _multiply_cosmo_factor,
+        clip: _passthrough_cosmo_factor,
+    }
+
     def __new__(
         cls,
         input_array,
@@ -476,3 +726,106 @@ class cosmo_array(unyt_array):
         exponent is 0 (cosmo_factor.a_factor == 1)
         """
         return (not self.comoving) or (self.cosmo_factor.a_factor == 1.0)
+
+    @classmethod
+    def from_astropy(cls, arr, unit_registry=None, comoving=True, cosmo_factor=None, compression=None):
+        """
+        Convert an AstroPy "Quantity" to a cosmo_array.
+
+        Parameters
+        ----------
+        arr: AstroPy Quantity
+            The Quantity to convert from.
+        unit_registry: yt UnitRegistry, optional
+            A yt unit registry to use in the conversion. If one is not supplied, the default one will be used.
+        comoving : bool
+            if True then the array is in comoving co-ordinates, and if False then it is in physical units.
+        cosmo_factor : float
+            Object to store conversion data between comoving and physical coordinates
+        compression : string
+            String describing any compression that was applied to this array in the hdf5 file.
+
+        Example
+        -------
+        >>> from astropy.units import kpc
+        >>> cosmo_array.from_astropy([1, 2, 3] * kpc)
+        cosmo_array([1., 2., 3.], 'kpc')
+        """
+
+        obj = super().from_astropy(arr, unit_registry=unit_registry).view(cls)
+        obj.comoving = comoving
+        obj.cosmo_factor = cosmo_factor
+        obj.compression = compression
+
+        return obj
+
+    @classmethod
+    def from_pint(cls, arr, unit_registry=None, comoving=True, cosmo_factor=None, compression=None):
+        """
+        Convert a Pint "Quantity" to a cosmo_array.
+
+        Parameters
+        ----------
+        arr : Pint Quantity
+            The Quantity to convert from.
+        unit_registry : yt UnitRegistry, optional
+            A yt unit registry to use in the conversion. If one is not
+            supplied, the default one will be used.
+        comoving : bool
+            if True then the array is in comoving co-ordinates, and if False then it is in physical units.
+        cosmo_factor : float
+            Object to store conversion data between comoving and physical coordinates
+        compression : string
+            String describing any compression that was applied to this array in the hdf5 file.
+
+        Examples
+        --------
+        >>> from pint import UnitRegistry
+        >>> import numpy as np
+        >>> ureg = UnitRegistry()
+        >>> a = np.arange(4)
+        >>> b = ureg.Quantity(a, "erg/cm**3")
+        >>> b
+        <Quantity([0 1 2 3], 'erg / centimeter ** 3')>
+        >>> c = cosmo_array.from_pint(b)
+        >>> c
+        cosmo_array([0, 1, 2, 3], 'erg/cm**3')
+        """
+        obj = super().from_pint(arr, unit_registry=unit_registry).view(cls)
+        obj.comoving = comoving
+        obj.cosmo_factor = cosmo_factor
+        obj.compression = compression
+
+        return obj
+
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        cm = [getattr(inp, "comoving", True) for inp in inputs]
+        cf = [getattr(inp, "cosmo_factor", None) for inp in inputs]
+        comp = [getattr(inp, "compression", None) for inp in inputs]
+
+        if all(cm):
+            # all inputs are comoving
+            ret_cm = True
+        elif not any(cm):
+            # all inputs are physical
+            ret_cm = False
+        else:
+            # mix of comoving and physical inputs
+            inputs = [inp.to_comoving() if not inp.comoving else inp for inp in inputs]
+            ret_cm = True
+
+        if len(set(comp)) == 1:
+            # all compressions identical, preserve it
+            ret_comp = comp[0]
+        else:
+            # mixed compressions, strip it off
+            ret_comp = None
+
+        ret_arr = super().__array_ufunc__(ufunc, method, *inputs, **kwargs).view(type(self))
+
+        # This is rough: need to handle cases like multiply and divide with reduce; use of numpy "out" kwarg; etc.
+        ret_arr.comoving = ret_cm
+        ret_arr.cosmo_factor = self._cosmo_factor_ufunc_registry[ufunc](*cf)
+        ret_arr.compression = ret_comp
+
+        return ret_arr

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -219,7 +219,7 @@ def _passthrough_cosmo_factor(ca_cf, ca_cf2=None, **kwargs):
         return cf
 
 
-def _return_without_cosmo_factor(ca_cf, ca_cf2=None, **kwargs):
+def _return_without_cosmo_factor(ca_cf, ca_cf2=None, inputs=None):
     ca, cf = ca_cf
     ca2, cf2 = ca_cf2 if ca_cf2 is not None else (None, None)
     if ca_cf2 is None:
@@ -227,10 +227,18 @@ def _return_without_cosmo_factor(ca_cf, ca_cf2=None, **kwargs):
         pass
     elif (ca and not ca2):
         # one is not a cosmo_array, warn on e.g. comparison to constants:
-        warnings.warn(f"Mixing ufunc arguments with and without cosmo_factors, continuing assuming provided cosmo_factor ({cf}) for all arguments.", RuntimeWarning)
-    elif (not ca and ca2):
+        if inputs[1] != 0:  # allow comparison to 0
+            warnings.warn(
+                f"Mixing ufunc arguments with and without cosmo_factors, continuing assuming provided cosmo_factor ({cf}) for all arguments.",
+                RuntimeWarning,
+            )
+    elif not ca and ca2:
         # two is not a cosmo_array, warn on e.g. comparison to constants:
-        warnings.warn(f"Mixing ufunc arguments with and without cosmo_factors, continuing assuming provided cosmo_factor ({cf2}) for all arguments.", RuntimeWarning)
+        if inputs[0] != 0:  # allow comparison to 0
+            warnings.warn(
+                f"Mixing ufunc arguments with and without cosmo_factors, continuing assuming provided cosmo_factor ({cf2}) for all arguments.",
+                RuntimeWarning,
+            )
     elif (ca and ca2) and (cf is not None and cf2 is None):
         # one has no cosmo_factor information, warn:
         warnings.warn(f"Mixing ufunc arguments with and without cosmo_factors, continuing assuming provided cosmo_factor ({cf}) for all arguments.", RuntimeWarning)
@@ -263,10 +271,10 @@ def _arctan2_cosmo_factor(ca_cf1, ca_cf2, **kwargs):
     return cosmo_factor(a ** 0, scale_factor=cf1.scale_factor)
 
 
-def _comparison_cosmo_factor(ca_cf1, ca_cf2=None, **kwargs):
+def _comparison_cosmo_factor(ca_cf1, ca_cf2=None, inputs=None):
     ca1, cf1 = ca_cf1
     ca2, cf2 = ca_cf2 if ca_cf2 is not None else (None, None)
-    return _return_without_cosmo_factor((ca1, cf1), ca_cf2=(ca2, cf2))
+    return _return_without_cosmo_factor((ca1, cf1), ca_cf2=(ca2, cf2), inputs=inputs)
 
 
 class InvalidScaleFactor(Exception):

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -7,6 +7,7 @@ import warnings
 
 import unyt
 from unyt import unyt_array
+
 # Eventually import of POWER_SIGN_MAPPING will fail because it has been
 # replaced with POWER_MAPPING in a bugfix (unyt PR#231). Then see segment
 # of unyt.array.__array_ufunc__ where it is used and update
@@ -241,7 +242,9 @@ def _passthrough_cosmo_factor(ca_cf, ca_cf2=None, **kwargs):
         return cf
 
 
-def _return_without_cosmo_factor(ca_cf, ca_cf2=None, inputs=None, zero_comparison=False):
+def _return_without_cosmo_factor(
+    ca_cf, ca_cf2=None, inputs=None, zero_comparison=False
+):
     ca, cf = ca_cf
     ca2, cf2 = ca_cf2 if ca_cf2 is not None else (None, None)
     if ca_cf2 is None:
@@ -325,7 +328,9 @@ def _comparison_cosmo_factor(ca_cf1, ca_cf2=None, inputs=None):
     else:
         ca2_iszero = all(ca2 == 0)
     zero_comparison = ca1_iszero or ca2_iszero
-    return _return_without_cosmo_factor(ca_cf1, ca_cf2=ca_cf2, inputs=inputs, zero_comparison=zero_comparison)
+    return _return_without_cosmo_factor(
+        ca_cf1, ca_cf2=ca_cf2, inputs=inputs, zero_comparison=zero_comparison
+    )
 
 
 class InvalidScaleFactor(Exception):

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -383,10 +383,11 @@ class cosmo_factor:
         return self.a_factor >= b.a_factor
 
     def __eq__(self, b):
-        return self.a_factor == b.a_factor
+        # Doesn't handle some corner cases, e.g. cosmo_factor(a ** 1, scale_factor=1) is considered equal to cosmo_factor(a ** 2, scale_factor=1) because 1 ** 1 == 1 ** 2. Should check self.expr vs b.expr with sympy?
+        return (self.scale_factor == b.scale_factor) and (self.a_factor == b.a_factor)
 
     def __ne__(self, b):
-        return self.a_factor != b.a_factor
+        return not self.__eq__(b)
 
 
 class cosmo_array(unyt_array):

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -169,11 +169,11 @@ def _passthrough_cosmo_factor(cf, cf2=None):
 
 
 def _return_without_cosmo_factor(cf, cf2=None):
-    if (cf1 is None and cf2 is not None):
+    if (cf is None and cf2 is not None):
         warnings.warn(f"Mixing ufunc arguments with and without cosmo_factors, continuing assuming provided cosmo_factor ({cf2}) for all arguments.", RuntimeWarning)
-    if (cf1 is not None and cf2 is None):
-        warnings.warn(f"Mixing ufunc arguments with and without cosmo_factors, continuing assuming provided cosmo_factor ({cf1}) for all arguments.", RuntimeWarning)
-    if (cf1 is not None) and (cf2 is not None) and (cf1 != cf2):
+    if (cf is not None and cf2 is None):
+        warnings.warn(f"Mixing ufunc arguments with and without cosmo_factors, continuing assuming provided cosmo_factor ({cf}) for all arguments.", RuntimeWarning)
+    if (cf is not None) and (cf2 is not None) and (cf != cf2):
         raise ValueError(f"Ufunc arguments have cosmo_factors that differ: {cf} and {cf2}.")
     return None
 

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -7,6 +7,11 @@ import warnings
 
 import unyt
 from unyt import unyt_array
+# Eventually import of POWER_SIGN_MAPPING will fail because it has been
+# replaced with POWER_MAPPING in a bugfix (unyt PR#231). Then see segment
+# of unyt.array.__array_ufunc__ where it is used and update
+# cosmo_array.__array_ufunc__ accordingly. There is an xfailing test in
+# test_cosmo_array_attrs to catch when this occurs with a test failure.
 from unyt.array import multiple_output_operators, POWER_SIGN_MAPPING
 
 import sympy

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -207,8 +207,9 @@ def _power_cosmo_factor(ca_cf1, ca_cf2, inputs=None, power=None):
     if hasattr(power, "units"):
         if not power.units.is_dimensionless:
             raise ValueError("Exponent must be dimensionless.")
-        else:
-            power.to_value(unyt.dimensionless)
+        elif power.units is not unyt.dimensionless:
+            power = power.to_value(unyt.dimensionless)
+        # else power.units is unyt.dimensionless, do nothing
     if ca2 and cf2.a_factor != 1.0:
         raise ValueError("Exponent has scaling with scale factor != 1.")
     if cf1 is None:

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -116,7 +116,9 @@ def _propagate_cosmo_array_attributes(func):
 
 
 def _sqrt_cosmo_factor(ca_cf, **kwargs):
-    return _power_cosmo_factor(ca_cf, (False, None), power=.5)  # ufunc sqrt not supported
+    return _power_cosmo_factor(
+        ca_cf, (False, None), power=0.5
+    )  # ufunc sqrt not supported
 
 
 def _multiply_cosmo_factor(ca_cf1, ca_cf2, **kwargs):
@@ -133,7 +135,10 @@ def _multiply_cosmo_factor(ca_cf1, ca_cf2, **kwargs):
         return cf1
     elif (ca1 and ca2) and ((cf1 is None) or (cf2 is None)):
         # both cosmo_array but not both with cosmo_factor (both without shortcircuited above already):
-        warnings.warn(f"Mixing ufunc arguments with and without cosmo_factors ({cf1} and {cf2}), discarding cosmo_factor in return value.", RuntimeWarning)
+        warnings.warn(
+            f"Mixing ufunc arguments with and without cosmo_factors ({cf1} and {cf2}), discarding cosmo_factor in return value.",
+            RuntimeWarning,
+        )
         return None
     elif (ca1 and ca2) and ((cf1 is not None) and (cf2 is not None)):
         # both cosmo_array and both with cosmo_factor:
@@ -159,14 +164,22 @@ def _preserve_cosmo_factor(ca_cf1, ca_cf2=None, **kwargs):
         return cf2
     elif (ca1 and ca2) and (cf1 is None and cf2 is not None):
         # both cosmo_array, but not both with cosmo_factor (both without shortcircuited above already):
-        warnings.warn(f"Mixing ufunc arguments with and without cosmo_factors, continuing assuming provided cosmo_factor ({cf2}) for all arguments.", RuntimeWarning)
+        warnings.warn(
+            f"Mixing ufunc arguments with and without cosmo_factors, continuing assuming provided cosmo_factor ({cf2}) for all arguments.",
+            RuntimeWarning,
+        )
         return cf2
     elif (ca1 and ca2) and (cf1 is not None and cf2 is None):
         # both cosmo_array, but not both with cosmo_factor (both without shortcircuited above already):
-        warnings.warn(f"Mixing ufunc arguments with and without cosmo_factors, continuing assuming provided cosmo_factor ({cf1}) for all arguments.", RuntimeWarning)
+        warnings.warn(
+            f"Mixing ufunc arguments with and without cosmo_factors, continuing assuming provided cosmo_factor ({cf1}) for all arguments.",
+            RuntimeWarning,
+        )
         return cf1
     elif (ca1 and ca2) and (cf1 != cf2):
-        raise ValueError(f"Ufunc arguments have cosmo_factors that differ: {cf1} and {cf2}.")
+        raise ValueError(
+            f"Ufunc arguments have cosmo_factors that differ: {cf1} and {cf2}."
+        )
     elif (ca1 and ca2) and (cf1 == cf2):
         return cf1  # or cf2, they're equal
     else:
@@ -184,7 +197,7 @@ def _power_cosmo_factor(ca_cf1, ca_cf2, inputs=None, power=None):
             raise ValueError("Exponent must be dimensionless.")
         else:
             power.to_value(unyt.dimensionless)
-    if ca2 and cf2.a_factor != 1.:
+    if ca2 and cf2.a_factor != 1.0:
         raise ValueError("Exponent has scaling with scale factor != 1.")
     if cf1 is None:
         return None
@@ -198,7 +211,9 @@ def _square_cosmo_factor(ca_cf, **kwargs):
 def _divide_cosmo_factor(ca_cf1, ca_cf2, **kwargs):
     ca1, cf1 = ca_cf1
     ca2, cf2 = ca_cf2
-    return _multiply_cosmo_factor((ca1, cf1), (ca2, _reciprocal_cosmo_factor((ca2, cf2))))
+    return _multiply_cosmo_factor(
+        (ca1, cf1), (ca2, _reciprocal_cosmo_factor((ca2, cf2)))
+    )
 
 
 def _reciprocal_cosmo_factor(ca_cf, **kwargs):
@@ -213,7 +228,9 @@ def _passthrough_cosmo_factor(ca_cf, ca_cf2=None, **kwargs):
         return cf
     elif (cf2 is not None) and cf != cf2:
         # if both have cosmo_factor information and it differs this is an error
-        raise ValueError(f"Ufunc arguments have cosmo_factors that differ: {cf} and {cf2}.")
+        raise ValueError(
+            f"Ufunc arguments have cosmo_factors that differ: {cf} and {cf2}."
+        )
     else:
         # passthrough is for e.g. ufuncs with a second dimensionless argument, so ok if cf2 is None and cf1 is not
         return cf
@@ -225,7 +242,7 @@ def _return_without_cosmo_factor(ca_cf, ca_cf2=None, inputs=None):
     if ca_cf2 is None:
         # no second argument
         pass
-    elif (ca and not ca2):
+    elif ca and not ca2:
         # one is not a cosmo_array, warn on e.g. comparison to constants:
         if inputs[1] != 0:  # allow comparison to 0
             warnings.warn(
@@ -241,13 +258,21 @@ def _return_without_cosmo_factor(ca_cf, ca_cf2=None, inputs=None):
             )
     elif (ca and ca2) and (cf is not None and cf2 is None):
         # one has no cosmo_factor information, warn:
-        warnings.warn(f"Mixing ufunc arguments with and without cosmo_factors, continuing assuming provided cosmo_factor ({cf}) for all arguments.", RuntimeWarning)
+        warnings.warn(
+            f"Mixing ufunc arguments with and without cosmo_factors, continuing assuming provided cosmo_factor ({cf}) for all arguments.",
+            RuntimeWarning,
+        )
     elif (ca and ca2) and (cf is None and cf2 is not None):
         # two has no cosmo_factor information, warn:
-        warnings.warn(f"Mixing ufunc arguments with and without cosmo_factors, continuing assuming provided cosmo_factor ({cf2}) for all arguments.", RuntimeWarning)
+        warnings.warn(
+            f"Mixing ufunc arguments with and without cosmo_factors, continuing assuming provided cosmo_factor ({cf2}) for all arguments.",
+            RuntimeWarning,
+        )
     elif (cf is not None) and (cf2 is not None) and (cf != cf2):
         # both have cosmo_factor, don't match:
-        raise ValueError(f"Ufunc arguments have cosmo_factors that differ: {cf} and {cf2}.")
+        raise ValueError(
+            f"Ufunc arguments have cosmo_factors that differ: {cf} and {cf2}."
+        )
     elif (cf is not None) and (cf2 is not None) and (cf == cf2):
         # both have cosmo_factor, and they match:
         pass
@@ -262,12 +287,20 @@ def _arctan2_cosmo_factor(ca_cf1, ca_cf2, **kwargs):
     ca2, cf2 = ca_cf2
     if (cf1 is None) and (cf2 is None):
         return None
-    if (cf1 is None and cf2 is not None):
-        warnings.warn(f"Mixing ufunc arguments with and without cosmo_factors, continuing assuming provided cosmo_factor ({cf2}) for all arguments.", RuntimeWarning)
-    if (cf1 is not None and cf2 is None):
-        warnings.warn(f"Mixing ufunc arguments with and without cosmo_factors, continuing assuming provided cosmo_factor ({cf1}) for all arguments.", RuntimeWarning)
+    if cf1 is None and cf2 is not None:
+        warnings.warn(
+            f"Mixing ufunc arguments with and without cosmo_factors, continuing assuming provided cosmo_factor ({cf2}) for all arguments.",
+            RuntimeWarning,
+        )
+    if cf1 is not None and cf2 is None:
+        warnings.warn(
+            f"Mixing ufunc arguments with and without cosmo_factors, continuing assuming provided cosmo_factor ({cf1}) for all arguments.",
+            RuntimeWarning,
+        )
     if (cf1 is not None) and (cf2 is not None) and (cf1 != cf2):
-        raise ValueError(f"Ufunc arguments have cosmo_factors that differ: {cf1} and {cf2}.")
+        raise ValueError(
+            f"Ufunc arguments have cosmo_factors that differ: {cf1} and {cf2}."
+        )
     return cosmo_factor(a ** 0, scale_factor=cf1.scale_factor)
 
 
@@ -819,7 +852,9 @@ class cosmo_array(unyt_array):
         return (not self.comoving) or (self.cosmo_factor.a_factor == 1.0)
 
     @classmethod
-    def from_astropy(cls, arr, unit_registry=None, comoving=True, cosmo_factor=None, compression=None):
+    def from_astropy(
+        cls, arr, unit_registry=None, comoving=True, cosmo_factor=None, compression=None
+    ):
         """
         Convert an AstroPy "Quantity" to a cosmo_array.
 
@@ -851,7 +886,9 @@ class cosmo_array(unyt_array):
         return obj
 
     @classmethod
-    def from_pint(cls, arr, unit_registry=None, comoving=True, cosmo_factor=None, compression=None):
+    def from_pint(
+        cls, arr, unit_registry=None, comoving=True, cosmo_factor=None, compression=None
+    ):
         """
         Convert a Pint "Quantity" to a cosmo_array.
 
@@ -911,7 +948,10 @@ class cosmo_array(unyt_array):
             ret_cm = False
         else:
             # mix of comoving and physical inputs
-            inputs = [inp.to_comoving() if cm[0] and not cm[1] else inp for inp, cm in zip(inputs, cms)]
+            inputs = [
+                inp.to_comoving() if cm[0] and not cm[1] else inp
+                for inp, cm in zip(inputs, cms)
+            ]
             ret_cm = True
 
         if len(set(comps)) == 1:
@@ -933,9 +973,7 @@ class cosmo_array(unyt_array):
                 )
             else:
                 ret_cf = _power_cosmo_factor(
-                    cfs[0],
-                    (False, None),
-                    power=power_sign * inputs[0].size,
+                    cfs[0], (False, None), power=power_sign * inputs[0].size
                 )
         else:
             ret_cf = self._cosmo_factor_ufunc_registry[ufunc](*cfs, inputs=inputs)
@@ -945,7 +983,9 @@ class cosmo_array(unyt_array):
         # if unyt returns a bare ndarray, do the same
         # otherwise we create a view and attach our attributes
         if isinstance(ret, tuple):
-            ret = tuple(r.view(type(self)) if isinstance(r, unyt_array) else r for r in ret)
+            ret = tuple(
+                r.view(type(self)) if isinstance(r, unyt_array) else r for r in ret
+            )
             for r in ret:
                 if isinstance(r, type(self)):
                     r.comoving = ret_cm

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -152,7 +152,7 @@ def _multiply_cosmo_factor(ca_cf1, ca_cf2, **kwargs):
         # both cosmo_array and both with cosmo_factor:
         return cf1 * cf2  # cosmo_factor.__mul__ raises if scale factors differ
     else:
-        raise NotImplementedError  # should not get here
+        raise RuntimeError("Unexpected state, please report this error on github.")
 
 
 def _preserve_cosmo_factor(ca_cf1, ca_cf2=None, **kwargs):
@@ -195,7 +195,7 @@ def _preserve_cosmo_factor(ca_cf1, ca_cf2=None, **kwargs):
     elif (ca1 and ca2) and (cf1 == cf2):
         return cf1  # or cf2, they're equal
     else:
-        raise NotImplementedError  # should not get here
+        raise RuntimeError("Unexpected state, please report this error on github.")
 
 
 def _power_cosmo_factor(ca_cf1, ca_cf2, inputs=None, power=None):
@@ -294,7 +294,7 @@ def _return_without_cosmo_factor(ca_cf, ca_cf2=None, inputs=None, zero_compariso
         # both have cosmo_factor, and they match:
         pass
     else:
-        raise NotImplementedError  # should not get here
+        raise RuntimeError("Unexpected state, please report this error on github.")
     # return without cosmo_factor
     return None
 

--- a/tests/subset_write_test.py
+++ b/tests/subset_write_test.py
@@ -1,10 +1,7 @@
 from tests.helper import requires
 
-import numpy as np
-from swiftsimio.subset_writer import write_subset, find_datasets
+from swiftsimio.subset_writer import write_subset
 import swiftsimio as sw
-import h5py
-import sys
 import os
 
 

--- a/tests/subset_write_test.py
+++ b/tests/subset_write_test.py
@@ -46,7 +46,7 @@ def compare_data_contents(A, B):
             try:
                 if not (param_A == param_B):
                     bad_compares.append(f"{part_type} {attr}")
-            except:
+            except ValueError:
                 if not (param_A == param_B).all():
                     bad_compares.append(f"{part_type} {attr}")
 

--- a/tests/test_cosmo_array.py
+++ b/tests/test_cosmo_array.py
@@ -8,13 +8,9 @@ from swiftsimio.objects import cosmo_array, cosmo_factor
 
 
 class TestCosmoArrayInit:
-
     def test_init_from_ndarray(self):
         arr = cosmo_array(
-            np.ones(5),
-            units=u.Mpc,
-            cosmo_factor=cosmo_factor("a^1", 1),
-            comoving=False
+            np.ones(5), units=u.Mpc, cosmo_factor=cosmo_factor("a^1", 1), comoving=False
         )
         assert hasattr(arr, "cosmo_factor")
         assert hasattr(arr, "comoving")
@@ -25,7 +21,7 @@ class TestCosmoArrayInit:
             [1, 1, 1, 1, 1],
             units=u.Mpc,
             cosmo_factor=cosmo_factor("a^1", 1),
-            comoving=False
+            comoving=False,
         )
         assert hasattr(arr, "cosmo_factor")
         assert hasattr(arr, "comoving")
@@ -35,7 +31,7 @@ class TestCosmoArrayInit:
         arr = cosmo_array(
             u.unyt_array(np.ones(5), units=u.Mpc),
             cosmo_factor=cosmo_factor("a^1", 1),
-            comoving=False
+            comoving=False,
         )
         assert hasattr(arr, "cosmo_factor")
         assert hasattr(arr, "comoving")
@@ -45,7 +41,7 @@ class TestCosmoArrayInit:
         arr = cosmo_array(
             [u.unyt_array(1, units=u.Mpc) for _ in range(5)],
             cosmo_factor=cosmo_factor("a^1", 1),
-            comoving=False
+            comoving=False,
         )
         assert hasattr(arr, "cosmo_factor")
         assert hasattr(arr, "comoving")

--- a/tests/test_cosmo_array_attrs.py
+++ b/tests/test_cosmo_array_attrs.py
@@ -556,6 +556,7 @@ class TestCosmoArrayUfuncs:
             cosmo_factor=cosmo_factor(a**1, scale_factor=0.5),
         )
         res = np.divide.reduce(inp, axis=0)
+        # unyt_array seems to give non-sensical units here!:
         np.testing.assert_allclose(res.to_value(u.kpc**-2), np.array([1., .5]))
         assert res.comoving is False
         assert res.cosmo_factor == inp.cosmo_factor ** 0

--- a/tests/test_cosmo_array_attrs.py
+++ b/tests/test_cosmo_array_attrs.py
@@ -165,12 +165,17 @@ class TestCopyFuncs:
         assert arr.compatible_with_comoving()
         assert arr.compatible_with_physical()
 
+
 class TestCheckUfuncCoverage:
     def test_multi_output_coverage(self):
-        assert set(multiple_output_operators.keys()) == set((np.modf, np.frexp, np.divmod))
+        assert set(multiple_output_operators.keys()) == set(
+            (np.modf, np.frexp, np.divmod)
+        )
 
     def test_ufunc_coverage(self):
-        assert set(u.unyt_array._ufunc_registry.keys()) == set(cosmo_array._ufunc_registry.keys())
+        assert set(u.unyt_array._ufunc_registry.keys()) == set(
+            cosmo_array._ufunc_registry.keys()
+        )
 
 
 class TestCosmoArrayUfuncs:
@@ -180,7 +185,7 @@ class TestCosmoArrayUfuncs:
             [2],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         res = np.ones_like(inp)
         assert res.to_value(u.kpc) == 1
@@ -211,7 +216,7 @@ class TestCosmoArrayUfuncs:
             [2],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         inp2 = cosmo_array([2], u.kpc, comoving=False, cosmo_factor=None)
         with pytest.warns(RuntimeWarning, match="Mixing ufunc arguments"):
@@ -225,7 +230,7 @@ class TestCosmoArrayUfuncs:
             [2],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         with pytest.warns(RuntimeWarning, match="Mixing ufunc arguments"):
             res = inp1 + inp2
@@ -237,13 +242,13 @@ class TestCosmoArrayUfuncs:
             [2],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         inp2 = cosmo_array(
             [2],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=0.5),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=0.5),
         )
         with pytest.raises(
             ValueError, match="Ufunc arguments have cosmo_factors that differ"
@@ -254,7 +259,7 @@ class TestCosmoArrayUfuncs:
             [2],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         res = inp + inp
         assert res.to_value(u.kpc) == 4
@@ -265,7 +270,7 @@ class TestCosmoArrayUfuncs:
         # no cosmo_factors
         inp = cosmo_array([2], u.kpc, comoving=False, cosmo_factor=None)
         res = inp * inp
-        assert res.to_value(u.kpc**2) == 4
+        assert res.to_value(u.kpc ** 2) == 4
         assert res.comoving is False
         assert res.cosmo_factor is None
         # one is not cosmo_array
@@ -287,12 +292,12 @@ class TestCosmoArrayUfuncs:
             [2],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         inp2 = cosmo_array([2], u.kpc, comoving=False, cosmo_factor=None)
         with pytest.warns(RuntimeWarning, match="Mixing ufunc arguments"):
             res = inp1 * inp2
-        assert res.to_value(u.kpc**2) == 4
+        assert res.to_value(u.kpc ** 2) == 4
         assert res.comoving is False
         assert res.cosmo_factor is None
         # only two has cosmo_factor
@@ -301,11 +306,11 @@ class TestCosmoArrayUfuncs:
             [2],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         with pytest.warns(RuntimeWarning, match="Mixing ufunc arguments"):
             res = inp1 * inp2
-        assert res.to_value(u.kpc**2) == 4
+        assert res.to_value(u.kpc ** 2) == 4
         assert res.comoving is False
         assert res.cosmo_factor is None
         # cosmo_factors both present
@@ -313,24 +318,24 @@ class TestCosmoArrayUfuncs:
             [2],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         res = inp * inp
-        assert res.to_value(u.kpc**2) == 4
+        assert res.to_value(u.kpc ** 2) == 4
         assert res.comoving is False
-        assert res.cosmo_factor == inp.cosmo_factor**2
+        assert res.cosmo_factor == inp.cosmo_factor ** 2
 
     def test_dividing_ufunc(self):
         inp = cosmo_array(
             [2.0],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         res = inp / inp
         assert res.to_value(u.dimensionless) == 1  # also ensures units ok
         assert res.comoving is False
-        assert res.cosmo_factor == inp.cosmo_factor**0
+        assert res.cosmo_factor == inp.cosmo_factor ** 0
 
     def test_return_without_ufunc(self):
         # 1 argument
@@ -338,7 +343,7 @@ class TestCosmoArrayUfuncs:
             [1],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         res = np.logical_not(inp)
         assert res == np.logical_not(1)
@@ -348,7 +353,7 @@ class TestCosmoArrayUfuncs:
             [2],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         res = np.logaddexp(inp, inp)
         assert res == np.logaddexp(2, 2)
@@ -358,13 +363,13 @@ class TestCosmoArrayUfuncs:
             [2],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         inp2 = cosmo_array(
             [2],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=0.5),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=0.5),
         )
         with pytest.raises(
             ValueError, match="Ufunc arguments have cosmo_factors that differ"
@@ -376,7 +381,7 @@ class TestCosmoArrayUfuncs:
             [2],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         with pytest.warns(RuntimeWarning, match="Mixing ufunc arguments"):
             res = np.logaddexp(inp1, inp2)
@@ -387,7 +392,7 @@ class TestCosmoArrayUfuncs:
             [2],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         inp2 = cosmo_array([2], u.kpc, comoving=False, cosmo_factor=None)
         with pytest.warns(RuntimeWarning, match="Mixing ufunc arguments"):
@@ -400,7 +405,7 @@ class TestCosmoArrayUfuncs:
             [2],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         with pytest.warns(RuntimeWarning, match="Mixing ufunc arguments"):
             res = np.logaddexp(inp1, inp2)
@@ -411,7 +416,7 @@ class TestCosmoArrayUfuncs:
             [2],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         inp2 = u.unyt_array([2], u.kpc)
         with pytest.warns(RuntimeWarning, match="Mixing ufunc arguments"):
@@ -424,36 +429,36 @@ class TestCosmoArrayUfuncs:
             [4],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         res = np.sqrt(inp)
-        assert res.to_value(u.kpc**0.5) == 2  # also ensures units ok
+        assert res.to_value(u.kpc ** 0.5) == 2  # also ensures units ok
         assert res.comoving is False
-        assert res.cosmo_factor == inp.cosmo_factor**0.5
+        assert res.cosmo_factor == inp.cosmo_factor ** 0.5
 
     def test_square_ufunc(self):
         inp = cosmo_array(
             [2],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         res = np.square(inp)
-        assert res.to_value(u.kpc**2) == 4  # also ensures units ok
+        assert res.to_value(u.kpc ** 2) == 4  # also ensures units ok
         assert res.comoving is False
-        assert res.cosmo_factor == inp.cosmo_factor**2
+        assert res.cosmo_factor == inp.cosmo_factor ** 2
 
     def test_reciprocal_ufunc(self):
         inp = cosmo_array(
             [2.0],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         res = np.reciprocal(inp)
-        assert res.to_value(u.kpc**-1) == 0.5  # also ensures units ok
+        assert res.to_value(u.kpc ** -1) == 0.5  # also ensures units ok
         assert res.comoving is False
-        assert res.cosmo_factor == inp.cosmo_factor**-1
+        assert res.cosmo_factor == inp.cosmo_factor ** -1
 
     def test_passthrough_ufunc(self):
         # 1 argument
@@ -461,7 +466,7 @@ class TestCosmoArrayUfuncs:
             [2],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         res = np.negative(inp)
         assert res.to_value(u.kpc) == -2
@@ -472,7 +477,7 @@ class TestCosmoArrayUfuncs:
             [2],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         res = np.copysign(inp, inp)
         assert res.to_value(u.kpc) == inp.to_value(u.kpc)
@@ -483,13 +488,13 @@ class TestCosmoArrayUfuncs:
             [2],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         inp2 = cosmo_array(
             [2],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=0.5),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=0.5),
         )
         with pytest.raises(ValueError):
             res = np.copysign(inp1, inp2)
@@ -499,7 +504,7 @@ class TestCosmoArrayUfuncs:
             [2],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         res = np.arctan2(inp, inp)
         assert res.to_value(u.dimensionless) == np.arctan2(2, 2)
@@ -511,13 +516,13 @@ class TestCosmoArrayUfuncs:
             [1],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         inp2 = cosmo_array(
             [2],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         res = inp1 < inp2
         assert res.all()
@@ -528,7 +533,7 @@ class TestCosmoArrayUfuncs:
             [1],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         out = cosmo_array([np.nan], u.dimensionless, comoving=True, cosmo_factor=None)
         np.abs(inp, out=out)
@@ -541,10 +546,10 @@ class TestCosmoArrayUfuncs:
             [[1, 2], [3, 4]],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=0.5),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=0.5),
         )
         res = np.multiply.reduce(inp, axis=0)
-        np.testing.assert_allclose(res.to_value(u.kpc**2), np.array([3., 8.]))
+        np.testing.assert_allclose(res.to_value(u.kpc ** 2), np.array([3.0, 8.0]))
         assert res.comoving is False
         assert res.cosmo_factor == inp.cosmo_factor ** 2
 
@@ -552,26 +557,26 @@ class TestCosmoArrayUfuncs:
     def test_reduce_divide(self):
         # Will fail until unyt issue #230 is fixed (PR submitted).
         inp = cosmo_array(
-            [[1., 2.], [1., 4.]],
+            [[1.0, 2.0], [1.0, 4.0]],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=0.5),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=0.5),
         )
         res = np.divide.reduce(inp, axis=0)
         # unyt_array seems to give non-sensical units here!:
-        np.testing.assert_allclose(res.to_value(u.kpc**-2), np.array([1., .5]))
+        np.testing.assert_allclose(res.to_value(u.kpc ** -2), np.array([1.0, 0.5]))
         assert res.comoving is False
         assert res.cosmo_factor == inp.cosmo_factor ** 0
 
     def test_reduce_other(self):
         inp = cosmo_array(
-            [[1., 2.], [1., 2.]],
+            [[1.0, 2.0], [1.0, 2.0]],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         res = np.add.reduce(inp, axis=0)
-        np.testing.assert_allclose(res.to_value(u.kpc), np.array([2., 4.]))
+        np.testing.assert_allclose(res.to_value(u.kpc), np.array([2.0, 4.0]))
         assert res.comoving is False
         assert res.cosmo_factor == inp.cosmo_factor
 
@@ -581,7 +586,7 @@ class TestCosmoArrayUfuncs:
             [2.5],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0)
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         res1, res2 = np.modf(inp)
         assert res1.to_value(u.kpc) == 0.5
@@ -595,7 +600,7 @@ class TestCosmoArrayUfuncs:
             [2.5],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0)
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         res1, res2 = np.frexp(inp)
         assert res1 == 0.625
@@ -609,7 +614,7 @@ class TestCosmoArrayUfuncs:
             [2.5],
             u.kpc,
             comoving=False,
-            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0)
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
         )
         out1 = cosmo_array([np.nan], u.dimensionless, comoving=True, cosmo_factor=None)
         out2 = cosmo_array([np.nan], u.dimensionless, comoving=True, cosmo_factor=None)

--- a/tests/test_cosmo_array_attrs.py
+++ b/tests/test_cosmo_array_attrs.py
@@ -5,6 +5,7 @@ Tests that functions returning copies of cosmo_array
 
 import pytest
 import numpy as np
+import unyt as u
 from swiftsimio.objects import cosmo_array, cosmo_factor, a
 
 
@@ -163,3 +164,353 @@ class TestCopyFuncs:
         )
         assert arr.compatible_with_comoving()
         assert arr.compatible_with_physical()
+
+class TestCosmoArrayUfuncs:
+    def test_preserving_ufunc(self):
+        # 1 argument
+        inp = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        res = np.ones_like(inp)
+        assert res.to_value(u.kpc) == 1
+        assert res.comoving is False
+        assert res.cosmo_factor == inp.cosmo_factor
+        # 2 argument, no cosmo_factors
+        inp = cosmo_array([2], u.kpc, comoving=False, cosmo_factor=None)
+        res = inp + inp
+        assert res.to_value(u.kpc) == 4
+        assert res.comoving is False
+        assert res.cosmo_factor is None
+        # 2 argument, one is not cosmo_array
+        inp1 = u.unyt_array([2], u.kpc)
+        inp2 = cosmo_array([2], u.kpc, comoving=False, cosmo_factor=None)
+        res = inp1 + inp2
+        assert res.to_value(u.kpc) == 4
+        assert res.comoving is False
+        assert res.cosmo_factor is None
+        # 2 argument, two is not cosmo_array
+        inp1 = cosmo_array([2], u.kpc, comoving=False, cosmo_factor=None)
+        inp2 = u.unyt_array([2], u.kpc)
+        res = inp1 + inp2
+        assert res.to_value(u.kpc) == 4
+        assert res.comoving is False
+        assert res.cosmo_factor is None
+        # 2 argument, only one has cosmo_factor
+        inp1 = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        inp2 = cosmo_array([2], u.kpc, comoving=False, cosmo_factor=None)
+        with pytest.warns(RuntimeWarning, match="Mixing ufunc arguments"):
+            res = inp1 + inp2
+        assert res.to_value(u.kpc) == 4
+        assert res.comoving is False
+        assert res.cosmo_factor == inp1.cosmo_factor
+        # 2 argument, only two has cosmo_factor
+        inp1 = cosmo_array([2], u.kpc, comoving=False, cosmo_factor=None)
+        inp2 = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        with pytest.warns(RuntimeWarning, match="Mixing ufunc arguments"):
+            res = inp1 + inp2
+        assert res.to_value(u.kpc) == 4
+        assert res.comoving is False
+        assert res.cosmo_factor == inp2.cosmo_factor
+        # 2 argument, mismatched cosmo_factors
+        inp1 = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        inp2 = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=0.5),
+        )
+        with pytest.raises(
+            ValueError, match="Ufunc arguments have cosmo_factors that differ"
+        ):
+            res = inp1 + inp2
+        # 2 argument, matched cosmo_factors
+        inp = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        res = inp + inp
+        assert res.to_value(u.kpc) == 4
+        assert res.comoving is False
+        assert res.cosmo_factor == inp.cosmo_factor
+
+    def test_multiplying_ufunc(self):
+        # no cosmo_factors
+        inp = cosmo_array([2], u.kpc, comoving=False, cosmo_factor=None)
+        res = inp * inp
+        assert res.to_value(u.kpc**2) == 4
+        assert res.comoving is False
+        assert res.cosmo_factor is None
+        # one is not cosmo_array
+        inp1 = 2
+        inp2 = cosmo_array([2], u.kpc, comoving=False, cosmo_factor=None)
+        res = inp1 * inp2
+        assert res.to_value(u.kpc) == 4
+        assert res.comoving is False
+        assert res.cosmo_factor == inp2.cosmo_factor
+        # two is not cosmo_array
+        inp1 = cosmo_array([2], u.kpc, comoving=False, cosmo_factor=None)
+        inp2 = 2
+        res = inp1 * inp2
+        assert res.to_value(u.kpc) == 4
+        assert res.comoving is False
+        assert res.cosmo_factor == inp1.cosmo_factor
+        # only one has cosmo_factor
+        inp1 = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        inp2 = cosmo_array([2], u.kpc, comoving=False, cosmo_factor=None)
+        with pytest.warns(RuntimeWarning, match="Mixing ufunc arguments"):
+            res = inp1 * inp2
+        assert res.to_value(u.kpc**2) == 4
+        assert res.comoving is False
+        assert res.cosmo_factor is None
+        # only two has cosmo_factor
+        inp1 = cosmo_array([2], u.kpc, comoving=False, cosmo_factor=None)
+        inp2 = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        with pytest.warns(RuntimeWarning, match="Mixing ufunc arguments"):
+            res = inp1 * inp2
+        assert res.to_value(u.kpc**2) == 4
+        assert res.comoving is False
+        assert res.cosmo_factor is None
+        # cosmo_factors both present
+        inp = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        res = inp * inp
+        assert res.to_value(u.kpc**2) == 4
+        assert res.comoving is False
+        assert res.cosmo_factor == inp.cosmo_factor**2
+
+    def test_dividing_ufunc(self):
+        inp = cosmo_array(
+            [2.0],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        res = inp / inp
+        assert res.to_value(u.dimensionless) == 1  # also ensures units ok
+        assert res.comoving is False
+        assert res.cosmo_factor == inp.cosmo_factor**0
+
+    def test_return_without_ufunc(self):
+        # 1 argument
+        inp = cosmo_array(
+            [1],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        res = np.logical_not(inp)
+        assert res == np.logical_not(1)
+        assert isinstance(res, np.ndarray) and not isinstance(res, u.unyt_array)
+        # 2 arguments, both cosmo_array
+        inp = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        res = np.logaddexp(inp, inp)
+        assert res == np.logaddexp(2, 2)
+        assert isinstance(res, np.ndarray) and not isinstance(res, u.unyt_array)
+        # 2 arguments, mismatched cosmo_factor
+        inp1 = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        inp2 = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=0.5),
+        )
+        with pytest.raises(
+            ValueError, match="Ufunc arguments have cosmo_factors that differ"
+        ):
+            res = np.logaddexp(inp1, inp2)
+        # 2 arguments, one missing comso_factor
+        inp1 = cosmo_array([2], u.kpc, comoving=False, cosmo_factor=None)
+        inp2 = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        with pytest.warns(RuntimeWarning, match="Mixing ufunc arguments"):
+            res = np.logaddexp(inp1, inp2)
+        assert res == np.logaddexp(2, 2)
+        assert isinstance(res, np.ndarray) and not isinstance(res, u.unyt_array)
+        # 2 arguments, two missing comso_factor
+        inp1 = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        inp2 = cosmo_array([2], u.kpc, comoving=False, cosmo_factor=None)
+        with pytest.warns(RuntimeWarning, match="Mixing ufunc arguments"):
+            res = np.logaddexp(inp1, inp2)
+        assert res == np.logaddexp(2, 2)
+        assert isinstance(res, np.ndarray) and not isinstance(res, u.unyt_array)
+        # 2 arguments, one not cosmo_array
+        inp1 = u.unyt_array([2], u.kpc)
+        inp2 = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        with pytest.warns(RuntimeWarning, match="Mixing ufunc arguments"):
+            res = np.logaddexp(inp1, inp2)
+        assert res == np.logaddexp(2, 2)
+        assert isinstance(res, np.ndarray) and not isinstance(res, u.unyt_array)
+        # 2 arguments, two not cosmo_array
+        inp1 = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        inp2 = u.unyt_array([2], u.kpc)
+        with pytest.warns(RuntimeWarning, match="Mixing ufunc arguments"):
+            res = np.logaddexp(inp1, inp2)
+        assert res == np.logaddexp(2, 2)
+        assert isinstance(res, np.ndarray) and not isinstance(res, u.unyt_array)
+
+    def test_sqrt_ufunc(self):
+        inp = cosmo_array(
+            [4],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        res = np.sqrt(inp)
+        assert res.to_value(u.kpc**0.5) == 2  # also ensures units ok
+        assert res.comoving is False
+        assert res.cosmo_factor == inp.cosmo_factor**0.5
+
+    def test_square_ufunc(self):
+        inp = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        res = np.square(inp)
+        assert res.to_value(u.kpc**2) == 4  # also ensures units ok
+        assert res.comoving is False
+        assert res.cosmo_factor == inp.cosmo_factor**2
+
+    def test_reciprocal_ufunc(self):
+        inp = cosmo_array(
+            [2.0],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        res = np.reciprocal(inp)
+        assert res.to_value(u.kpc**-1) == 0.5  # also ensures units ok
+        assert res.comoving is False
+        assert res.cosmo_factor == inp.cosmo_factor**-1
+
+    def test_passthrough_ufunc(self):
+        # 1 argument
+        inp = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        res = np.negative(inp)
+        assert res.to_value(u.kpc) == -2
+        assert res.comoving is False
+        assert res.cosmo_factor == inp.cosmo_factor
+        # 2 argument, matching
+        inp = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        res = np.copysign(inp, inp)
+        assert res.to_value(u.kpc) == inp.to_value(u.kpc)
+        assert res.comoving is False
+        assert res.cosmo_factor == inp.cosmo_factor
+        # 2 argument, not matching
+        inp1 = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        inp2 = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=0.5),
+        )
+        with pytest.raises(ValueError):
+            res = np.copysign(inp1, inp2)
+
+    def test_arctan2_ufunc(self):
+        inp = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        res = np.arctan2(inp, inp)
+        assert res.to_value(u.dimensionless) == np.arctan2(2, 2)
+        assert res.comoving is False
+        assert res.cosmo_factor.a_factor == 1  # also ensures cosmo_factor present
+
+    def test_comparison_ufunc(self):
+        inp1 = cosmo_array(
+            [1],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        inp2 = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        res = inp1 < inp2
+        assert res.all()
+        assert isinstance(res, np.ndarray) and not isinstance(res, u.unyt_array)

--- a/tests/test_cosmo_array_attrs.py
+++ b/tests/test_cosmo_array_attrs.py
@@ -625,3 +625,82 @@ class TestCosmoArrayUfuncs:
         assert out2.comoving is False
         assert out1.cosmo_factor == inp.cosmo_factor
         assert out2.cosmo_factor == inp.cosmo_factor
+
+    def test_comparison_with_zero(self):
+        inp1 = cosmo_array(
+            [1, 1, 1],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
+        )
+        inp2 = 0
+        res = inp1 > inp2
+        assert res.all()
+        inp1 = cosmo_array(
+            [1, 1, 1],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
+        )
+        inp2 = 0.5
+        with pytest.warns(RuntimeWarning, match="Mixing ufunc arguments"):
+            res = inp1 > inp2
+        assert res.all()
+        inp1 = cosmo_array(
+            [1, 1, 1],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
+        )
+        inp2 = cosmo_array(
+            [0, 0, 0],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
+        )
+        assert (inp1 > inp2).all()
+        inp1 = cosmo_array(
+            [1, 1, 1],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
+        )
+        inp2 = np.ones(3) * u.kpc
+        with pytest.warns(RuntimeWarning, match="Mixing ufunc arguments"):
+            assert (inp1 == inp2).all()
+        inp1 = cosmo_array(
+            [1, 1, 1],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
+        )
+        inp2 = np.zeros(3) * u.kpc
+        assert (inp1 > inp2).all()
+        inp1 = cosmo_array(
+            [1, 1, 1],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
+        )
+        inp2 = cosmo_array(
+            1,
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
+        )
+        res = inp1 == inp2
+        assert res.all()
+        inp1 = cosmo_array(
+            [1, 1, 1],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
+        )
+        inp2 = cosmo_array(
+            0,
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a ** 1, scale_factor=1.0),
+        )
+        res = inp1 > inp2
+        assert res.all()

--- a/tests/test_cosmo_array_attrs.py
+++ b/tests/test_cosmo_array_attrs.py
@@ -514,3 +514,28 @@ class TestCosmoArrayUfuncs:
         res = inp1 < inp2
         assert res.all()
         assert isinstance(res, np.ndarray) and not isinstance(res, u.unyt_array)
+
+    def test_out_arg(self):
+        inp = cosmo_array(
+            [1],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        out = cosmo_array([np.nan], u.kpc, comoving=True, cosmo_factor=None)
+        np.abs(inp, out=out)
+        assert out == np.abs(inp)
+        assert out.comoving is False
+        assert out.cosmo_factor == inp.cosmo_factor
+
+    def test_reduce_multiply(self):
+        inp = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        res = np.multiply.reduce((inp, inp, inp))
+        assert res.to_value(u.kpc**3) == 8  # also ensures units ok
+        assert res.comoving is False
+        assert res.cosmo_factor == inp.cosmo_factor**3

--- a/tests/test_cosmo_array_attrs.py
+++ b/tests/test_cosmo_array_attrs.py
@@ -539,3 +539,28 @@ class TestCosmoArrayUfuncs:
         assert res.to_value(u.kpc**3) == 8  # also ensures units ok
         assert res.comoving is False
         assert res.cosmo_factor == inp.cosmo_factor**3
+
+    def test_reduce_divide(self):
+        inp = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        res = np.divide.reduce((inp, inp, inp))
+        assert res.to_value(u.kpc**3) == .5  # also ensures units ok
+        assert res.comoving is False
+        assert res.cosmo_factor == inp.cosmo_factor / inp.cosmo_factor / inp.cosmo_factor
+
+    def test_reduce_other(self):
+        inp = cosmo_array(
+            [2],
+            u.kpc,
+            comoving=False,
+            cosmo_factor=cosmo_factor(a**1, scale_factor=1.0),
+        )
+        res = np.add.reduce((inp, inp, inp))
+        assert res.to_value(u.kpc) == 6  # also ensures units ok
+        assert res.comoving is False
+        assert res.cosmo_factor == inp.cosmo_factor
+

--- a/tests/test_cosmo_array_attrs.py
+++ b/tests/test_cosmo_array_attrs.py
@@ -548,7 +548,9 @@ class TestCosmoArrayUfuncs:
         assert res.comoving is False
         assert res.cosmo_factor == inp.cosmo_factor ** 2
 
+    @pytest.mark.xfail
     def test_reduce_divide(self):
+        # Will fail until unyt issue #230 is fixed (PR submitted).
         inp = cosmo_array(
             [[1., 2.], [1., 4.]],
             u.kpc,

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -152,7 +152,7 @@ def test_cell_metadata_is_valid(filename):
     boxsize = cosmo_array(
         boxsize,
         comoving=True,
-        cosmo_factor=cosmo_factor(a ** 1, mask_region.metadata.a)
+        cosmo_factor=cosmo_factor(a ** 1, mask_region.metadata.a),
     )
 
     start_offset = offsets
@@ -202,7 +202,7 @@ def test_dithered_cell_metadata_is_valid(filename):
     boxsize = cosmo_array(
         boxsize,
         comoving=True,
-        cosmo_factor=cosmo_factor(a ** 1, mask_region.metadata.a)
+        cosmo_factor=cosmo_factor(a ** 1, mask_region.metadata.a),
     )
     offsets = mask_region.offsets["dark_matter"]
     counts = mask_region.counts["dark_matter"]
@@ -250,7 +250,7 @@ def test_reading_select_region_metadata(filename):
     boxsize = cosmo_array(
         full_data.metadata.boxsize,
         comoving=True,
-        cosmo_factor=cosmo_factor(a ** 1, full_data.metadata.a)
+        cosmo_factor=cosmo_factor(a ** 1, full_data.metadata.a),
     )
     restrict = cosmo_array([boxsize * 0.2, boxsize * 0.8]).T
 
@@ -277,7 +277,9 @@ def test_reading_select_region_metadata(filename):
         selected_subset_mask = logical_and.reduce(
             [
                 logical_and(x > y_lower, x < y_upper)
-                for x, (y_lower, y_upper) in zip(selected_data.gas.coordinates.T, restrict)
+                for x, (y_lower, y_upper) in zip(
+                    selected_data.gas.coordinates.T, restrict
+                )
             ]
         )
 
@@ -305,7 +307,7 @@ def test_reading_select_region_metadata_not_spatial_only(filename):
     boxsize = cosmo_array(
         full_data.metadata.boxsize,
         comoving=True,
-        cosmo_factor=cosmo_factor(a ** 1, full_data.metadata.a)
+        cosmo_factor=cosmo_factor(a ** 1, full_data.metadata.a),
     )
     restrict = cosmo_array([boxsize * 0.26, boxsize * 0.74]).T
 
@@ -332,7 +334,9 @@ def test_reading_select_region_metadata_not_spatial_only(filename):
         selected_subset_mask = logical_and.reduce(
             [
                 logical_and(x > y_lower, x < y_upper)
-                for x, (y_lower, y_upper) in zip(selected_data.gas.coordinates.T, restrict)
+                for x, (y_lower, y_upper) in zip(
+                    selected_data.gas.coordinates.T, restrict
+                )
             ]
         )
 

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -5,7 +5,7 @@ Tests the masking using some test data.
 from tests.helper import requires
 from swiftsimio import load, mask
 
-from unyt import unyt_array as array
+from unyt import unyt_array as array, dimensionless
 
 
 @requires("cosmological_volume.hdf5")
@@ -67,7 +67,7 @@ def test_reading_select_region_half_box(filename):
     selected_coordinates = selected_data.gas.coordinates
 
     # Some of these particles will be outside because of the periodic BCs
-    assert ((selected_coordinates / full_data.metadata.boxsize) > 0.5).sum() < 25
+    assert ((selected_coordinates / full_data.metadata.boxsize).to_value(dimensionless) > 0.5).sum() < 25
 
 
 @requires("cosmological_volume.hdf5")

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -67,7 +67,10 @@ def test_reading_select_region_half_box(filename):
     selected_coordinates = selected_data.gas.coordinates
 
     # Some of these particles will be outside because of the periodic BCs
-    assert ((selected_coordinates / full_data.metadata.boxsize).to_value(dimensionless) > 0.5).sum() < 25
+    assert (
+        (selected_coordinates / full_data.metadata.boxsize).to_value(dimensionless)
+        > 0.5
+    ).sum() < 25
 
 
 @requires("cosmological_volume.hdf5")


### PR DESCRIPTION
Implementation of support for numpy ufuncs so that results preserve sensible `comoving` and `cosmo_factor` attributes. Will resolve #131 and resolve #142, which are symptoms of the previous lack of support for this.