### PR TITLE
Zero size array support

### DIFF
--- a/swiftsimio/metadata/metadata/metadata_fields.py
+++ b/swiftsimio/metadata/metadata/metadata_fields.py
@@ -20,7 +20,7 @@ metadata_fields_to_read = {
 
 # These will be unpacked to the top-level object. Be careful not to overwrite
 # things in the same namespace!
-header_unpack_arrays = {"BoxSize": "boxsize", "NumPart_ThisFile": "num_part"}
+header_unpack_arrays = {"BoxSize": "boxsize", "NumPart_ThisFile": "num_part", "CanHaveTypes": "has_type"}
 
 # Some of these 'arrays' are really types of mass table, so unpack
 # those differently:

--- a/swiftsimio/reader.py
+++ b/swiftsimio/reader.py
@@ -599,7 +599,10 @@ class SWIFTMetadata(object):
         The particle types that are present in the file.
         """
 
-        return np.where(np.array(self.num_part) != 0)[0]
+        if hasattr(self, "has_type"):
+            return np.where(np.array(self.has_type) != 0)[0]
+        else:
+            return np.where(np.array(self.num_part) != 0)[0]
 
     @property
     def present_particle_names(self):


### PR DESCRIPTION
https://gitlab.cosma.dur.ac.uk/swift/swiftsim/-/merge_requests/1560 adds support for empty particle arrays to SWIFT. These arrays can be present if a simulation is run with a certain particle type enabled (e.g. stars), but a snapshot is written before any of those particles were actually created. The advantage of writing empty arrays is that then all snapshots for that run will contain exactly the same datasets and metadata.

This PR adds support for this to `swiftsimio`. We read the new header attribute `CanHaveTypes` and use this rather than the particle number to decide whether or not to create the particle groups. If this attribute is not present, we revert to the old behaviour.

Scripts that are run on every snapshot of a run should now always get the same `SWIFTDataset`, regardless of whether or not a certain particle type is actually present in that snapshot.