### PR TITLE
Adjustments for changes in unyt.

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ to make the experience better and these are recommended.
 Requirements
 ------------
 
-This requires `python` `v3.6.0` or higher. Unfortunately it is not
+This requires `python` `v3.8.0` or higher. Unfortunately it is not
 possible to support `swiftsimio` on versions of python lower than this.
 It is important that you upgrade if you are still a `python2` user.
 

--- a/docs/source/getting_started/index.rst
+++ b/docs/source/getting_started/index.rst
@@ -18,7 +18,7 @@ are detailed below.
 Requirements
 ------------
 
-This requires ``python`` ``v3.6.0`` or higher. Unfortunately it is not
+This requires ``python`` ``v3.8.0`` or higher. Unfortunately it is not
 possible to support :mod:`swiftsimio` on versions of python lower than this.
 It is important that you upgrade if you are still a ``python2`` user.
 

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,10 @@ setuptools.setup(
     zip_safe=False,
     scripts=["swiftsnap"],
     classifiers=[
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
         "Operating System :: OS Independent",
     ],
-    install_requires=["numpy", "unyt>=2.3.0", "h5py", "numba>=0.50.0"],
+    install_requires=["numpy", "unyt>=2.9.0", "h5py", "numba>=0.50.0"],
 )

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -8,6 +8,7 @@ import warnings
 import unyt
 from unyt import unyt_array
 from unyt.array import multiple_output_operators
+
 try:
     from unyt.array import POWER_MAPPING
 except ImportError:

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -7,13 +7,11 @@ import warnings
 
 import unyt
 from unyt import unyt_array
-
-# Eventually import of POWER_SIGN_MAPPING will fail because it has been
-# replaced with POWER_MAPPING in a bugfix (unyt PR#231). Then see segment
-# of unyt.array.__array_ufunc__ where it is used and update
-# cosmo_array.__array_ufunc__ accordingly. There is an xfailing test in
-# test_cosmo_array_attrs to catch when this occurs with a test failure.
-from unyt.array import multiple_output_operators, POWER_SIGN_MAPPING
+from unyt.array import multiple_output_operators
+try:
+    from unyt.array import POWER_MAPPING
+except ImportError:
+    raise ImportError("unyt >=2.9.0 required")
 
 import sympy
 import numpy as np
@@ -1023,16 +1021,16 @@ class cosmo_array(unyt_array):
         # make sure we evaluate the cosmo_factor_ufunc_registry function:
         # might raise/warn even if we're not returning a cosmo_array
         if ufunc in (multiply, divide) and method == "reduce":
-            power_sign = POWER_SIGN_MAPPING[ufunc]
+            power_map = POWER_MAPPING[ufunc]
             if "axis" in kwargs and kwargs["axis"] is not None:
                 ret_cf = _power_cosmo_factor(
                     cfs[0],
                     (False, None),
-                    power=power_sign * inputs[0].shape[kwargs["axis"]],
+                    power=power_map(inputs[0].shape[kwargs["axis"]]),
                 )
             else:
                 ret_cf = _power_cosmo_factor(
-                    cfs[0], (False, None), power=power_sign * inputs[0].size
+                    cfs[0], (False, None), power=power_map(inputs[0].size)
                 )
         else:
             ret_cf = self._cosmo_factor_ufunc_registry[ufunc](*cfs, inputs=inputs)

--- a/tests/test_cosmo_array_attrs.py
+++ b/tests/test_cosmo_array_attrs.py
@@ -553,20 +553,17 @@ class TestCosmoArrayUfuncs:
         assert res.comoving is False
         assert res.cosmo_factor == inp.cosmo_factor ** 2
 
-    @pytest.mark.xfail
     def test_reduce_divide(self):
-        # Will fail until unyt issue #230 is fixed (PR submitted).
         inp = cosmo_array(
-            [[1.0, 2.0], [1.0, 4.0]],
+            [[1.0, 2.0], [1.0, 4.0], [1.0, 1.0]],
             u.kpc,
             comoving=False,
             cosmo_factor=cosmo_factor(a ** 1, scale_factor=0.5),
         )
         res = np.divide.reduce(inp, axis=0)
-        # unyt_array seems to give non-sensical units here!:
-        np.testing.assert_allclose(res.to_value(u.kpc ** -2), np.array([1.0, 0.5]))
+        np.testing.assert_allclose(res.to_value(u.kpc ** -1), np.array([1.0, 0.5]))
         assert res.comoving is False
-        assert res.cosmo_factor == inp.cosmo_factor ** 0
+        assert res.cosmo_factor == inp.cosmo_factor ** -1
 
     def test_reduce_other(self):
         inp = cosmo_array(


### PR DESCRIPTION
unyt has released a new version with a bugfix affecting cosmo_array. I've made the functional changes to handle the changes in unyt, and for now put a try/except on an import prompting users to update unyt if needed. If we prefer something more backwards compatible, that could be done, just let me know.

It also appears at a glance that python3.6 fails to install the latest unyt release during the test suite. Not sure what's going on with that, will have to look into it.