### PR TITLE
Made sure visualisation functions return correct cosmo_arrays.

### DIFF
--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -178,7 +178,7 @@ class cosmo_factor:
 
         return cosmo_factor(expr=self.expr * b.expr, scale_factor=self.scale_factor)
 
-    def __div__(self, b):
+    def __truediv__(self, b):
         if not self.scale_factor == b.scale_factor:
             raise InvalidScaleFactor(
                 "Attempting to divide two cosmo_factors with different scale factors "
@@ -196,8 +196,8 @@ class cosmo_factor:
     def __rmul__(self, b):
         return self.__mul__(b)
 
-    def __rdiv__(self, b):
-        return b.__div__(self)
+    def __rtruediv__(self, b):
+        return b.__truediv__(self)
 
     def __pow__(self, p):
         return cosmo_factor(expr=self.expr ** p, scale_factor=self.scale_factor)

--- a/swiftsimio/visualisation/projection.py
+++ b/swiftsimio/visualisation/projection.py
@@ -430,9 +430,6 @@ def project_gas(
       array if you want it to be visualised the 'right way up'.
     """
 
-    comoving = data.gas.coordinates.comoving
-    cosmo_factor = data.gas.coordinates.cosmo_factor
-
     image = project_gas_pixel_grid(
         data=data,
         resolution=resolution,
@@ -458,7 +455,15 @@ def project_gas(
         # the units...
         units.convert_to_units(1.0 / data.metadata.boxsize.units ** 2)
 
+    comoving = data.gas.coordinates.comoving
+    coord_cosmo_factor = data.gas.coordinates.cosmo_factor
     if project is not None:
         units *= getattr(data.gas, project).units
+        project_cosmo_factor = getattr(data.gas, project).cosmo_factor
+        new_cosmo_factor = project_cosmo_factor / coord_cosmo_factor ** 2
+    else:
+        new_cosmo_factor = coord_cosmo_factor ** (-2)
 
-    return cosmo_array(image, units=units, cosmo_factor=cosmo_factor, comoving=comoving)
+    return cosmo_array(
+        image, units=units, cosmo_factor=new_cosmo_factor, comoving=comoving
+    )

--- a/swiftsimio/visualisation/slice.py
+++ b/swiftsimio/visualisation/slice.py
@@ -508,9 +508,6 @@ def slice_gas(
     if z_slice is None:
         z_slice = 0.0 * data.gas.coordinates.units
 
-    comoving = data.gas.coordinates.comoving
-    cosmo_factor = data.gas.coordinates.cosmo_factor
-
     image = slice_gas_pixel_grid(
         data,
         resolution,
@@ -539,7 +536,15 @@ def slice_gas(
         # the units...
         units.convert_to_units(1.0 / data.metadata.boxsize.units ** 3)
 
+    comoving = data.gas.coordinates.comoving
+    coord_cosmo_factor = data.gas.coordinates.cosmo_factor
     if project is not None:
         units *= getattr(data.gas, project).units
+        project_cosmo_factor = getattr(data.gas, project).cosmo_factor
+        new_cosmo_factor = project_cosmo_factor / coord_cosmo_factor ** 3
+    else:
+        new_cosmo_factor = coord_cosmo_factor ** (-3)
 
-    return cosmo_array(image, units=units, cosmo_factor=cosmo_factor, comoving=comoving)
+    return cosmo_array(
+        image, units=units, cosmo_factor=new_cosmo_factor, comoving=comoving
+    )

--- a/swiftsimio/visualisation/volume_render.py
+++ b/swiftsimio/visualisation/volume_render.py
@@ -472,9 +472,6 @@ def render_gas(
     units are appropriate
     """
 
-    comoving = data.gas.coordinates.comoving
-    cosmo_factor = data.gas.coordinates.cosmo_factor
-
     image = render_gas_voxel_grid(
         data,
         resolution,
@@ -499,7 +496,15 @@ def render_gas(
         )
         units.convert_to_units(1.0 / data.metadata.boxsize.units ** 3)
 
+    comoving = data.gas.coordinates.comoving
+    coord_cosmo_factor = data.gas.coordinates.cosmo_factor
     if project is not None:
         units *= getattr(data.gas, project).units
+        project_cosmo_factor = getattr(data.gas, project).cosmo_factor
+        new_cosmo_factor = project_cosmo_factor / coord_cosmo_factor ** 3
+    else:
+        new_cosmo_factor = coord_cosmo_factor ** (-3)
 
-    return cosmo_array(image, units=units, cosmo_factor=cosmo_factor, comoving=comoving)
+    return cosmo_array(
+        image, units=units, cosmo_factor=new_cosmo_factor, comoving=comoving
+    )


### PR DESCRIPTION
I realised yesterday that #137 was incomplete, since it did not correctly set the new `cosmo_factor` for the returned arrays; it simply used the `cosmo_array` of the coordinates (which most likely has the wrong expression). This is now fixed and also tested in the unit test.

While fixing this, I realised that the `cosmo_factor` object defines `__div__` and `__rdiv__`, which are not supported by Python 3. I have replaced these with `__truediv__` and `__rtruediv__`.