### PR TITLE
make particle IDs start at 1

### DIFF
--- a/swiftsimio/writer.py
+++ b/swiftsimio/writer.py
@@ -575,7 +575,7 @@ class SWIFTWriterDataset(object):
         """
 
         numbers_of_particles = [getattr(self, name).n_part for name in names_to_write]
-        already_used = 0
+        already_used = 1
 
         for number, name in zip(numbers_of_particles, names_to_write):
             getattr(self, name).particle_ids = np.arange(


### PR DESCRIPTION
So apparently when running with DM and hydro, particle ID = 0 is a no-no. So let's just always start with 1.