### PR TITLE
Minor housekeeping requests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 90

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ htmlcov/*
 
 # MacOS
 *.DS_Store
+
+# Formatting venv
+black_formatting_env/*


### PR DESCRIPTION
I use an editor that integrates flake8 checking and will pick up a configuration from a .flake8 file. Could we add that to specify the line length (which otherwise defaults to 78) for the project so that my editor can stop yelling at me?

Also makes sense to add the venv for auto-formatting to .gitignore.