### PR TITLE
Intersect spatial masks

### DIFF
--- a/docs/source/masking/index.rst
+++ b/docs/source/masking/index.rst
@@ -68,6 +68,23 @@ relatively small overhead when reading the data. This allows you to use snapshot
 that are much larger than the available memory on your machine and process them
 with ease.
 
+It is also possible to build up a region with a more complicated geometry by
+making repeated calls to :meth:`~swiftsimio.reader.SWIFTMask.constrain_spatial`
+and setting the optional argument `intersect=True`. By default any existing
+selection of cells would be overwritten; this option adds any additional cells
+that need to be selected for the new region to the existing selection instead.
+For instance, to add the diagonally opposed octant to the selection made above
+(and so obtain a region shaped like two cubes with a single corner touching):
+
+.. code-block:: python
+   additional_region = [[0.5 * b, 1.0 * b] for b in boxsize]
+   mask.constrain_spatial(additional_region, intersect=True)
+
+In the first call to :meth:`~swiftsimio.reader.SWIFTMask.constrain_spatial` the
+`intersect` argument can be set to `True` or left `False` (the default): since
+no mask yet exists both give the same result.
+
+
 Full mask
 ---------
 

--- a/docs/source/masking/index.rst
+++ b/docs/source/masking/index.rst
@@ -77,6 +77,7 @@ For instance, to add the diagonally opposed octant to the selection made above
 (and so obtain a region shaped like two cubes with a single corner touching):
 
 .. code-block:: python
+
    additional_region = [[0.5 * b, 1.0 * b] for b in boxsize]
    mask.constrain_spatial(additional_region, intersect=True)
 

--- a/swiftsimio/masks.py
+++ b/swiftsimio/masks.py
@@ -8,7 +8,7 @@ import h5py
 
 import numpy as np
 
-from swiftsimio import metadata, SWIFTMetadata, SWIFTUnits
+from swiftsimio import SWIFTMetadata
 
 from swiftsimio.accelerated import ranges_from_array
 from typing import Dict


### PR DESCRIPTION
A student here was asking whether it was possible to select multiple spatial regions - basically wanting to make repeated calls to `constrain_spatial` to build up a more complicated region. On inspection this wasn't supported but seems to be very easy to implement. I just added an optional `intersect` argument to `constrain_spatial` and set the default to `False` (the previous behaviour). If it's `True` then the new region is intersected with any existing spatial mask. I checked carefully that there are no other member variables of `SWIFTMask` that need special treatment if a user does this - as far as I can tell it's a nearly trivial change that works seamlessly with the existing code. I added test coverage and a mention in the narrative docs.