### PR TITLE
Update python-publish.yml

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install setuptools wheel twine build
         pip install -r requirements.txt
         pip install .
     - name: Build and publish


### PR DESCRIPTION
Publish action is failing due to missing dependency `build`. Added it. 