### PR TITLE
Made sure visualisation functions include periodic copies of particles.

### DIFF
--- a/swiftsimio/visualisation/projection.py
+++ b/swiftsimio/visualisation/projection.py
@@ -238,12 +238,14 @@ def project_pixel_grid(
     hfinal = array(hsml[combined_mask] / max_range)
     rescaled_box = array([box_x / max_range, box_y / max_range])
 
-    xall = array([])
-    yall = array([])
-    mall = array([])
-    hall = array([])
+    xall = xfinal.copy()
+    yall = yfinal.copy()
+    mall = mfinal.copy()
+    hall = hfinal.copy()
     for xshift in [-1, 0, 1]:
         for yshift in [-1, 0, 1]:
+            if xshift == 0 and yshift == 0:
+                continue
             thisx = xfinal + xshift * rescaled_box[0]
             thisy = yfinal + yshift * rescaled_box[1]
             inside = (

--- a/swiftsimio/visualisation/projection.py
+++ b/swiftsimio/visualisation/projection.py
@@ -41,6 +41,7 @@ from swiftsimio.visualisation.projection_backends.kernels import (
 scatter = backends["fast"]
 scatter_parallel = backends_parallel["fast"]
 
+
 def project_pixel_grid(
     data: __SWIFTParticleDataset,
     boxsize: unyt_array,

--- a/swiftsimio/visualisation/slice.py
+++ b/swiftsimio/visualisation/slice.py
@@ -16,6 +16,7 @@ from numpy import (
     isclose,
     matmul,
     copy,
+    append,
 )
 from unyt import unyt_array, unyt_quantity
 import unyt
@@ -410,12 +411,40 @@ def slice_gas_pixel_grid(
                 f"Comoving smoothing length is not compatible with physical coordinates!"
             )
 
+    xfinal = array((x - x_min) / max_range)
+    yfinal = array((y - y_min) / max_range)
+    zfinal = array(z / max_range)
+    mfinal = array(m)
+    hfinal = array(hsml / max_range)
+    rescaled_box = array([box_x / max_range, box_y / max_range])
+
+    xall = array([])
+    yall = array([])
+    zall = array([])
+    mall = array([])
+    hall = array([])
+    for xshift in [-1, 0, 1]:
+        for yshift in [-1, 0, 1]:
+            thisx = xfinal + xshift * rescaled_box[0]
+            thisy = yfinal + yshift * rescaled_box[1]
+            inside = (
+                (thisx - xshift * hfinal <= rescaled_box[0])
+                & (thisx - xshift * hfinal >= 0.0)
+                & (thisy - yshift * hfinal <= rescaled_box[1])
+                & (thisy - yshift * hfinal >= 0.0)
+            )
+            xall = append(xall, thisx[inside])
+            yall = append(yall, thisy[inside])
+            zall = append(zall, zfinal[inside])
+            mall = append(mall, mfinal[inside])
+            hall = append(hall, hfinal[inside])
+
     common_parameters = dict(
-        x=(x - x_min) / max_range,
-        y=(y - y_min) / max_range,
-        z=z / max_range,
-        m=m,
-        h=hsml / max_range,
+        x=xall,
+        y=yall,
+        z=zall,
+        m=mall,
+        h=hall,
         z_slice=(z_center + z_slice) / max_range,
         res=resolution,
     )

--- a/swiftsimio/visualisation/slice.py
+++ b/swiftsimio/visualisation/slice.py
@@ -418,13 +418,15 @@ def slice_gas_pixel_grid(
     hfinal = array(hsml / max_range)
     rescaled_box = array([box_x / max_range, box_y / max_range])
 
-    xall = array([])
-    yall = array([])
-    zall = array([])
-    mall = array([])
-    hall = array([])
+    xall = xfinal.copy()
+    yall = yfinal.copy()
+    zall = zfinal.copy()
+    mall = mfinal.copy()
+    hall = hfinal.copy()
     for xshift in [-1, 0, 1]:
         for yshift in [-1, 0, 1]:
+            if xshift == 0 and yshift == 0:
+                continue
             thisx = xfinal + xshift * rescaled_box[0]
             thisy = yfinal + yshift * rescaled_box[1]
             inside = (

--- a/swiftsimio/visualisation/volume_render.py
+++ b/swiftsimio/visualisation/volume_render.py
@@ -254,6 +254,7 @@ def scatter_parallel(
 
     return output
 
+
 def render_gas_voxel_grid(
     data: SWIFTDataset,
     resolution: int,

--- a/swiftsimio/visualisation/volume_render.py
+++ b/swiftsimio/visualisation/volume_render.py
@@ -395,14 +395,16 @@ def render_gas_voxel_grid(
     hfinal = array(hsml / x_range)
     rescaled_box = array([box_x / x_range, box_y / x_range, box_z / x_range])
 
-    xall = array([])
-    yall = array([])
-    zall = array([])
-    mall = array([])
-    hall = array([])
+    xall = xfinal.copy()
+    yall = yfinal.copy()
+    zall = zfinal.copy()
+    mall = mfinal.copy()
+    hall = hfinal.copy()
     for xshift in [-1, 0, 1]:
         for yshift in [-1, 0, 1]:
             for zshift in [-1, 0, 1]:
+                if xshift == 0 and yshift == 0 and zshift == 0:
+                    continue
                 thisx = xfinal + xshift * rescaled_box[0]
                 thisy = yfinal + yshift * rescaled_box[1]
                 thisz = zfinal + zshift * rescaled_box[2]


### PR DESCRIPTION
The visualisation functions only consider one periodic copy of each particle. As a result, there are some weird edge effects when visualising the full box. This is what you get when you visualise the full `cosmological_volume.hdf5` test file ("zoom" is the region inside the white square that excludes the edge):

Projection:
![project](https://user-images.githubusercontent.com/7336967/181795238-ab375f16-4e2d-4e8c-9149-39e944ee6e9d.png)

Slice:
![slice](https://user-images.githubusercontent.com/7336967/181795260-69821f96-47d8-447a-bd17-48a2a89ec0a4.png)

Volume render (slice through the centre of the voxel cube):
![render](https://user-images.githubusercontent.com/7336967/181795289-849eaffd-1c32-4877-a01b-821829cad0e1.png)

This PR adds periodic copies of all particles that could potentially contribute before calling the visualisation function. This restores the correct edge:

Projection:
![project](https://user-images.githubusercontent.com/7336967/181795615-72246f82-d3e2-450b-a9cd-f8fa40a4756e.png)

Slice:
![slice](https://user-images.githubusercontent.com/7336967/181795651-5bf61fbf-434b-43c4-9abe-417a9996de6e.png)

Volume render:
![render](https://user-images.githubusercontent.com/7336967/181795683-d3de8dcb-83b5-4e9c-8630-3888adf72860.png)