### PR TITLE
Made sure visualisation functions include periodic copies of particles (attempt 2)

### DIFF
--- a/docs/source/visualisation/index.rst
+++ b/docs/source/visualisation/index.rst
@@ -17,6 +17,7 @@ common interface:
        project="masses", # Variable to project, e.g. masses, temperatures, etc.
        parallel=False, # Construct the image in (thread) parallel?
        region=None, # None, or a list telling which region to render_func_name
+       periodic=True, # Whether or not to apply periodic boundary conditions
    )
 
 The output of these functions comes with associated units and has the correct

--- a/swiftsimio/visualisation/projection.py
+++ b/swiftsimio/visualisation/projection.py
@@ -237,6 +237,8 @@ def project_pixel_grid(
         m=m[combined_mask],
         h=hsml[combined_mask] / max_range,
         res=resolution,
+        box_x=box_x / max_range,
+        box_y=box_y / max_range,
     )
 
     if parallel:

--- a/swiftsimio/visualisation/projection.py
+++ b/swiftsimio/visualisation/projection.py
@@ -52,6 +52,7 @@ def project_pixel_grid(
     rotation_center: Union[None, unyt_array] = None,
     parallel: bool = False,
     backend: str = "fast",
+    periodic: bool = True,
 ):
     r"""
     Creates a 2D projection of a SWIFT dataset, projected by the "project"
@@ -108,6 +109,9 @@ def project_pixel_grid(
     backend: str, optional
         Backend to use. See documentation for details. Defaults to 'fast'.
 
+    periodic: bool, optional
+        Account for periodic boundary conditions for the simulation box?
+        Defaults to ``True``.
 
     Returns
     -------
@@ -231,14 +235,21 @@ def project_pixel_grid(
     else:
         combined_mask = mask
 
+    if periodic:
+        periodic_box_x = box_x / max_range
+        periodic_box_y = box_y / max_range
+    else:
+        periodic_box_x = 0.0
+        periodic_box_y = 0.0
+
     common_arguments = dict(
         x=(x[combined_mask] - x_min) / max_range,
         y=(y[combined_mask] - y_min) / max_range,
         m=m[combined_mask],
         h=hsml[combined_mask] / max_range,
         res=resolution,
-        box_x=box_x / max_range,
-        box_y=box_y / max_range,
+        box_x=periodic_box_x,
+        box_y=periodic_box_y,
     )
 
     if parallel:
@@ -264,6 +275,7 @@ def project_gas_pixel_grid(
     rotation_center: Union[None, unyt_array] = None,
     parallel: bool = False,
     backend: str = "fast",
+    periodic: bool = True,
 ):
     r"""
     Creates a 2D projection of a SWIFT dataset, projected by the "project"
@@ -319,6 +331,9 @@ def project_gas_pixel_grid(
     backend: str, optional
         Backend to use. See documentation for details. Defaults to 'fast'.
 
+    periodic: bool, optional
+        Account for periodic boundary conditions for the simulation box?
+        Defaults to ``True``.
 
     Returns
     -------
@@ -349,6 +364,7 @@ def project_gas_pixel_grid(
         rotation_matrix=rotation_matrix,
         rotation_center=rotation_center,
         backend=backend,
+        periodic=periodic,
     )
 
     return image
@@ -364,6 +380,7 @@ def project_gas(
     rotation_matrix: Union[None, array] = None,
     parallel: bool = False,
     backend: str = "fast",
+    periodic: bool = True,
 ):
     r"""
     Creates a 2D projection of a SWIFT dataset, projected by the "project"
@@ -417,6 +434,10 @@ def project_gas(
     backend: str, optional
         Backend to use. See documentation for details. Defaults to 'fast'.
 
+    periodic: bool, optional
+        Account for periodic boundary conditions for the simulation box?
+        Defaults to ``True``.
+
 
     Returns
     -------
@@ -446,6 +467,7 @@ def project_gas(
         rotation_matrix=rotation_matrix,
         rotation_center=rotation_center,
         backend=backend,
+        periodic=periodic,
     )
 
     if region is not None:

--- a/swiftsimio/visualisation/projection_backends/fast.py
+++ b/swiftsimio/visualisation/projection_backends/fast.py
@@ -24,7 +24,15 @@ from swiftsimio.visualisation.projection_backends.kernels import (
 
 
 @jit(nopython=True, fastmath=True)
-def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray:
+def scatter(
+    x: float64,
+    y: float64,
+    m: float32,
+    h: float32,
+    res: int,
+    box_x: float64,
+    box_y: float64,
+) -> ndarray:
     """
     Creates a weighted scatter plot
 
@@ -84,68 +92,90 @@ def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray
     # Pre-calculate this constant for use with the above
     inverse_cell_area = res * res
 
-    for x_pos, y_pos, mass, hsml in zip(x, y, m, h):
-        # Calculate the cell that this particle; use the 64 bit version of the
-        # resolution as this is the same type as the positions
-        particle_cell_x = int32(float_res_64 * x_pos)
-        particle_cell_y = int32(float_res_64 * y_pos)
+    for x_pos_original, y_pos_original, mass, hsml in zip(x, y, m, h):
+        for xshift in range(3):
+            for yshift in range(3):
+                x_pos = x_pos_original + (xshift - 1) * box_x
+                y_pos = y_pos_original + (yshift - 1) * box_y
 
-        # SWIFT stores hsml as the FWHM.
-        kernel_width = kernel_gamma * hsml
+                # Calculate the cell that this particle; use the 64 bit version of the
+                # resolution as this is the same type as the positions
+                particle_cell_x = int32(float_res_64 * x_pos)
+                particle_cell_y = int32(float_res_64 * y_pos)
 
-        # The number of cells that this kernel spans
-        cells_spanned = int32(1.0 + kernel_width * float_res)
+                # SWIFT stores hsml as the FWHM.
+                kernel_width = kernel_gamma * hsml
 
-        if (
-            particle_cell_x + cells_spanned < 0
-            or particle_cell_x - cells_spanned > maximal_array_index
-            or particle_cell_y + cells_spanned < 0
-            or particle_cell_y - cells_spanned > maximal_array_index
-        ):
-            # Can happily skip this particle
-            continue
+                # The number of cells that this kernel spans
+                cells_spanned = int32(1.0 + kernel_width * float_res)
 
-        if cells_spanned <= 1:
-            # Easygame, gg
-            if (
-                particle_cell_x >= 0
-                and particle_cell_x <= maximal_array_index
-                and particle_cell_y >= 0
-                and particle_cell_y <= maximal_array_index
-            ):
-                image[particle_cell_x, particle_cell_y] += mass * inverse_cell_area
-        else:
-            # Now we loop over the square of cells that the kernel lives in
-            for cell_x in range(
-                # Ensure that the lowest x value is 0, otherwise we'll segfault
-                max(0, particle_cell_x - cells_spanned),
-                # Ensure that the highest x value lies within the array bounds,
-                # otherwise we'll segfault (oops).
-                min(particle_cell_x + cells_spanned + 1, maximal_array_index + 1),
-            ):
-                # The distance in x to our new favourite cell -- remember that our x, y
-                # are all in a box of [0, 1]; calculate the distance to the cell centre
-                distance_x = (float32(cell_x) + 0.5) * pixel_width - float32(x_pos)
-                distance_x_2 = distance_x * distance_x
-                for cell_y in range(
-                    max(0, particle_cell_y - cells_spanned),
-                    min(particle_cell_y + cells_spanned + 1, maximal_array_index + 1),
+                if (
+                    particle_cell_x + cells_spanned < 0
+                    or particle_cell_x - cells_spanned > maximal_array_index
+                    or particle_cell_y + cells_spanned < 0
+                    or particle_cell_y - cells_spanned > maximal_array_index
                 ):
-                    distance_y = (float32(cell_y) + 0.5) * pixel_width - float32(y_pos)
-                    distance_y_2 = distance_y * distance_y
+                    # Can happily skip this particle
+                    continue
 
-                    r = sqrt(distance_x_2 + distance_y_2)
+                if cells_spanned <= 1:
+                    # Easygame, gg
+                    if (
+                        particle_cell_x >= 0
+                        and particle_cell_x <= maximal_array_index
+                        and particle_cell_y >= 0
+                        and particle_cell_y <= maximal_array_index
+                    ):
+                        image[particle_cell_x, particle_cell_y] += (
+                            mass * inverse_cell_area
+                        )
+                else:
+                    # Now we loop over the square of cells that the kernel lives in
+                    for cell_x in range(
+                        # Ensure that the lowest x value is 0, otherwise we'll segfault
+                        max(0, particle_cell_x - cells_spanned),
+                        # Ensure that the highest x value lies within the array bounds,
+                        # otherwise we'll segfault (oops).
+                        min(
+                            particle_cell_x + cells_spanned + 1, maximal_array_index + 1
+                        ),
+                    ):
+                        # The distance in x to our new favourite cell -- remember that our x, y
+                        # are all in a box of [0, 1]; calculate the distance to the cell centre
+                        distance_x = (float32(cell_x) + 0.5) * pixel_width - float32(
+                            x_pos
+                        )
+                        distance_x_2 = distance_x * distance_x
+                        for cell_y in range(
+                            max(0, particle_cell_y - cells_spanned),
+                            min(
+                                particle_cell_y + cells_spanned + 1,
+                                maximal_array_index + 1,
+                            ),
+                        ):
+                            distance_y = (
+                                float32(cell_y) + 0.5
+                            ) * pixel_width - float32(y_pos)
+                            distance_y_2 = distance_y * distance_y
 
-                    kernel_eval = kernel(r, kernel_width)
+                            r = sqrt(distance_x_2 + distance_y_2)
 
-                    image[cell_x, cell_y] += mass * kernel_eval
+                            kernel_eval = kernel(r, kernel_width)
+
+                            image[cell_x, cell_y] += mass * kernel_eval
 
     return image
 
 
 @jit(nopython=True, fastmath=True, parallel=True)
 def scatter_parallel(
-    x: float64, y: float64, m: float32, h: float32, res: int
+    x: float64,
+    y: float64,
+    m: float32,
+    h: float32,
+    res: int,
+    box_x: float64,
+    box_y: float64,
 ) -> ndarray:
     """
     Parallel implementation of scatter
@@ -216,6 +246,8 @@ def scatter_parallel(
             m=m[left_edge:right_edge],
             h=h[left_edge:right_edge],
             res=res,
+            box_x=box_x,
+            box_y=box_y,
         )
 
     return output

--- a/swiftsimio/visualisation/projection_backends/fast.py
+++ b/swiftsimio/visualisation/projection_backends/fast.py
@@ -38,7 +38,7 @@ def scatter(
 
     Computes contributions to from particles with positions
     (`x`,`y`) with smoothing lengths `h` weighted by quantities `m`.
-    This ignores boundary effects.
+    This includes periodic boundary effects.
 
     Parameters
     ----------
@@ -58,6 +58,14 @@ def scatter(
     res : int
         the number of pixels along one axis, i.e. this returns a square
         of res * res.
+
+    box_x: float64
+        box size in x, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
+
+    box_y: float64
+        box size in y, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
 
     Returns
     -------
@@ -93,6 +101,7 @@ def scatter(
     inverse_cell_area = res * res
 
     for x_pos_original, y_pos_original, mass, hsml in zip(x, y, m, h):
+        # loop over periodic copies of this particle
         for xshift in range(3):
             for yshift in range(3):
                 x_pos = x_pos_original + (xshift - 1) * box_x
@@ -183,7 +192,7 @@ def scatter_parallel(
     Creates a weighted scatter plot. Computes contributions from
     particles with positions (`x`,`y`) with smoothing lengths `h`
     weighted by quantities `m`.
-    This ignores boundary effects.
+    This includes periodic boundary effects.
 
     Parameters
     ----------
@@ -202,6 +211,14 @@ def scatter_parallel(
     res : int
         the number of pixels along one axis, i.e. this returns a square
         of res * res.
+
+    box_x: float64
+        box size in x, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
+
+    box_y: float64
+        box size in y, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
 
     Returns
     -------

--- a/swiftsimio/visualisation/projection_backends/fast.py
+++ b/swiftsimio/visualisation/projection_backends/fast.py
@@ -30,8 +30,8 @@ def scatter(
     m: float32,
     h: float32,
     res: int,
-    box_x: float64,
-    box_y: float64,
+    box_x: float64 = 0.0,
+    box_y: float64 = 0.0,
 ) -> ndarray:
     """
     Creates a weighted scatter plot
@@ -100,12 +100,25 @@ def scatter(
     # Pre-calculate this constant for use with the above
     inverse_cell_area = res * res
 
+    if box_x == 0.0:
+        xshift_min = 0
+        xshift_max = 1
+    else:
+        xshift_min = -1
+        xshift_max = 2
+    if box_y == 0.0:
+        yshift_min = 0
+        yshift_max = 1
+    else:
+        yshift_min = -1
+        yshift_max = 2
+
     for x_pos_original, y_pos_original, mass, hsml in zip(x, y, m, h):
         # loop over periodic copies of this particle
-        for xshift in range(3):
-            for yshift in range(3):
-                x_pos = x_pos_original + (xshift - 1) * box_x
-                y_pos = y_pos_original + (yshift - 1) * box_y
+        for xshift in range(xshift_min, xshift_max):
+            for yshift in range(yshift_min, yshift_max):
+                x_pos = x_pos_original + xshift * box_x
+                y_pos = y_pos_original + yshift * box_y
 
                 # Calculate the cell that this particle; use the 64 bit version of the
                 # resolution as this is the same type as the positions
@@ -183,8 +196,8 @@ def scatter_parallel(
     m: float32,
     h: float32,
     res: int,
-    box_x: float64,
-    box_y: float64,
+    box_x: float64 = 0.0,
+    box_y: float64 = 0.0,
 ) -> ndarray:
     """
     Parallel implementation of scatter

--- a/swiftsimio/visualisation/projection_backends/gpu.py
+++ b/swiftsimio/visualisation/projection_backends/gpu.py
@@ -183,7 +183,15 @@ def scatter_gpu(x: float64, y: float64, m: float32, h: float32, img: float32):
                     cuda.atomic.add(img, (cell_x, cell_y), mass * kernel_eval)
 
 
-def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray:
+def scatter(
+    x: float64,
+    y: float64,
+    m: float32,
+    h: float32,
+    res: int,
+    box_x: float64,
+    box_y: float64,
+) -> ndarray:
     """
     Parallel implementation of scatter
 

--- a/swiftsimio/visualisation/projection_backends/gpu.py
+++ b/swiftsimio/visualisation/projection_backends/gpu.py
@@ -208,8 +208,8 @@ def scatter(
     m: float32,
     h: float32,
     res: int,
-    box_x: float64,
-    box_y: float64,
+    box_x: float64 = 0.0,
+    box_y: float64 = 0.0,
 ) -> ndarray:
     """
     Parallel implementation of scatter
@@ -272,6 +272,14 @@ def scatter(
     output[:] = 0
 
     n_part = len(x)
+    if box_x == 0.0:
+        n_xshift = 1
+    else:
+        n_xshift = 3
+    if box_y == 0.0:
+        n_yshift = 1
+    else:
+        n_yshift = 3
     # set up a 3D grid:
     # the first dimension are the particles
     # the second and third dimension are the periodic
@@ -279,8 +287,8 @@ def scatter(
     threads_per_block = (16, 1, 1)
     blocks_per_grid = (
         ceil(n_part / threads_per_block[0]),
-        3 // threads_per_block[1],
-        3 // threads_per_block[2],
+        n_xshift // threads_per_block[1],
+        n_yshift // threads_per_block[2],
     )
     scatter_gpu[blocks_per_grid, threads_per_block](x, y, m, h, box_x, box_y, output)
 

--- a/swiftsimio/visualisation/projection_backends/histogram.py
+++ b/swiftsimio/visualisation/projection_backends/histogram.py
@@ -27,7 +27,7 @@ def scatter(
 
     Computes contributions to from particles with positions
     (`x`,`y`) with smoothing lengths `h` weighted by quantities `m`.
-    This ignores boundary effects.
+    This includes periodic boundary effects.
 
     Parameters
     ----------
@@ -47,6 +47,14 @@ def scatter(
     res : int
         the number of pixels along one axis, i.e. this returns a square
         of res * res.
+
+    box_x: float64
+        box size in x, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
+
+    box_y: float64
+        box size in y, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
 
     Returns
     -------
@@ -78,6 +86,7 @@ def scatter(
     inverse_cell_area = float_res * float_res
 
     for x_pos_original, y_pos_original, mass in zip(x, y, m):
+        # loop over periodic copies of this particle
         for xshift in range(3):
             for yshift in range(3):
                 x_pos = x_pos_original + (xshift - 1) * box_y
@@ -117,7 +126,7 @@ def scatter_parallel(
     Creates a weighted scatter plot. Computes contributions from
     particles with positions (`x`,`y`) with smoothing lengths `h`
     weighted by quantities `m`.
-    This ignores boundary effects.
+    This includes periodic boundary effects.
 
     Parameters
     ----------
@@ -136,6 +145,14 @@ def scatter_parallel(
     res : int
         the number of pixels along one axis, i.e. this returns a square
         of res * res.
+
+    box_x: float64
+        box size in x, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
+
+    box_y: float64
+        box size in y, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
 
     Returns
     -------

--- a/swiftsimio/visualisation/projection_backends/histogram.py
+++ b/swiftsimio/visualisation/projection_backends/histogram.py
@@ -19,8 +19,8 @@ def scatter(
     m: float32,
     h: float32,
     res: int,
-    box_x: float64,
-    box_y: float64,
+    box_x: float64 = 0.0,
+    box_y: float64 = 0.0,
 ) -> ndarray:
     """
     Creates a weighted scatter plot
@@ -85,12 +85,25 @@ def scatter(
     # Pre-calculate this constant for use with the above
     inverse_cell_area = float_res * float_res
 
+    if box_x == 0.0:
+        xshift_min = 0
+        xshift_max = 1
+    else:
+        xshift_min = -1
+        xshift_max = 2
+    if box_y == 0.0:
+        yshift_min = 0
+        yshift_max = 1
+    else:
+        yshift_min = -1
+        yshift_max = 2
+
     for x_pos_original, y_pos_original, mass in zip(x, y, m):
         # loop over periodic copies of this particle
-        for xshift in range(3):
-            for yshift in range(3):
-                x_pos = x_pos_original + (xshift - 1) * box_y
-                y_pos = y_pos_original + (yshift - 1) * box_y
+        for xshift in range(xshift_min, xshift_max):
+            for yshift in range(yshift_min, yshift_max):
+                x_pos = x_pos_original + xshift * box_y
+                y_pos = y_pos_original + yshift * box_y
 
                 # Calculate the cell that this particle; use the 64 bit version of the
                 # resolution as this is the same type as the positions
@@ -117,8 +130,8 @@ def scatter_parallel(
     m: float32,
     h: float32,
     res: int,
-    box_x: float64,
-    box_y: float64,
+    box_x: float64 = 0.0,
+    box_y: float64 = 0.0,
 ) -> ndarray:
     """
     Parallel implementation of scatter

--- a/swiftsimio/visualisation/projection_backends/reference.py
+++ b/swiftsimio/visualisation/projection_backends/reference.py
@@ -31,8 +31,8 @@ def scatter(
     m: float32,
     h: float32,
     res: int,
-    box_x: float64,
-    box_y: float64,
+    box_x: float64 = 0.0,
+    box_y: float64 = 0.0,
 ) -> ndarray:
     """
     Creates a weighted scatter plot
@@ -98,12 +98,25 @@ def scatter(
     # We need this for combining with the x_pos and y_pos variables.
     float_res_64 = float64(res)
 
+    if box_x == 0.0:
+        xshift_min = 0
+        xshift_max = 1
+    else:
+        xshift_min = -1
+        xshift_max = 2
+    if box_y == 0.0:
+        yshift_min = 0
+        yshift_max = 1
+    else:
+        yshift_min = -1
+        yshift_max = 2
+
     for x_pos_original, y_pos_original, mass, hsml in zip(x, y, m, h):
         # loop over periodic copies of this particle
-        for xshift in range(3):
-            for yshift in range(3):
-                x_pos = x_pos_original + (xshift - 1) * box_x
-                y_pos = y_pos_original + (yshift - 1) * box_y
+        for xshift in range(xshift_min, xshift_max):
+            for yshift in range(yshift_min, yshift_max):
+                x_pos = x_pos_original + xshift * box_x
+                y_pos = y_pos_original + yshift * box_y
 
                 # Calculate the cell that this particle; use the 64 bit version of the
                 # resolution as this is the same type as the positions
@@ -173,8 +186,8 @@ def scatter_parallel(
     m: float32,
     h: float32,
     res: int,
-    box_x: float64,
-    box_y: float64,
+    box_x: float64 = 0.0,
+    box_y: float64 = 0.0,
 ) -> ndarray:
     """
     Parallel implementation of scatter

--- a/swiftsimio/visualisation/projection_backends/reference.py
+++ b/swiftsimio/visualisation/projection_backends/reference.py
@@ -39,7 +39,7 @@ def scatter(
 
     Computes contributions to from particles with positions
     (`x`,`y`) with smoothing lengths `h` weighted by quantities `m`.
-    This ignores boundary effects.
+    This includes periodic boundary effects.
 
     Parameters
     ----------
@@ -59,6 +59,14 @@ def scatter(
     res : int
         the number of pixels along one axis, i.e. this returns a square
         of res * res.
+
+    box_x: float64
+        box size in x, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
+
+    box_y: float64
+        box size in y, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
 
     Returns
     -------
@@ -91,6 +99,7 @@ def scatter(
     float_res_64 = float64(res)
 
     for x_pos_original, y_pos_original, mass, hsml in zip(x, y, m, h):
+        # loop over periodic copies of this particle
         for xshift in range(3):
             for yshift in range(3):
                 x_pos = x_pos_original + (xshift - 1) * box_x
@@ -173,7 +182,7 @@ def scatter_parallel(
     Creates a weighted scatter plot. Computes contributions from
     particles with positions (`x`,`y`) with smoothing lengths `h`
     weighted by quantities `m`.
-    This ignores boundary effects.
+    This includes periodic boundary effects.
 
     Parameters
     ----------
@@ -192,6 +201,14 @@ def scatter_parallel(
     res : int
         the number of pixels along one axis, i.e. this returns a square
         of res * res.
+
+    box_x: float64
+        box size in x, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
+
+    box_y: float64
+        box size in y, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
 
     Returns
     -------

--- a/swiftsimio/visualisation/projection_backends/renormalised.py
+++ b/swiftsimio/visualisation/projection_backends/renormalised.py
@@ -29,7 +29,15 @@ from swiftsimio.visualisation.projection_backends.kernels import (
 
 
 @jit(nopython=True, fastmath=True)
-def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray:
+def scatter(
+    x: float64,
+    y: float64,
+    m: float32,
+    h: float32,
+    res: int,
+    box_x: float64,
+    box_y: float64,
+) -> ndarray:
     """
     Creates a weighted scatter plot
 
@@ -89,95 +97,123 @@ def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray
     # Pre-calculate this constant for use with the above
     inverse_cell_area = float_res * float_res
 
-    for x_pos, y_pos, mass, hsml in zip(x, y, m, h):
-        # Calculate the cell that this particle; use the 64 bit version of the
-        # resolution as this is the same type as the positions
-        particle_cell_x = int32(float_res_64 * x_pos)
-        particle_cell_y = int32(float_res_64 * y_pos)
+    for x_pos_original, y_pos_original, mass, hsml in zip(x, y, m, h):
+        for xshift in range(3):
+            for yshift in range(3):
+                x_pos = x_pos_original + (xshift - 1) * box_x
+                y_pos = y_pos_original + (yshift - 1) * box_y
 
-        # SWIFT stores hsml as the FWHM.
-        kernel_width = kernel_gamma * hsml
+                # Calculate the cell that this particle; use the 64 bit version of the
+                # resolution as this is the same type as the positions
+                particle_cell_x = int32(float_res_64 * x_pos)
+                particle_cell_y = int32(float_res_64 * y_pos)
 
-        # The number of cells that this kernel spans
-        cells_spanned = int32(1.0 + kernel_width * float_res)
+                # SWIFT stores hsml as the FWHM.
+                kernel_width = kernel_gamma * hsml
 
-        if (
-            particle_cell_x + cells_spanned < 0
-            or particle_cell_x - cells_spanned > maximal_array_index
-            or particle_cell_y + cells_spanned < 0
-            or particle_cell_y - cells_spanned > maximal_array_index
-        ):
-            # Can happily skip this particle
-            continue
+                # The number of cells that this kernel spans
+                cells_spanned = int32(1.0 + kernel_width * float_res)
 
-        if cells_spanned <= 1:
-            # Easygame, gg
-            if (
-                particle_cell_x >= 0
-                and particle_cell_x <= maximal_array_index
-                and particle_cell_y >= 0
-                and particle_cell_y <= maximal_array_index
-            ):
-                image[particle_cell_x, particle_cell_y] += mass * inverse_cell_area
-        else:
-            # First calculate the typical normalisation for this kernel in this
-            # segment of the image (use the whole square, including overlap with
-            # edges).
-
-            normalisation = float32(0.0)
-
-            for cell_x in range(
-                particle_cell_x - cells_spanned + 1, particle_cell_x + cells_spanned
-            ):
-                # The distance in x to our new favourite cell -- remember that our x, y
-                # are all in a box of [0, 1]; calculate the distance to the cell centre
-                distance_x = (float32(cell_x) + 0.5) * pixel_width - float32(x_pos)
-                distance_x_2 = distance_x * distance_x
-                for cell_y in range(
-                    particle_cell_y - cells_spanned + 1, particle_cell_y + cells_spanned
+                if (
+                    particle_cell_x + cells_spanned < 0
+                    or particle_cell_x - cells_spanned > maximal_array_index
+                    or particle_cell_y + cells_spanned < 0
+                    or particle_cell_y - cells_spanned > maximal_array_index
                 ):
-                    distance_y = (float32(cell_y) + 0.5) * pixel_width - float32(y_pos)
-                    distance_y_2 = distance_y * distance_y
+                    # Can happily skip this particle
+                    continue
 
-                    r = sqrt(distance_x_2 + distance_y_2)
+                if cells_spanned <= 1:
+                    # Easygame, gg
+                    if (
+                        particle_cell_x >= 0
+                        and particle_cell_x <= maximal_array_index
+                        and particle_cell_y >= 0
+                        and particle_cell_y <= maximal_array_index
+                    ):
+                        image[particle_cell_x, particle_cell_y] += (
+                            mass * inverse_cell_area
+                        )
+                else:
+                    # First calculate the typical normalisation for this kernel in this
+                    # segment of the image (use the whole square, including overlap with
+                    # edges).
 
-                    normalisation += kernel(r, kernel_width)
+                    normalisation = float32(0.0)
 
-            # We want sum(W_ij) = 1.0
-            normalisation = inverse_cell_area / normalisation
+                    for cell_x in range(
+                        particle_cell_x - cells_spanned + 1,
+                        particle_cell_x + cells_spanned,
+                    ):
+                        # The distance in x to our new favourite cell -- remember that our x, y
+                        # are all in a box of [0, 1]; calculate the distance to the cell centre
+                        distance_x = (float32(cell_x) + 0.5) * pixel_width - float32(
+                            x_pos
+                        )
+                        distance_x_2 = distance_x * distance_x
+                        for cell_y in range(
+                            particle_cell_y - cells_spanned + 1,
+                            particle_cell_y + cells_spanned,
+                        ):
+                            distance_y = (
+                                float32(cell_y) + 0.5
+                            ) * pixel_width - float32(y_pos)
+                            distance_y_2 = distance_y * distance_y
 
-            # Now we loop over the square of cells that the kernel lives in
-            for cell_x in range(
-                # Ensure that the lowest x value is 0, otherwise we'll segfault
-                max(0, particle_cell_x - cells_spanned),
-                # Ensure that the highest x value lies within the array bounds,
-                # otherwise we'll segfault (oops).
-                min(particle_cell_x + cells_spanned + 1, maximal_array_index + 1),
-            ):
-                # The distance in x to our new favourite cell -- remember that our x, y
-                # are all in a box of [0, 1]; calculate the distance to the cell centre
-                distance_x = (float32(cell_x) + 0.5) * pixel_width - float32(x_pos)
-                distance_x_2 = distance_x * distance_x
-                for cell_y in range(
-                    max(0, particle_cell_y - cells_spanned),
-                    min(particle_cell_y + cells_spanned + 1, maximal_array_index + 1),
-                ):
-                    distance_y = (float32(cell_y) + 0.5) * pixel_width - float32(y_pos)
-                    distance_y_2 = distance_y * distance_y
+                            r = sqrt(distance_x_2 + distance_y_2)
 
-                    r = sqrt(distance_x_2 + distance_y_2)
+                            normalisation += kernel(r, kernel_width)
 
-                    # Renormalise kernel before using
-                    kernel_eval = normalisation * kernel(r, kernel_width)
+                    # We want sum(W_ij) = 1.0
+                    normalisation = inverse_cell_area / normalisation
 
-                    image[cell_x, cell_y] += mass * kernel_eval
+                    # Now we loop over the square of cells that the kernel lives in
+                    for cell_x in range(
+                        # Ensure that the lowest x value is 0, otherwise we'll segfault
+                        max(0, particle_cell_x - cells_spanned),
+                        # Ensure that the highest x value lies within the array bounds,
+                        # otherwise we'll segfault (oops).
+                        min(
+                            particle_cell_x + cells_spanned + 1, maximal_array_index + 1
+                        ),
+                    ):
+                        # The distance in x to our new favourite cell -- remember that our x, y
+                        # are all in a box of [0, 1]; calculate the distance to the cell centre
+                        distance_x = (float32(cell_x) + 0.5) * pixel_width - float32(
+                            x_pos
+                        )
+                        distance_x_2 = distance_x * distance_x
+                        for cell_y in range(
+                            max(0, particle_cell_y - cells_spanned),
+                            min(
+                                particle_cell_y + cells_spanned + 1,
+                                maximal_array_index + 1,
+                            ),
+                        ):
+                            distance_y = (
+                                float32(cell_y) + 0.5
+                            ) * pixel_width - float32(y_pos)
+                            distance_y_2 = distance_y * distance_y
+
+                            r = sqrt(distance_x_2 + distance_y_2)
+
+                            # Renormalise kernel before using
+                            kernel_eval = normalisation * kernel(r, kernel_width)
+
+                            image[cell_x, cell_y] += mass * kernel_eval
 
     return image
 
 
 @jit(nopython=True, fastmath=True, parallel=True)
 def scatter_parallel(
-    x: float64, y: float64, m: float32, h: float32, res: int
+    x: float64,
+    y: float64,
+    m: float32,
+    h: float32,
+    res: int,
+    box_x: float64,
+    box_y: float64,
 ) -> ndarray:
     """
     Parallel implementation of scatter
@@ -249,6 +285,8 @@ def scatter_parallel(
             m=m[left_edge:right_edge],
             h=h[left_edge:right_edge],
             res=res,
+            box_x=box_x,
+            box_y=box_y,
         )
 
     return output

--- a/swiftsimio/visualisation/projection_backends/renormalised.py
+++ b/swiftsimio/visualisation/projection_backends/renormalised.py
@@ -35,8 +35,8 @@ def scatter(
     m: float32,
     h: float32,
     res: int,
-    box_x: float64,
-    box_y: float64,
+    box_x: float64 = 0.0,
+    box_y: float64 = 0.0,
 ) -> ndarray:
     """
     Creates a weighted scatter plot
@@ -105,12 +105,25 @@ def scatter(
     # Pre-calculate this constant for use with the above
     inverse_cell_area = float_res * float_res
 
+    if box_x == 0.0:
+        xshift_min = 0
+        xshift_max = 1
+    else:
+        xshift_min = -1
+        xshift_max = 2
+    if box_y == 0.0:
+        yshift_min = 0
+        yshift_max = 1
+    else:
+        yshift_min = -1
+        yshift_max = 2
+
     for x_pos_original, y_pos_original, mass, hsml in zip(x, y, m, h):
         # loop over periodic copies of this particle
-        for xshift in range(3):
-            for yshift in range(3):
-                x_pos = x_pos_original + (xshift - 1) * box_x
-                y_pos = y_pos_original + (yshift - 1) * box_y
+        for xshift in range(xshift_min, xshift_max):
+            for yshift in range(yshift_min, yshift_max):
+                x_pos = x_pos_original + xshift * box_x
+                y_pos = y_pos_original + yshift * box_y
 
                 # Calculate the cell that this particle; use the 64 bit version of the
                 # resolution as this is the same type as the positions
@@ -221,8 +234,8 @@ def scatter_parallel(
     m: float32,
     h: float32,
     res: int,
-    box_x: float64,
-    box_y: float64,
+    box_x: float64 = 0.0,
+    box_y: float64 = 0.0,
 ) -> ndarray:
     """
     Parallel implementation of scatter

--- a/swiftsimio/visualisation/projection_backends/renormalised.py
+++ b/swiftsimio/visualisation/projection_backends/renormalised.py
@@ -43,7 +43,7 @@ def scatter(
 
     Computes contributions to from particles with positions
     (`x`,`y`) with smoothing lengths `h` weighted by quantities `m`.
-    This ignores boundary effects.
+    This includes periodic boundary effects.
 
     Parameters
     ----------
@@ -63,6 +63,14 @@ def scatter(
     res : int
         the number of pixels along one axis, i.e. this returns a square
         of res * res.
+
+    box_x: float64
+        box size in x, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
+
+    box_y: float64
+        box size in y, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
 
     Returns
     -------
@@ -98,6 +106,7 @@ def scatter(
     inverse_cell_area = float_res * float_res
 
     for x_pos_original, y_pos_original, mass, hsml in zip(x, y, m, h):
+        # loop over periodic copies of this particle
         for xshift in range(3):
             for yshift in range(3):
                 x_pos = x_pos_original + (xshift - 1) * box_x
@@ -221,7 +230,7 @@ def scatter_parallel(
     Creates a weighted scatter plot. Computes contributions from
     particles with positions (`x`,`y`) with smoothing lengths `h`
     weighted by quantities `m`.
-    This ignores boundary effects.
+    This includes periodic boundary effects.
 
     Parameters
     ----------
@@ -240,6 +249,14 @@ def scatter_parallel(
     res : int
         the number of pixels along one axis, i.e. this returns a square
         of res * res.
+
+    box_x: float64
+        box size in x, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
+
+    box_y: float64
+        box size in y, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
 
     Returns
     -------

--- a/swiftsimio/visualisation/projection_backends/subsampled.py
+++ b/swiftsimio/visualisation/projection_backends/subsampled.py
@@ -47,7 +47,7 @@ def scatter(
 
     Computes contributions to from particles with positions
     (`x`,`y`) with smoothing lengths `h` weighted by quantities `m`.
-    This ignores boundary effects.
+    This includes periodic boundary effects.
 
     Parameters
     ----------
@@ -67,6 +67,14 @@ def scatter(
     res : int
         the number of pixels along one axis, i.e. this returns a square
         of res * res.
+
+    box_x: float64
+        box size in x, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
+
+    box_y: float64
+        box size in y, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
 
     Returns
     -------
@@ -132,6 +140,7 @@ def scatter(
     dithered_kernel *= inverse_cell_area / dithered_kernel.sum()
 
     for x_pos_original, y_pos_original, mass, hsml in zip(x, y, m, h):
+        # loop over periodic copies of this particle
         for xshift in range(3):
             for yshift in range(3):
                 x_pos = x_pos_original + (xshift - 1) * box_x
@@ -315,7 +324,7 @@ def scatter_parallel(
     Creates a weighted scatter plot. Computes contributions from
     particles with positions (`x`,`y`) with smoothing lengths `h`
     weighted by quantities `m`.
-    This ignores boundary effects.
+    This includes periodic boundary effects.
 
     Parameters
     ----------
@@ -334,6 +343,14 @@ def scatter_parallel(
     res : int
         the number of pixels along one axis, i.e. this returns a square
         of res * res.
+
+    box_x: float64
+        box size in x, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
+
+    box_y: float64
+        box size in y, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
 
     Returns
     -------

--- a/swiftsimio/visualisation/projection_backends/subsampled.py
+++ b/swiftsimio/visualisation/projection_backends/subsampled.py
@@ -39,8 +39,8 @@ def scatter(
     m: float32,
     h: float32,
     res: int,
-    box_x: float64,
-    box_y: float64,
+    box_x: float64 = 0.0,
+    box_y: float64 = 0.0,
 ) -> ndarray:
     """
     Creates a weighted scatter plot
@@ -139,12 +139,25 @@ def scatter(
     # May as well have this correctly normed.
     dithered_kernel *= inverse_cell_area / dithered_kernel.sum()
 
+    if box_x == 0.0:
+        xshift_min = 0
+        xshift_max = 1
+    else:
+        xshift_min = -1
+        xshift_max = 2
+    if box_y == 0.0:
+        yshift_min = 0
+        yshift_max = 1
+    else:
+        yshift_min = -1
+        yshift_max = 2
+
     for x_pos_original, y_pos_original, mass, hsml in zip(x, y, m, h):
         # loop over periodic copies of this particle
-        for xshift in range(3):
-            for yshift in range(3):
-                x_pos = x_pos_original + (xshift - 1) * box_x
-                y_pos = y_pos_original + (yshift - 1) * box_y
+        for xshift in range(xshift_min, xshift_max):
+            for yshift in range(yshift_min, yshift_max):
+                x_pos = x_pos_original + xshift * box_x
+                y_pos = y_pos_original + yshift * box_y
 
                 # Calculate the cell that this particle; use the 64 bit version of the
                 # resolution as this is the same type as the positions
@@ -315,8 +328,8 @@ def scatter_parallel(
     m: float32,
     h: float32,
     res: int,
-    box_x: float64,
-    box_y: float64,
+    box_x: float64 = 0.0,
+    box_y: float64 = 0.0,
 ) -> ndarray:
     """
     Parallel implementation of scatter

--- a/swiftsimio/visualisation/projection_backends/subsampled.py
+++ b/swiftsimio/visualisation/projection_backends/subsampled.py
@@ -33,7 +33,15 @@ kernel_gamma = float64(kernel_gamma)
 
 
 @jit(nopython=True, fastmath=True)
-def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray:
+def scatter(
+    x: float64,
+    y: float64,
+    m: float32,
+    h: float32,
+    res: int,
+    box_x: float64,
+    box_y: float64,
+) -> ndarray:
     """
     Creates a weighted scatter plot
 
@@ -123,152 +131,183 @@ def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray
     # May as well have this correctly normed.
     dithered_kernel *= inverse_cell_area / dithered_kernel.sum()
 
-    for x_pos, y_pos, mass, hsml in zip(x, y, m, h):
-        # Calculate the cell that this particle; use the 64 bit version of the
-        # resolution as this is the same type as the positions
-        particle_cell_x = int32(float_res * x_pos)
-        particle_cell_y = int32(float_res * y_pos)
+    for x_pos_original, y_pos_original, mass, hsml in zip(x, y, m, h):
+        for xshift in range(3):
+            for yshift in range(3):
+                x_pos = x_pos_original + (xshift - 1) * box_x
+                y_pos = y_pos_original + (yshift - 1) * box_y
 
-        # SWIFT stores hsml as the FWHM.
-        float_mass = float64(mass)
-        kernel_width = float64(kernel_gamma * hsml)
+                # Calculate the cell that this particle; use the 64 bit version of the
+                # resolution as this is the same type as the positions
+                particle_cell_x = int32(float_res * x_pos)
+                particle_cell_y = int32(float_res * y_pos)
 
-        # The number of cells that this kernel spans
-        float_cells_spanned = 1.0 + kernel_width * float_res
-        cells_spanned = int32(float_cells_spanned)
+                # SWIFT stores hsml as the FWHM.
+                float_mass = float64(mass)
+                kernel_width = float64(kernel_gamma * hsml)
 
-        if (
-            particle_cell_x + cells_spanned < 0
-            or particle_cell_x - cells_spanned > maximal_array_index
-            or particle_cell_y + cells_spanned < 0
-            or particle_cell_y - cells_spanned > maximal_array_index
-        ):
-            # Can happily skip this particle
-            continue
+                # The number of cells that this kernel spans
+                float_cells_spanned = 1.0 + kernel_width * float_res
+                cells_spanned = int32(float_cells_spanned)
 
-        # If the particle is too small, then it's very likely that:
-        # a) it does not lie on a boundary
-        # b) evaluating it over this boundary would cause significant errors
-        if kernel_width <= 0.25 * pixel_width:
-            # Here we check for overlaps between this kernel and boundaries.
-            # If they exist, we must use the sub-sampled kernel.
-
-            dx_left = x_pos - float64(particle_cell_x)
-            dx_right = float64(particle_cell_x) + 1.0 - x_pos
-            dy_down = y_pos - float64(particle_cell_y)
-            dy_up = float64(particle_cell_y) + 1.0 - y_pos
-
-            overlaps_left = dx_left < kernel_width
-            overlaps_right = dx_right < kernel_width
-            overlaps_down = dy_down < kernel_width
-            overlaps_up = dy_up < kernel_width
-
-            if not (overlaps_left or overlaps_right or overlaps_down or overlaps_up):
-                # Very simple case - no overlaps.
-                image[particle_cell_x, particle_cell_y] += mass * inverse_cell_area
-            else:
-                # Use pre-calculated kernel with a basic dither to lay down
-                # overlap
-                for x_dither_cell in range(0, 2 * DITHER_EVALUATIONS):
-                    float_x_dither_cell = float64(x_dither_cell)
-                    pixel_x = int32(
-                        float_res
-                        * (
-                            x_pos
-                            + (float_x_dither_cell * float_DITHER_EVALUATIONS_inv - 1.0)
-                            * kernel_width
-                        )
-                    )
-                    for y_dither_cell in range(0, 2 * DITHER_EVALUATIONS):
-                        float_y_dither_cell = float64(y_dither_cell)
-                        pixel_y = int32(
-                            float_res
-                            * (
-                                y_pos
-                                + (
-                                    float_y_dither_cell * float_DITHER_EVALUATIONS_inv
-                                    - 1.0
-                                )
-                                * kernel_width
-                            )
-                        )
-
-                        if (
-                            pixel_x >= 0
-                            and pixel_x <= maximal_array_index
-                            and pixel_y >= 0
-                            and pixel_y <= maximal_array_index
-                        ):
-                            image[pixel_x, pixel_y] += (
-                                float_mass
-                                * dithered_kernel[x_dither_cell, y_dither_cell]
-                            )
-
-        else:
-            # The number of times each pixel is subsampled.
-            subsample_factor = max(
-                1, 2 * int32(ceil(float_MIN_KERNEL_EVALUATIONS / float_cells_spanned))
-            )
-            float_subsample_factor = float64(subsample_factor)
-            inv_float_subsample_factor = 1.0 / float_subsample_factor
-            inv_float_subsample_factor_square = (
-                inv_float_subsample_factor * inv_float_subsample_factor
-            )
-
-            # Now we loop over the square of cells that the kernel lives in
-            for cell_x in range(
-                # Ensure that the lowest x value is 0, otherwise we'll segfault
-                max(0, particle_cell_x - cells_spanned),
-                # Ensure that the highest x value lies within the array bounds,
-                # otherwise we'll segfault (oops).
-                min(particle_cell_x + cells_spanned + 1, maximal_array_index + 1),
-            ):
-                float_cell_x = float64(cell_x)
-                for cell_y in range(
-                    max(0, particle_cell_y - cells_spanned),
-                    min(particle_cell_y + cells_spanned + 1, maximal_array_index + 1),
+                if (
+                    particle_cell_x + cells_spanned < 0
+                    or particle_cell_x - cells_spanned > maximal_array_index
+                    or particle_cell_y + cells_spanned < 0
+                    or particle_cell_y - cells_spanned > maximal_array_index
                 ):
-                    float_cell_y = float64(cell_y)
-                    # Now we subsample the pixels to get a more accurate determination
-                    # of the kernel weight. We take the mean of the kernel evaluations
-                    # within a given pixel and apply this as the true 'kernel evaluation'.
-                    kernel_eval = float64(0.0)
+                    # Can happily skip this particle
+                    continue
 
-                    for subsample_x in range(0, subsample_factor):
-                        subsample_position_x = (
-                            float64(subsample_x) + 0.5
-                        ) * inv_float_subsample_factor
+                # If the particle is too small, then it's very likely that:
+                # a) it does not lie on a boundary
+                # b) evaluating it over this boundary would cause significant errors
+                if kernel_width <= 0.25 * pixel_width:
+                    # Here we check for overlaps between this kernel and boundaries.
+                    # If they exist, we must use the sub-sampled kernel.
 
-                        distance_x = (
-                            float_cell_x + subsample_position_x
-                        ) * pixel_width - x_pos
+                    dx_left = x_pos - float64(particle_cell_x)
+                    dx_right = float64(particle_cell_x) + 1.0 - x_pos
+                    dy_down = y_pos - float64(particle_cell_y)
+                    dy_up = float64(particle_cell_y) + 1.0 - y_pos
 
-                        distance_x_2 = distance_x * distance_x
+                    overlaps_left = dx_left < kernel_width
+                    overlaps_right = dx_right < kernel_width
+                    overlaps_down = dy_down < kernel_width
+                    overlaps_up = dy_up < kernel_width
 
-                        for subsample_y in range(0, subsample_factor):
-                            subsample_position_y = (
-                                float64(subsample_y) + 0.5
-                            ) * inv_float_subsample_factor
+                    if not (
+                        overlaps_left or overlaps_right or overlaps_down or overlaps_up
+                    ):
+                        # Very simple case - no overlaps.
+                        image[particle_cell_x, particle_cell_y] += (
+                            mass * inverse_cell_area
+                        )
+                    else:
+                        # Use pre-calculated kernel with a basic dither to lay down
+                        # overlap
+                        for x_dither_cell in range(0, 2 * DITHER_EVALUATIONS):
+                            float_x_dither_cell = float64(x_dither_cell)
+                            pixel_x = int32(
+                                float_res
+                                * (
+                                    x_pos
+                                    + (
+                                        float_x_dither_cell
+                                        * float_DITHER_EVALUATIONS_inv
+                                        - 1.0
+                                    )
+                                    * kernel_width
+                                )
+                            )
+                            for y_dither_cell in range(0, 2 * DITHER_EVALUATIONS):
+                                float_y_dither_cell = float64(y_dither_cell)
+                                pixel_y = int32(
+                                    float_res
+                                    * (
+                                        y_pos
+                                        + (
+                                            float_y_dither_cell
+                                            * float_DITHER_EVALUATIONS_inv
+                                            - 1.0
+                                        )
+                                        * kernel_width
+                                    )
+                                )
 
-                            distance_y = (
-                                float_cell_y + subsample_position_y
-                            ) * pixel_width - y_pos
+                                if (
+                                    pixel_x >= 0
+                                    and pixel_x <= maximal_array_index
+                                    and pixel_y >= 0
+                                    and pixel_y <= maximal_array_index
+                                ):
+                                    image[pixel_x, pixel_y] += (
+                                        float_mass
+                                        * dithered_kernel[x_dither_cell, y_dither_cell]
+                                    )
 
-                            distance_y_2 = distance_y * distance_y
-
-                            r = sqrt(distance_x_2 + distance_y_2)
-                            kernel_eval += kernel(r, kernel_width)
-
-                    image[cell_x, cell_y] += (
-                        float_mass * kernel_eval * inv_float_subsample_factor_square
+                else:
+                    # The number of times each pixel is subsampled.
+                    subsample_factor = max(
+                        1,
+                        2
+                        * int32(
+                            ceil(float_MIN_KERNEL_EVALUATIONS / float_cells_spanned)
+                        ),
                     )
+                    float_subsample_factor = float64(subsample_factor)
+                    inv_float_subsample_factor = 1.0 / float_subsample_factor
+                    inv_float_subsample_factor_square = (
+                        inv_float_subsample_factor * inv_float_subsample_factor
+                    )
+
+                    # Now we loop over the square of cells that the kernel lives in
+                    for cell_x in range(
+                        # Ensure that the lowest x value is 0, otherwise we'll segfault
+                        max(0, particle_cell_x - cells_spanned),
+                        # Ensure that the highest x value lies within the array bounds,
+                        # otherwise we'll segfault (oops).
+                        min(
+                            particle_cell_x + cells_spanned + 1, maximal_array_index + 1
+                        ),
+                    ):
+                        float_cell_x = float64(cell_x)
+                        for cell_y in range(
+                            max(0, particle_cell_y - cells_spanned),
+                            min(
+                                particle_cell_y + cells_spanned + 1,
+                                maximal_array_index + 1,
+                            ),
+                        ):
+                            float_cell_y = float64(cell_y)
+                            # Now we subsample the pixels to get a more accurate determination
+                            # of the kernel weight. We take the mean of the kernel evaluations
+                            # within a given pixel and apply this as the true 'kernel evaluation'.
+                            kernel_eval = float64(0.0)
+
+                            for subsample_x in range(0, subsample_factor):
+                                subsample_position_x = (
+                                    float64(subsample_x) + 0.5
+                                ) * inv_float_subsample_factor
+
+                                distance_x = (
+                                    float_cell_x + subsample_position_x
+                                ) * pixel_width - x_pos
+
+                                distance_x_2 = distance_x * distance_x
+
+                                for subsample_y in range(0, subsample_factor):
+                                    subsample_position_y = (
+                                        float64(subsample_y) + 0.5
+                                    ) * inv_float_subsample_factor
+
+                                    distance_y = (
+                                        float_cell_y + subsample_position_y
+                                    ) * pixel_width - y_pos
+
+                                    distance_y_2 = distance_y * distance_y
+
+                                    r = sqrt(distance_x_2 + distance_y_2)
+                                    kernel_eval += kernel(r, kernel_width)
+
+                            image[cell_x, cell_y] += (
+                                float_mass
+                                * kernel_eval
+                                * inv_float_subsample_factor_square
+                            )
 
     return image
 
 
 @jit(nopython=True, fastmath=True, parallel=True)
 def scatter_parallel(
-    x: float64, y: float64, m: float32, h: float32, res: int
+    x: float64,
+    y: float64,
+    m: float32,
+    h: float32,
+    res: int,
+    box_x: float64,
+    box_y: float64,
 ) -> ndarray:
     """
     Parallel implementation of scatter
@@ -340,6 +379,8 @@ def scatter_parallel(
             m=m[left_edge:right_edge],
             h=h[left_edge:right_edge],
             res=res,
+            box_x=box_x,
+            box_y=box_y,
         )
 
     return output

--- a/swiftsimio/visualisation/projection_backends/subsampled_extreme.py
+++ b/swiftsimio/visualisation/projection_backends/subsampled_extreme.py
@@ -39,8 +39,8 @@ def scatter(
     m: float32,
     h: float32,
     res: int,
-    box_x: float64,
-    box_y: float64,
+    box_x: float64 = 0.0,
+    box_y: float64 = 0.0,
 ) -> ndarray:
     """
     Creates a weighted scatter plot
@@ -141,12 +141,25 @@ def scatter(
     # May as well have this correctly normed.
     dithered_kernel *= inverse_cell_area / dithered_kernel.sum()
 
+    if box_x == 0.0:
+        xshift_min = 0
+        xshift_max = 1
+    else:
+        xshift_min = -1
+        xshift_max = 2
+    if box_y == 0.0:
+        yshift_min = 0
+        yshift_max = 1
+    else:
+        yshift_min = -1
+        yshift_max = 2
+
     for x_pos_original, y_pos_original, mass, hsml in zip(x, y, m, h):
         # loop over periodic copies of this particle
-        for xshift in range(3):
-            for yshift in range(3):
-                x_pos = x_pos_original + (xshift - 1) * box_x
-                y_pos = y_pos_original + (yshift - 1) * box_y
+        for xshift in range(xshift_min, xshift_max):
+            for yshift in range(yshift_min, yshift_max):
+                x_pos = x_pos_original + xshift * box_x
+                y_pos = y_pos_original + yshift * box_y
 
                 # Calculate the cell that this particle; use the 64 bit version of the
                 # resolution as this is the same type as the positions
@@ -317,8 +330,8 @@ def scatter_parallel(
     m: float32,
     h: float32,
     res: int,
-    box_x: float64,
-    box_y: float64,
+    box_x: float64 = 0.0,
+    box_y: float64 = 0.0,
 ) -> ndarray:
     """
     Parallel implementation of scatter

--- a/swiftsimio/visualisation/projection_backends/subsampled_extreme.py
+++ b/swiftsimio/visualisation/projection_backends/subsampled_extreme.py
@@ -33,7 +33,15 @@ kernel_gamma = float64(kernel_gamma)
 
 
 @jit(nopython=True, fastmath=True)
-def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray:
+def scatter(
+    x: float64,
+    y: float64,
+    m: float32,
+    h: float32,
+    res: int,
+    box_x: float64,
+    box_y: float64,
+) -> ndarray:
     """
     Creates a weighted scatter plot
 
@@ -125,152 +133,183 @@ def scatter(x: float64, y: float64, m: float32, h: float32, res: int) -> ndarray
     # May as well have this correctly normed.
     dithered_kernel *= inverse_cell_area / dithered_kernel.sum()
 
-    for x_pos, y_pos, mass, hsml in zip(x, y, m, h):
-        # Calculate the cell that this particle; use the 64 bit version of the
-        # resolution as this is the same type as the positions
-        particle_cell_x = int32(float_res * x_pos)
-        particle_cell_y = int32(float_res * y_pos)
+    for x_pos_original, y_pos_original, mass, hsml in zip(x, y, m, h):
+        for xshift in range(3):
+            for yshift in range(3):
+                x_pos = x_pos_original + (xshift - 1) * box_x
+                y_pos = y_pos_original + (yshift - 1) * box_y
 
-        # SWIFT stores hsml as the FWHM.
-        float_mass = float64(mass)
-        kernel_width = float64(kernel_gamma * hsml)
+                # Calculate the cell that this particle; use the 64 bit version of the
+                # resolution as this is the same type as the positions
+                particle_cell_x = int32(float_res * x_pos)
+                particle_cell_y = int32(float_res * y_pos)
 
-        # The number of cells that this kernel spans
-        float_cells_spanned = 1.0 + kernel_width * float_res
-        cells_spanned = int32(float_cells_spanned)
+                # SWIFT stores hsml as the FWHM.
+                float_mass = float64(mass)
+                kernel_width = float64(kernel_gamma * hsml)
 
-        if (
-            particle_cell_x + cells_spanned < 0
-            or particle_cell_x - cells_spanned > maximal_array_index
-            or particle_cell_y + cells_spanned < 0
-            or particle_cell_y - cells_spanned > maximal_array_index
-        ):
-            # Can happily skip this particle
-            continue
+                # The number of cells that this kernel spans
+                float_cells_spanned = 1.0 + kernel_width * float_res
+                cells_spanned = int32(float_cells_spanned)
 
-        # If the particle is too small, then it's very likely that:
-        # a) it does not lie on a boundary
-        # b) evaluating it over this boundary would cause significant errors
-        if kernel_width <= 0.25 * pixel_width:
-            # Here we check for overlaps between this kernel and boundaries.
-            # If they exist, we must use the sub-sampled kernel.
-
-            dx_left = x_pos - float64(particle_cell_x)
-            dx_right = float64(particle_cell_x) + 1.0 - x_pos
-            dy_down = y_pos - float64(particle_cell_y)
-            dy_up = float64(particle_cell_y) + 1.0 - y_pos
-
-            overlaps_left = dx_left < kernel_width
-            overlaps_right = dx_right < kernel_width
-            overlaps_down = dy_down < kernel_width
-            overlaps_up = dy_up < kernel_width
-
-            if not (overlaps_left or overlaps_right or overlaps_down or overlaps_up):
-                # Very simple case - no overlaps.
-                image[particle_cell_x, particle_cell_y] += mass * inverse_cell_area
-            else:
-                # Use pre-calculated kernel with a basic dither to lay down
-                # overlap
-                for x_dither_cell in range(0, 2 * DITHER_EVALUATIONS):
-                    float_x_dither_cell = float64(x_dither_cell)
-                    pixel_x = int32(
-                        float_res
-                        * (
-                            x_pos
-                            + (float_x_dither_cell * float_DITHER_EVALUATIONS_inv - 1.0)
-                            * kernel_width
-                        )
-                    )
-                    for y_dither_cell in range(0, 2 * DITHER_EVALUATIONS):
-                        float_y_dither_cell = float64(y_dither_cell)
-                        pixel_y = int32(
-                            float_res
-                            * (
-                                y_pos
-                                + (
-                                    float_y_dither_cell * float_DITHER_EVALUATIONS_inv
-                                    - 1.0
-                                )
-                                * kernel_width
-                            )
-                        )
-
-                        if (
-                            pixel_x >= 0
-                            and pixel_x <= maximal_array_index
-                            and pixel_y >= 0
-                            and pixel_y <= maximal_array_index
-                        ):
-                            image[pixel_x, pixel_y] += (
-                                float_mass
-                                * dithered_kernel[x_dither_cell, y_dither_cell]
-                            )
-
-        else:
-            # The number of times each pixel is subsampled.
-            subsample_factor = max(
-                1, 2 * int32(ceil(float_MIN_KERNEL_EVALUATIONS / float_cells_spanned))
-            )
-            float_subsample_factor = float64(subsample_factor)
-            inv_float_subsample_factor = 1.0 / float_subsample_factor
-            inv_float_subsample_factor_square = (
-                inv_float_subsample_factor * inv_float_subsample_factor
-            )
-
-            # Now we loop over the square of cells that the kernel lives in
-            for cell_x in range(
-                # Ensure that the lowest x value is 0, otherwise we'll segfault
-                max(0, particle_cell_x - cells_spanned),
-                # Ensure that the highest x value lies within the array bounds,
-                # otherwise we'll segfault (oops).
-                min(particle_cell_x + cells_spanned + 1, maximal_array_index + 1),
-            ):
-                float_cell_x = float64(cell_x)
-                for cell_y in range(
-                    max(0, particle_cell_y - cells_spanned),
-                    min(particle_cell_y + cells_spanned + 1, maximal_array_index + 1),
+                if (
+                    particle_cell_x + cells_spanned < 0
+                    or particle_cell_x - cells_spanned > maximal_array_index
+                    or particle_cell_y + cells_spanned < 0
+                    or particle_cell_y - cells_spanned > maximal_array_index
                 ):
-                    float_cell_y = float64(cell_y)
-                    # Now we subsample the pixels to get a more accurate determination
-                    # of the kernel weight. We take the mean of the kernel evaluations
-                    # within a given pixel and apply this as the true 'kernel evaluation'.
-                    kernel_eval = float64(0.0)
+                    # Can happily skip this particle
+                    continue
 
-                    for subsample_x in range(0, subsample_factor):
-                        subsample_position_x = (
-                            float64(subsample_x) + 0.5
-                        ) * inv_float_subsample_factor
+                # If the particle is too small, then it's very likely that:
+                # a) it does not lie on a boundary
+                # b) evaluating it over this boundary would cause significant errors
+                if kernel_width <= 0.25 * pixel_width:
+                    # Here we check for overlaps between this kernel and boundaries.
+                    # If they exist, we must use the sub-sampled kernel.
 
-                        distance_x = (
-                            float_cell_x + subsample_position_x
-                        ) * pixel_width - x_pos
+                    dx_left = x_pos - float64(particle_cell_x)
+                    dx_right = float64(particle_cell_x) + 1.0 - x_pos
+                    dy_down = y_pos - float64(particle_cell_y)
+                    dy_up = float64(particle_cell_y) + 1.0 - y_pos
 
-                        distance_x_2 = distance_x * distance_x
+                    overlaps_left = dx_left < kernel_width
+                    overlaps_right = dx_right < kernel_width
+                    overlaps_down = dy_down < kernel_width
+                    overlaps_up = dy_up < kernel_width
 
-                        for subsample_y in range(0, subsample_factor):
-                            subsample_position_y = (
-                                float64(subsample_y) + 0.5
-                            ) * inv_float_subsample_factor
+                    if not (
+                        overlaps_left or overlaps_right or overlaps_down or overlaps_up
+                    ):
+                        # Very simple case - no overlaps.
+                        image[particle_cell_x, particle_cell_y] += (
+                            mass * inverse_cell_area
+                        )
+                    else:
+                        # Use pre-calculated kernel with a basic dither to lay down
+                        # overlap
+                        for x_dither_cell in range(0, 2 * DITHER_EVALUATIONS):
+                            float_x_dither_cell = float64(x_dither_cell)
+                            pixel_x = int32(
+                                float_res
+                                * (
+                                    x_pos
+                                    + (
+                                        float_x_dither_cell
+                                        * float_DITHER_EVALUATIONS_inv
+                                        - 1.0
+                                    )
+                                    * kernel_width
+                                )
+                            )
+                            for y_dither_cell in range(0, 2 * DITHER_EVALUATIONS):
+                                float_y_dither_cell = float64(y_dither_cell)
+                                pixel_y = int32(
+                                    float_res
+                                    * (
+                                        y_pos
+                                        + (
+                                            float_y_dither_cell
+                                            * float_DITHER_EVALUATIONS_inv
+                                            - 1.0
+                                        )
+                                        * kernel_width
+                                    )
+                                )
 
-                            distance_y = (
-                                float_cell_y + subsample_position_y
-                            ) * pixel_width - y_pos
+                                if (
+                                    pixel_x >= 0
+                                    and pixel_x <= maximal_array_index
+                                    and pixel_y >= 0
+                                    and pixel_y <= maximal_array_index
+                                ):
+                                    image[pixel_x, pixel_y] += (
+                                        float_mass
+                                        * dithered_kernel[x_dither_cell, y_dither_cell]
+                                    )
 
-                            distance_y_2 = distance_y * distance_y
-
-                            r = sqrt(distance_x_2 + distance_y_2)
-                            kernel_eval += kernel(r, kernel_width)
-
-                    image[cell_x, cell_y] += (
-                        float_mass * kernel_eval * inv_float_subsample_factor_square
+                else:
+                    # The number of times each pixel is subsampled.
+                    subsample_factor = max(
+                        1,
+                        2
+                        * int32(
+                            ceil(float_MIN_KERNEL_EVALUATIONS / float_cells_spanned)
+                        ),
                     )
+                    float_subsample_factor = float64(subsample_factor)
+                    inv_float_subsample_factor = 1.0 / float_subsample_factor
+                    inv_float_subsample_factor_square = (
+                        inv_float_subsample_factor * inv_float_subsample_factor
+                    )
+
+                    # Now we loop over the square of cells that the kernel lives in
+                    for cell_x in range(
+                        # Ensure that the lowest x value is 0, otherwise we'll segfault
+                        max(0, particle_cell_x - cells_spanned),
+                        # Ensure that the highest x value lies within the array bounds,
+                        # otherwise we'll segfault (oops).
+                        min(
+                            particle_cell_x + cells_spanned + 1, maximal_array_index + 1
+                        ),
+                    ):
+                        float_cell_x = float64(cell_x)
+                        for cell_y in range(
+                            max(0, particle_cell_y - cells_spanned),
+                            min(
+                                particle_cell_y + cells_spanned + 1,
+                                maximal_array_index + 1,
+                            ),
+                        ):
+                            float_cell_y = float64(cell_y)
+                            # Now we subsample the pixels to get a more accurate determination
+                            # of the kernel weight. We take the mean of the kernel evaluations
+                            # within a given pixel and apply this as the true 'kernel evaluation'.
+                            kernel_eval = float64(0.0)
+
+                            for subsample_x in range(0, subsample_factor):
+                                subsample_position_x = (
+                                    float64(subsample_x) + 0.5
+                                ) * inv_float_subsample_factor
+
+                                distance_x = (
+                                    float_cell_x + subsample_position_x
+                                ) * pixel_width - x_pos
+
+                                distance_x_2 = distance_x * distance_x
+
+                                for subsample_y in range(0, subsample_factor):
+                                    subsample_position_y = (
+                                        float64(subsample_y) + 0.5
+                                    ) * inv_float_subsample_factor
+
+                                    distance_y = (
+                                        float_cell_y + subsample_position_y
+                                    ) * pixel_width - y_pos
+
+                                    distance_y_2 = distance_y * distance_y
+
+                                    r = sqrt(distance_x_2 + distance_y_2)
+                                    kernel_eval += kernel(r, kernel_width)
+
+                            image[cell_x, cell_y] += (
+                                float_mass
+                                * kernel_eval
+                                * inv_float_subsample_factor_square
+                            )
 
     return image
 
 
 @jit(nopython=True, fastmath=True, parallel=True)
 def scatter_parallel(
-    x: float64, y: float64, m: float32, h: float32, res: int
+    x: float64,
+    y: float64,
+    m: float32,
+    h: float32,
+    res: int,
+    box_x: float64,
+    box_y: float64,
 ) -> ndarray:
     """
     Parallel implementation of scatter
@@ -344,6 +383,8 @@ def scatter_parallel(
             m=m[left_edge:right_edge],
             h=h[left_edge:right_edge],
             res=res,
+            box_x=box_x,
+            box_y=box_y,
         )
 
     return output

--- a/swiftsimio/visualisation/projection_backends/subsampled_extreme.py
+++ b/swiftsimio/visualisation/projection_backends/subsampled_extreme.py
@@ -47,7 +47,7 @@ def scatter(
 
     Computes contributions to from particles with positions
     (`x`,`y`) with smoothing lengths `h` weighted by quantities `m`.
-    This ignores boundary effects.
+    This includes periodic boundary effects.
 
     Parameters
     ----------
@@ -67,6 +67,14 @@ def scatter(
     res : int
         the number of pixels along one axis, i.e. this returns a square
         of res * res.
+
+    box_x: float64
+        box size in x, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
+
+    box_y: float64
+        box size in y, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
 
     Returns
     -------
@@ -134,6 +142,7 @@ def scatter(
     dithered_kernel *= inverse_cell_area / dithered_kernel.sum()
 
     for x_pos_original, y_pos_original, mass, hsml in zip(x, y, m, h):
+        # loop over periodic copies of this particle
         for xshift in range(3):
             for yshift in range(3):
                 x_pos = x_pos_original + (xshift - 1) * box_x
@@ -317,7 +326,7 @@ def scatter_parallel(
     Creates a weighted scatter plot. Computes contributions from
     particles with positions (`x`,`y`) with smoothing lengths `h`
     weighted by quantities `m`.
-    This ignores boundary effects.
+    This includes periodic boundary effects.
 
     Parameters
     ----------
@@ -336,6 +345,14 @@ def scatter_parallel(
     res : int
         the number of pixels along one axis, i.e. this returns a square
         of res * res.
+
+    box_x: float64
+        box size in x, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
+
+    box_y: float64
+        box size in y, in the same rescaled length units as x and y. Used
+        for periodic wrapping.
 
     Returns
     -------

--- a/swiftsimio/visualisation/slice.py
+++ b/swiftsimio/visualisation/slice.py
@@ -146,6 +146,7 @@ def slice_scatter(
     for x_pos_original, y_pos_original, z_pos_original, mass, hsml in zip(
         x, y, z, m, h
     ):
+        # loop over periodic copies of the particle
         for xshift in range(3):
             for yshift in range(3):
                 for zshift in range(3):
@@ -229,7 +230,7 @@ def slice_scatter_parallel(
     """
     Parallel implementation of slice_scatter
 
-    Creates a scatter plot of the given quantities for a particles in a data slice ignoring boundary effects.
+    Creates a scatter plot of the given quantities for a particles in a data slice including periodic boundary effects.
 
     Parameters
     ----------

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -188,6 +188,9 @@ def test_volume_render():
         np.array([1.0, 1.0, 1.0, 1.0]),
         np.array([0.2, 0.2, 0.2, 0.000002]),
         64,
+        1.0,
+        1.0,
+        1.0,
     )
 
     return
@@ -207,10 +210,26 @@ def test_volume_parallel():
     masses = np.ones(number_of_parts, dtype=np.float32)
 
     image = volume_render.scatter(
-        coordinates[0], coordinates[1], coordinates[2], masses, hsml, resolution
+        coordinates[0],
+        coordinates[1],
+        coordinates[2],
+        masses,
+        hsml,
+        resolution,
+        1.0,
+        1.0,
+        1.0,
     )
     image_par = volume_render.scatter_parallel(
-        coordinates[0], coordinates[1], coordinates[2], masses, hsml, resolution
+        coordinates[0],
+        coordinates[1],
+        coordinates[2],
+        masses,
+        hsml,
+        resolution,
+        1.0,
+        1.0,
+        1.0,
     )
 
     assert np.isclose(image, image_par).all()
@@ -288,7 +307,7 @@ def test_render_outside_region():
 
     slice_scatter_parallel(x, y, z, m, h, 0.2, resolution, 1.0, 1.0, 1.0)
 
-    volume_render.scatter_parallel(x, y, z, m, h, resolution)
+    volume_render.scatter_parallel(x, y, z, m, h, resolution, 1.0, 1.0, 1.0)
 
 
 @requires("cosmological_volume.hdf5")

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -116,6 +116,9 @@ def test_slice(save=False):
         np.array([0.2, 0.2, 0.2, 0.000002]),
         0.99,
         256,
+        1.0,
+        1.0,
+        1.0,
     )
 
     if save:
@@ -151,6 +154,9 @@ def test_slice_parallel(save=False):
         hsml,
         z_slice,
         resolution,
+        1.0,
+        1.0,
+        1.0,
     )
     image_par = slice_scatter_parallel(
         coordinates[0],
@@ -160,6 +166,9 @@ def test_slice_parallel(save=False):
         hsml,
         z_slice,
         resolution,
+        1.0,
+        1.0,
+        1.0,
     )
 
     if save:
@@ -277,7 +286,7 @@ def test_render_outside_region():
             else:
                 continue
 
-    slice_scatter_parallel(x, y, z, m, h, 0.2, resolution)
+    slice_scatter_parallel(x, y, z, m, h, 0.2, resolution, 1.0, 1.0, 1.0)
 
     volume_render.scatter_parallel(x, y, z, m, h, resolution)
 

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -40,6 +40,8 @@ def test_scatter(save=False):
                 np.array([1.0, 1.0, 1.0, 1.0]),
                 np.array([0.2, 0.2, 0.2, 0.000002]),
                 256,
+                1.0,
+                1.0,
             )
         except CudaSupportError:
             if CUDA_AVAILABLE:
@@ -65,7 +67,7 @@ def test_scatter_mass_conservation():
     total_mass = np.sum(m)
 
     for resolution in resolutions:
-        image = scatter(x, y, m, h, resolution)
+        image = scatter(x, y, m, h, resolution, 1.0, 1.0)
         mass_in_image = image.sum() / (resolution ** 2)
 
         # Check mass conservation to 5%
@@ -92,9 +94,9 @@ def test_scatter_parallel(save=False):
     hsml = np.random.rand(number_of_parts).astype(np.float32) * h_max
     masses = np.ones(number_of_parts, dtype=np.float32)
 
-    image = scatter(coordinates[0], coordinates[1], masses, hsml, resolution)
+    image = scatter(coordinates[0], coordinates[1], masses, hsml, resolution, 1.0, 1.0)
     image_par = scatter_parallel(
-        coordinates[0], coordinates[1], masses, hsml, resolution
+        coordinates[0], coordinates[1], masses, hsml, resolution, 1.0, 1.0
     )
 
     if save:
@@ -264,11 +266,11 @@ def test_render_outside_region():
     h = 10 ** np.random.rand(number_of_parts) - 1.0
     h[h > 0.5] = 0.05
     m = np.ones_like(h)
-    backends["histogram"](x, y, m, h, resolution)
+    backends["histogram"](x, y, m, h, resolution, 1.0, 1.0)
 
     for backend in backends_parallel.keys():
         try:
-            backends[backend](x, y, m, h, resolution)
+            backends[backend](x, y, m, h, resolution, 1.0, 1.0)
         except CudaSupportError:
             if CUDA_AVAILABLE:
                 raise ImportError("Optional loading of the CUDA module is broken")


### PR DESCRIPTION
New version of #148 that implements the periodic wrapping on the backend level. The memory footprint is not affected by this version, but there should still be a (small) performance penalty.

Here are some timings for my small test based on `cosmological_volume.hdf5`:

Old version:
```
Projection:
Backend "histogram" took 743.87 +- 12.995156135586896 ms
Backend "fast" took 620.74 +- 32.442475264777684 ms
Backend "renormalised" took 1128.18 +- 201.63854249894925 ms
Backend "subsampled" took 2442.19 +- 135.6247984160516 ms
Backend "subsampled_extreme" took 2361.57 +- 158.01341649057622 ms
Backend "reference" took 1250.00 +- 166.40818857369823 ms
Backend "gpu" took 41.47 +- 10.81907894761692 ms
Slicing:
Took 419.78 +- 8.391963275394627 ms
Volume rendering:
Took 4440.49 +- 59.48874302494967 ms
```

New version:
```
Projection:
Backend "histogram" took 733.99 +- 33.32694376915969 ms
Backend "fast" took 584.81 +- 20.463084650768796 ms
Backend "renormalised" took 785.32 +- 20.98768985286519 ms
Backend "subsampled" took 1270.11 +- 28.538669311331958 ms
Backend "subsampled_extreme" took 1263.11 +- 44.949929481954534 ms
Backend "reference" took 756.16 +- 27.871183567513178 ms
Backend "gpu" took 53.32 +- 13.414277270534988 ms
Slicing:
Took 411.87 +- 8.084733606619707 ms
Volume rendering:
Took 4338.15 +- 241.85104295403843 ms
```

For some reason all of them (except for the gpu backend) were actually faster in the new version. Not sure I understand why.

I am still running a larger and more representative test.