### PR TITLE
Fix broken distribution on pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = ["swiftsimio"]
+packages = ["swiftsimio", "swiftsimio.initial_conditions", "swiftsimio.metadata", "swiftsimio.metadata.cosmology", "swiftsimio.metadata.metadata", "swiftsimio.metadata.particle", "swiftsimio.metadata.unit", "swiftsimio.metadata.writer", "swiftsimio.visualisation", "swiftsimio.visualisation.projection_backends", "swiftsimio.visualisation.tools"]
 
 [project]
 name = "swiftsimio"


### PR DESCRIPTION
It turns out that all submodules need to be listed in pyproject.toml, otherwise installing from pypi results in broken imports and missing submodules. I tried to get automatic discovery working but it seems glitchy, I can't seem to avoid including tests, docs, etc. even though the setuputils docs say these should automatically be ignored. Rather than start manually ignoring things, I went with manually specifying what to include.