### PR TITLE
Added initial power spec version

### DIFF
--- a/docs/source/visualisation/index.rst
+++ b/docs/source/visualisation/index.rst
@@ -30,5 +30,6 @@ additional functionality.
    projection
    slice
    volume_render
+   power_spectra
    tools
 

--- a/docs/source/visualisation/power_spectra.rst
+++ b/docs/source/visualisation/power_spectra.rst
@@ -32,10 +32,10 @@ dataset. For example:
         parallel=True,
     )
 
-The specific field being depositied can be controlled with the `project`
-keyword argument. The `resolution` argument gives the one-dimensional
-resolution of the 3D grid, so in this case you would recieve a `512x512x512`
-grid. Note that the `gas_mass_deposit` is a :cls:`swiftsimio.cosmo_array`,
+The specific field being depositied can be controlled with the ``project``
+keyword argument. The ``resolution``` argument gives the one-dimensional
+resolution of the 3D grid, so in this case you would recieve a ``512x512x512``
+grid. Note that the ``gas_mass_deposit`` is a :obj:`swiftsimio.cosmo_array`,
 and as such includes cosmological and unit information that is used later
 in the process.
 
@@ -59,7 +59,7 @@ function. For example, using the above deposit:
 
 This power spectrum can then be plotted. Units are included on both the wavenumbers
 and the power spectrum. Cross-spectra are also supported through the
-`cross_deposition` keyword, but by default this generates the auto power.
+``cross_deposition`` keyword, but by default this generates the auto power.
 
 
 More Complex Scenarios
@@ -76,15 +76,15 @@ As in a power spectrum we are only interested in the periodicity of the
 system, we can fold it back in on itself during the rendering process.
 The position of the particle in the box is set to be:
 
-:math:`x_i' := \left(x_i % \frac{L}{2^{n}}\right)\frac{2^{n}}{L}`
+:math:`x_i' := \left( x_i \% \frac{L}{2^{n}} \right) \frac{2^{n}}{L}`
 
 where :math:`L` is the box-size and :math:`n` is some integer greater
 than or equal to zero. This allows you to probe modes in the reduced
 box-length :math:`L / 2^{n}` with the same fixed resolution deposition
 buffer.
 
-The `folding` parameter is available for both `render_to_deposit`
-and `deposition_to_power_spectrum`, but it may be easier to use the
+The ``folding`` parameter is available for both ``render_to_deposit``
+and ``deposition_to_power_spectrum``, but it may be easier to use the
 utility functions provided for automatically stitching together
 the folded spectra. The function
 :meth:`swiftsimio.visualsation.power_spectrum.folded_depositions_to_power_spectrum`
@@ -119,6 +119,6 @@ number of grid points included in the bin. For two overlapping foldings,
 
 :math:`P(k) = \frac{N(k)_i^{1/3} P(k)_i + N(k)_j^{1/3} P(k)_j}{N(k)_i^{1/3} + N(k)_j^{1/3}}`
 
-which can be visualised using the `folding_tracker` return value of the
+which can be visualised using the ``folding_tracker`` return value of the
 function.
 

--- a/docs/source/visualisation/power_spectra.rst
+++ b/docs/source/visualisation/power_spectra.rst
@@ -1,0 +1,124 @@
+Power Spectra
+=============
+
+Though SWIFT includes functionality for calculating power spectra, this tool
+runs on-the-fly, and as such after a run has completed you may wish to create
+a number of more non-standard power spectra.
+
+These tools are available as part of the :mod:`swiftsimio.visualisation.power_spectrum`
+package. Making a power spectrum consists of two major steps: depositing the particles
+on grid(s), and then binning their fourier transform to get the one-dimensional power.
+
+
+Depositing on a Grid
+--------------------
+
+Depositing your particles on a grid is performed using
+:meth:`swiftsimio.visualisation.power_spectrum.render_to_deposit`. This function
+performs a nearest-grid-point (NGP) of all particles in the provided particle
+dataset. For example:
+
+.. code-block:: python
+
+    from swiftsimio import load
+    from swiftsimio.visualisation.power_spectrum import render_to_deposit
+
+    data = load("cosmo_volume_example.hdf5")
+
+    gas_mass_deposit = render_to_deposit(
+        data.gas,
+        resolution=512,
+        project="masses",
+        parallel=True,
+    )
+
+The specific field being depositied can be controlled with the `project`
+keyword argument. The `resolution` argument gives the one-dimensional
+resolution of the 3D grid, so in this case you would recieve a `512x512x512`
+grid. Note that the `gas_mass_deposit` is a :cls:`swiftsimio.cosmo_array`,
+and as such includes cosmological and unit information that is used later
+in the process.
+
+
+Generating a Power Spectrum
+---------------------------
+
+Once you have your grid deposited, you can easily generate a power spectrum
+using the
+:meth:`swiftsimio.visualisation.power_spectrum.deposition_to_power_spectrum`
+function. For example, using the above deposit:
+
+.. code-block:: python
+
+    from swiftsimio.visualisation.power_spectrum import deposition_to_power_spectrum
+
+    wavenumbers, power_spectrum, _ = deposition_to_power_spectrum(
+        deposition=gas_mass_deposit,
+        box_size=data.metadata.box_size,
+    )
+
+This power spectrum can then be plotted. Units are included on both the wavenumbers
+and the power spectrum. Cross-spectra are also supported through the
+`cross_deposition` keyword, but by default this generates the auto power.
+
+
+More Complex Scenarios
+----------------------
+
+In a realistic simualted power spectrum, you will need to perform 'folding'
+to achieve a viable dynamic range within an achievable memory footprint.
+Consider, for instance, a 1 Gpc simulation volume with a 1 kpc resolution
+limit. In that case, you would need a deposition grid with :math:`10^{18}`
+cells, amounting to a 4 EB (yes, exabyte!) memory footprint. That is,
+of course, not realistic!
+
+As in a power spectrum we are only interested in the periodicity of the
+system, we can fold it back in on itself during the rendering process.
+The position of the particle in the box is set to be:
+
+:math:`x_i' := \left(x_i % \frac{L}{2^{n}}\right)\frac{2^{n}}{L}`
+
+where :math:`L` is the box-size and :math:`n` is some integer greater
+than or equal to zero. This allows you to probe modes in the reduced
+box-length :math:`L / 2^{n}` with the same fixed resolution deposition
+buffer.
+
+The `folding` parameter is available for both `render_to_deposit`
+and `deposition_to_power_spectrum`, but it may be easier to use the
+utility functions provided for automatically stitching together
+the folded spectra. The function
+:meth:`swiftsimio.visualsation.power_spectrum.folded_depositions_to_power_spectrum`
+allows you to do this easily:
+
+.. code-block:: python
+
+    from swiftsimio.visualisation.power_spectrum import folded_depositions_to_power_spectrum
+    import unyt
+
+    folded_depositions = {}
+
+    for fold in [x * 2 for x in range(5)]:
+        folded_depositions[fold] = render_to_deposit(
+            data.gas,
+            resolution=512,
+            project="masses",
+            parallel=True,
+            folding=2.0 ** fold,
+        )
+
+    bins, centers, power_spectrum, foldings = folded_depositions_to_power_spectrum(
+        depositions=folded_depositions,
+        box_size=data.metadata.box_size,
+        number_of_wavenumber_bins=128,
+        wavenumber_range=[1e-2 / unyt.Mpc, 1e2 / unyt.Mpc],
+        log_wavenumber_bins=True,
+    )
+
+Depositions are automatically faded between using the cube-root of the
+number of grid points included in the bin. For two overlapping foldings,
+
+:math:`P(k) = \frac{N(k)_i^{1/3} P(k)_i + N(k)_j^{1/3} P(k)_j}{N(k)_i^{1/3} + N(k)_j^{1/3}}`
+
+which can be visualised using the `folding_tracker` return value of the
+function.
+

--- a/docs/source/visualisation/power_spectra.rst
+++ b/docs/source/visualisation/power_spectra.rst
@@ -122,3 +122,6 @@ number of grid points included in the bin. For two overlapping foldings,
 which can be visualised using the ``folding_tracker`` return value of the
 function.
 
+The returned bin centers are actually calcualted as the weighted mean
+k-values directly from the grid that contributed to each bin.
+

--- a/docs/source/visualisation/power_spectra.rst
+++ b/docs/source/visualisation/power_spectra.rst
@@ -97,13 +97,13 @@ allows you to do this easily:
 
     folded_depositions = {}
 
-    for fold in [x * 2 for x in range(5)]:
-        folded_depositions[fold] = render_to_deposit(
+    for folding in [x * 2 for x in range(5)]:
+        folded_depositions[folding] = render_to_deposit(
             data.gas,
             resolution=512,
             project="masses",
             parallel=True,
-            folding=2.0 ** fold,
+            folding=folding,
         )
 
     bins, centers, power_spectrum, foldings = folded_depositions_to_power_spectrum(

--- a/swiftsimio/visualisation/power_spectrum.py
+++ b/swiftsimio/visualisation/power_spectrum.py
@@ -10,7 +10,7 @@ from swiftsimio.accelerated import jit, NUM_THREADS, prange
 from swiftsimio import cosmo_array
 from swiftsimio.reader import __SWIFTParticleDataset
 
-from typing import Optional
+from typing import Optional, Dict, Tuple
 
 
 @jit(nopython=True, fastmath=True)
@@ -252,11 +252,11 @@ def render_to_deposit(
 
 
 def folded_depositions_to_power_spectrum(
-    depositions: dict[int, cosmo_array],
+    depositions: Dict[int, cosmo_array],
     box_size: cosmo_array,
     number_of_wavenumber_bins: int,
-    cross_depositions: Optional[dict[int, cosmo_array]] = None,
-    wavenumber_range: Optional[tuple[unyt.unyt_quantity]] = None,
+    cross_depositions: Optional[Dict[int, cosmo_array]] = None,
+    wavenumber_range: Optional[Tuple[unyt.unyt_quantity]] = None,
     log_wavenumber_bins: bool = True,
 ) -> tuple[unyt.unyt_array]:
     """

--- a/swiftsimio/visualisation/power_spectrum.py
+++ b/swiftsimio/visualisation/power_spectrum.py
@@ -258,7 +258,7 @@ def folded_depositions_to_power_spectrum(
     cross_depositions: Optional[Dict[int, cosmo_array]] = None,
     wavenumber_range: Optional[Tuple[unyt.unyt_quantity]] = None,
     log_wavenumber_bins: bool = True,
-) -> tuple[unyt.unyt_array]:
+) -> Tuple[unyt.unyt_array]:
     """
     Convert some folded depositions to power spectra.
 
@@ -381,7 +381,7 @@ def deposition_to_power_spectrum(
     folding: float = 1.0,
     cross_deposition: Optional[unyt.unyt_array] = None,
     wavenumber_bins: Optional[unyt.unyt_array] = None,
-) -> tuple[unyt.unyt_array]:
+) -> Tuple[unyt.unyt_array]:
     """
     Convert a deposition to a power spectrum, by default
     using a linear binning strategy.

--- a/swiftsimio/visualisation/power_spectrum.py
+++ b/swiftsimio/visualisation/power_spectrum.py
@@ -1,0 +1,308 @@
+"""
+Tools for creating power spectra from SWIFT data.
+"""
+
+from numpy import float32, float64, int32, zeros, ndarray
+import numpy as np
+
+from swiftsimio.accelerated import jit, NUM_THREADS, prange
+from swiftsimio import cosmo_array
+from swiftsimio.reader import __SWIFTParticleDataset
+
+@jit(nopython=True, fastmath=True)
+def deposit(
+    x: float64,
+    y: float64,
+    z: float64,
+    m: float32,
+    res: int32,
+    fold: float64,
+    box_x: float64,
+    box_y: float64,
+    box_z: float64,
+) -> ndarray:
+    """
+    Deposit the particles to a 3D grid, with the potential
+    for folding. Note that unlike the other vis tools, this
+    requires the 'raw' positions of the particles.
+
+    Parameters
+    ----------
+    x : np.array[float64]
+        array of x-positions of the particles. Must be bounded by [0, 1].
+    y: np.array[float64]
+        array of y-positions of the particles. Must be bounded by [0, 1].
+    z: np.array[float64]
+        array of z-positions of the particles. Must be bounded by [0, 1].
+    m: np.array[float32]
+        array of masses (or otherwise weights) of the particles
+    res: int
+        the number of pixels along one axis, i.e. this returns a cube
+        of res * res * res.
+    fold: float64
+        the number of times to fold the box. Note that this is the
+        number of times to fold the box, not the number of folds.
+    box_x: float64
+        box size in x, in the same rescaled length units as x, y, and z. c
+    box_y: float64
+        box size in y, in the same rescaled length units as x, y, and z.
+    box_z: float64
+        box size in z, in the same rescaled length units as x, y, and z.
+
+    Returns
+    -------
+    np.array[float32, float32, float32]
+        Pixel grid of deposited quantity density.
+    """
+
+    output = zeros((res, res, res), dtype=float32)
+
+    float_res = float32(res)
+
+    # Fold the box
+    box_over_fold_x = box_x / fold
+    box_over_fold_y = box_y / fold
+    box_over_fold_z = box_z / fold
+
+    inv_box_over_fold_x = 1.0 / box_over_fold_x
+    inv_box_over_fold_y = 1.0 / box_over_fold_y
+    inv_box_over_fold_z = 1.0 / box_over_fold_z
+
+    # In pixel space.
+    inv_volume_element = float_res * float_res * float_res
+    inv_volume_element *= fold * fold * fold
+
+    for x_pos, y_pos, z_pos, mass in zip(x, y, z, m):
+        # Fold the particles
+        x_pos = (x_pos % box_over_fold_x) * inv_box_over_fold_x
+        y_pos = (y_pos % box_over_fold_y) * inv_box_over_fold_y
+        z_pos = (z_pos % box_over_fold_z) * inv_box_over_fold_z
+
+        # Convert to grid position
+        x_pix = int32(x_pos * float_res)
+        y_pix = int32(y_pos * float_res)
+        z_pix = int32(z_pos * float_res)
+
+        # Deposit the mass
+        output[x_pix, y_pix, z_pix] += mass * inv_volume_element
+
+    return output
+
+
+@jit(nopython=True, fastmath=True, parallel=True)
+def deposit_parallel(
+    x: float64,
+    y: float64,
+    z: float64,
+    m: float32,
+    res: int32,
+    fold: float64,
+    box_x: float64,
+    box_y: float64,
+    box_z: float64,
+) -> ndarray:
+    """
+    Deposit the particles to a 3D grid, with the potential
+    for folding. Note that unlike the other vis tools, this
+    requires the 'raw' positions of the particles.
+
+    Parameters
+    ----------
+    x : np.array[float64]
+        array of x-positions of the particles. Must be bounded by [0, 1].
+    y: np.array[float64]
+        array of y-positions of the particles. Must be bounded by [0, 1].
+    z: np.array[float64]
+        array of z-positions of the particles. Must be bounded by [0, 1].
+    m: np.array[float32]
+        array of masses (or otherwise weights) of the particles
+    res: int
+        the number of pixels along one axis, i.e. this returns a cube
+        of res * res * res.
+    fold: float64
+        the number of times to fold the box. Note that this is the
+        number of times to fold the box, not the number of folds.
+    box_x: float64
+        box size in x, in the same rescaled length units as x, y, and z. c
+    box_y: float64
+        box size in y, in the same rescaled length units as x, y, and z.
+    box_z: float64
+        box size in z, in the same rescaled length units as x, y, and z.
+
+    Returns
+    -------
+    np.array[float32, float32, float32]
+        Pixel grid of deposited quantity density.
+    """
+
+    number_of_particles = x.size
+    core_particles = number_of_particles // NUM_THREADS
+
+    output = zeros((res, res, res), dtype=float32)
+
+    for thread in prange(NUM_THREADS):
+        start = thread * core_particles
+        end = (thread + 1) * core_particles
+
+        if thread == NUM_THREADS - 1:
+            end = number_of_particles
+
+        output += deposit(
+            x=x[start:end],
+            y=y[start:end],
+            z=z[start:end],
+            m=m[start:end],
+            res=res,
+            fold=fold,
+            box_x=box_x,
+            box_y=box_y,
+            box_z=box_z,
+        )
+
+    return output
+
+
+def render_to_deposit(
+    data: __SWIFTParticleDataset,
+    resolution: int,
+    project: str = "masses",
+    folding: float = 1.0,
+    parallel: bool = False,
+) -> ndarray:
+    """
+    Render a dataset to a deposition.
+
+    Parameters
+    ----------
+    data: SWIFTDataset
+        The dataset to render to a deposition.
+    resolution: int
+        The resolution of the deposition.
+    project: str
+        The quantity to project to the deposition. Must be a valid quantity
+        in the dataset.
+    folding: int
+        The number of times to fold the box.
+    parallel: bool
+        Whether to use parallel deposition.
+
+    Returns
+    -------
+    np.array[float32, float32, float32]
+        The deposition.
+    """
+
+    # Get the positions and masses
+    positions = data.coordinates
+    quantity = getattr(data, project)
+
+    if positions.comoving:
+        if not quantity.compatible_with_comoving():
+            raise AttributeError(
+                f'Physical quantity "{project}" is not compatible with comoving coordinates!'
+            )
+        else:
+            if not quantity.compatible_with_physical():
+                raise AttributeError(
+                    f'Comoving quantity "{project}" is not compatible with physical coordinates!'
+                )
+
+
+    # Get the box size
+    box_size = data.metadata.boxsize
+
+    if not box_size.units == positions.units:
+        raise AttributeError("Box size and positions have different units!")
+    
+    # Deposit the particles
+    arguments = dict(
+        x=positions[:, 0].v,
+        y=positions[:, 1].v,
+        z=positions[:, 2].v,
+        m=quantity.v,
+        res=resolution,
+        fold=folding,
+        box_x=box_size[0].v,
+        box_y=box_size[1].v,
+        box_z=box_size[2].v,
+    )
+    
+    if parallel:
+        deposition = deposit_parallel(**arguments)
+    else:
+        deposition = deposit(**arguments)
+
+    comoving = positions.comoving
+    coord_cosmo_factor = positions.cosmo_factor
+
+    units = 1.0 / (data.metadata.boxsize[0] * data.metadata.boxsize[1] * data.metadata.boxsize[2])
+    units.convert_to_units(1.0 / data.metadata.boxsize.units ** 3)
+
+    units *= quantity.units
+    new_cosmo_factor = quantity.cosmo_factor / (coord_cosmo_factor ** 3)
+
+    return cosmo_array(deposition, comoving=comoving, cosmo_factor=new_cosmo_factor, units=units)
+    
+
+
+def deposition_to_power_spectrum(deposition: ndarray, box_size: cosmo_array, folding: float = 1.0) -> ndarray:
+    """
+    Convert a deposition to a power spectrum.
+
+    Parameters
+    ----------
+    deposition: np.array[float32, float32, float32]
+        The deposition to convert to a power spectrum.
+    box_size: cosmo_array
+        The box size of the deposition, from the dataset.
+
+    Returns
+    -------
+    np.array[float32]
+        The power spectrum of the deposition.
+
+    Notes
+    -----
+
+    This is adapted from Bert Vandenbroucke's code at
+    https://bertvandenbroucke.netlify.app/2019/05/24/computing-a-power-spectrum-in-python/
+    """
+
+    if not len(deposition.shape) == 3:
+        raise ValueError("Deposition must be a 3D array")
+
+    if not deposition.shape[0] == deposition.shape[1] == deposition.shape[2]:
+        raise ValueError("Deposition must be a cube")
+
+    box_size = box_size[0] / folding
+    npix = deposition.shape[0]
+    pixel_size = box_size / npix
+
+    # Convert to overdensity
+    mean_deposition = np.mean(deposition.v)
+    overdensity = (deposition.v - mean_deposition) / mean_deposition
+
+    fourier_amplitudes = np.abs(np.fft.fftn(overdensity)) ** 2
+
+    kfreq = np.fft.fftfreq(n=npix, d=pixel_size)
+    kfreq3d = np.meshgrid(kfreq, kfreq, kfreq)
+    knrm = np.sqrt(kfreq3d[0] ** 2 + kfreq3d[1] ** 2 + kfreq3d[2] ** 2)
+
+    knrm = knrm.flatten()
+    fourier_amplitudes = fourier_amplitudes.flatten()
+
+    kbins = np.arange(0.5, npix // 2 + 1, 1.0) / box_size
+    # kvals are in pixel co-ordinates. We know the pixels
+    # span the entire box, so we can convert to physical
+    # co-ordinates.
+    kvals = 0.5 * (kbins[1:] + kbins[:-1])
+
+    power_spectrum = (
+        np.histogram(knrm, bins=kbins, weights=fourier_amplitudes)[0]
+        / np.histogram(knrm, bins=kbins)[0]
+    )
+    
+    power_spectrum *= 4.0 / 3.0 * np.pi * (kbins[1:] ** 3 - kbins[:-1] ** 3)
+    power_spectrum *= folding ** 3
+
+    return kvals, power_spectrum

--- a/swiftsimio/visualisation/power_spectrum.py
+++ b/swiftsimio/visualisation/power_spectrum.py
@@ -292,6 +292,9 @@ def folded_depositions_to_power_spectrum(
 
     power_spectrum: unyt.unyt_array[float32]
         The power spectrum.
+
+    folding_tracker: np.array
+        A tracker of the contribution of various folded elements.
     """
 
     # Fraction of total bin range to use.
@@ -380,7 +383,8 @@ def deposition_to_power_spectrum(
     wavenumber_bins: Optional[unyt.unyt_array] = None,
 ) -> tuple[unyt.unyt_array]:
     """
-    Convert a deposition to a power spectrum.
+    Convert a deposition to a power spectrum, by default
+    using a linear binning strategy.
 
     Parameters
     ----------
@@ -388,6 +392,9 @@ def deposition_to_power_spectrum(
         The deposition to convert to a power spectrum.
     box_size: cosmo_array
         The box size of the deposition, from the dataset.
+    folding: float
+        The (real) folding that was used to generate the
+        deposition. 2 for a half-size box, 4 for quarter, etc.
     cross_deposition: unyt.unyt_array[float32, float32, float32]
         An optional second deposition to cross-correlate with the first.
         If not provided, we assume you want an auto-spectrum.
@@ -397,7 +404,7 @@ def deposition_to_power_spectrum(
     Returns
     -------
 
-    kvals: unyt.unyt_array[float32]
+    wavenumber_centers: unyt.unyt_array[float32]
         The k-values of the power spectrum, with units.
 
     power_spectrum: unyt.unyt_array[float32]

--- a/swiftsimio/visualisation/power_spectrum.py
+++ b/swiftsimio/visualisation/power_spectrum.py
@@ -283,8 +283,8 @@ def deposition_to_power_spectrum(deposition: ndarray, box_size: cosmo_array, fol
     mean_deposition = np.mean(deposition.v)
     overdensity = (deposition.v - mean_deposition) / mean_deposition
 
-    fft = np.fft.fftn(overdensity)
-    fourier_amplitudes = (fft * fft.conj()).real
+    fft = np.fft.fftn(overdensity / np.prod(deposition.shape))
+    fourier_amplitudes = (fft * fft.conj()).real * box_size ** 3
 
     kfreq = np.fft.fftfreq(n=npix, d=pixel_size)
 
@@ -311,7 +311,6 @@ def deposition_to_power_spectrum(deposition: ndarray, box_size: cosmo_array, fol
         / np.histogram(knrm, bins=kbins)[0]
     )
     
-    # power_spectrum *= (4.0 / 3.0 * np.pi * (kbins[1:] ** 3 - kbins[:-1] ** 3))
     power_spectrum *= folding ** 3
 
-    return kvals, power_spectrum / np.prod(deposition.shape)
+    return kvals, power_spectrum

--- a/swiftsimio/visualisation/power_spectrum.py
+++ b/swiftsimio/visualisation/power_spectrum.py
@@ -290,11 +290,7 @@ def deposition_to_power_spectrum(
     box_size = box_size[0] / folding
     npix = deposition.shape[0]
 
-    # Convert to overdensity
-    mean_deposition = np.mean(deposition.v)
-    overdensity = (deposition.v - mean_deposition) / mean_deposition
-
-    fft = np.fft.fftn(overdensity / np.prod(deposition.shape))
+    fft = np.fft.fftn(deposition.v / np.prod(deposition.shape))
     fourier_amplitudes = (fft * fft.conj()).real * box_size ** 3
 
     # Calculate k-value spacing (centered FFT)

--- a/swiftsimio/visualisation/power_spectrum.py
+++ b/swiftsimio/visualisation/power_spectrum.py
@@ -199,7 +199,7 @@ def render_to_deposit(
     """
 
     # Get the positions and masses
-    folding = 2.0**folding
+    folding = 2.0 ** folding
     positions = data.coordinates
     quantity = getattr(data, project)
 
@@ -244,10 +244,10 @@ def render_to_deposit(
     units = 1.0 / (
         data.metadata.boxsize[0] * data.metadata.boxsize[1] * data.metadata.boxsize[2]
     )
-    units.convert_to_units(1.0 / data.metadata.boxsize.units**3)
+    units.convert_to_units(1.0 / data.metadata.boxsize.units ** 3)
 
     units *= quantity.units
-    new_cosmo_factor = quantity.cosmo_factor / (coord_cosmo_factor**3)
+    new_cosmo_factor = quantity.cosmo_factor / (coord_cosmo_factor ** 3)
 
     return cosmo_array(
         deposition, comoving=comoving, cosmo_factor=new_cosmo_factor, units=units
@@ -403,7 +403,7 @@ def folded_depositions_to_power_spectrum(
 
         if folding != final_folding:
             cutoff_wavenumber = (
-                2.0**folding * np.min(depositions[folding].shape) / np.min(box_size)
+                2.0 ** folding * np.min(depositions[folding].shape) / np.min(box_size)
             )
 
             if cutoff_above_wavenumber_fraction is not None:
@@ -428,7 +428,7 @@ def folded_depositions_to_power_spectrum(
             corrected_wavenumber_centers[prefer_bins] = folded_wavenumber_centers[
                 prefer_bins
             ].to(corrected_wavenumber_centers.units)
-            folding_tracker[prefer_bins] = 2.0**folding
+            folding_tracker[prefer_bins] = 2.0 ** folding
 
             contributed_counts[prefer_bins] = folded_counts[prefer_bins]
         elif transition == "average":
@@ -461,7 +461,7 @@ def folded_depositions_to_power_spectrum(
 
             # For debugging, we calculate an effective fold number.
             folding_tracker[use_bins] = (
-                (folding_tracker * existing_weight + (2.0**folding) * new_weight)
+                (folding_tracker * existing_weight + (2.0 ** folding) * new_weight)
                 / transition_norm
             )[use_bins]
 
@@ -542,7 +542,7 @@ def deposition_to_power_spectrum(
             deposition.shape == cross_deposition.shape
         ), "Depositions must have the same shape"
 
-    folding = 2.0**folding
+    folding = 2.0 ** folding
 
     box_size_folded = box_size[0] / folding
     npix = deposition.shape[0]
@@ -564,7 +564,7 @@ def deposition_to_power_spectrum(
     else:
         conj_fft = fft.conj()
 
-    fourier_amplitudes = (fft * conj_fft).real * box_size_folded**3
+    fourier_amplitudes = (fft * conj_fft).real * box_size_folded ** 3
 
     # Calculate k-value spacing (centered FFT)
     dk = 2 * np.pi / (box_size_folded)
@@ -596,7 +596,7 @@ def deposition_to_power_spectrum(
     divisor[zero_mask] = 1
 
     # Correct for folding
-    binned_amplitudes *= folding**3
+    binned_amplitudes *= folding ** 3
 
     # Correct units and names
     wavenumbers = unyt.unyt_array(
@@ -608,10 +608,7 @@ def deposition_to_power_spectrum(
     )
 
     power_spectrum = (
-        unyt.unyt_array(
-            (binned_amplitudes) / divisor,
-            units=fourier_amplitudes.units,
-        )
+        unyt.unyt_array((binned_amplitudes) / divisor, units=fourier_amplitudes.units)
         - shot_noise
     )
 

--- a/swiftsimio/visualisation/power_spectrum.py
+++ b/swiftsimio/visualisation/power_spectrum.py
@@ -335,8 +335,4 @@ def deposition_to_power_spectrum(
         binned_amplitudes / divisor, units=fourier_amplitudes.units, name="P(k)"
     )
 
-    import pdb
-
-    pdb.set_trace()
-
     return kvals, power_spectrum, binned_counts

--- a/swiftsimio/visualisation/power_spectrum.py
+++ b/swiftsimio/visualisation/power_spectrum.py
@@ -170,7 +170,7 @@ def render_to_deposit(
     project: str = "masses",
     folding: float = 1.0,
     parallel: bool = False,
-) -> ndarray:
+) -> cosmo_array:
     """
     Render a dataset to a deposition.
 
@@ -190,7 +190,7 @@ def render_to_deposit(
 
     Returns
     -------
-    np.array[float32, float32, float32]
+    cosmo_array[float32, float32, float32]
         The deposition.
     """
 

--- a/swiftsimio/visualisation/power_spectrum.py
+++ b/swiftsimio/visualisation/power_spectrum.py
@@ -205,11 +205,11 @@ def render_to_deposit(
             raise AttributeError(
                 f'Physical quantity "{project}" is not compatible with comoving coordinates!'
             )
-        else:
-            if not quantity.compatible_with_physical():
-                raise AttributeError(
-                    f'Comoving quantity "{project}" is not compatible with physical coordinates!'
-                )
+    else:
+        if not quantity.compatible_with_physical():
+            raise AttributeError(
+                f'Comoving quantity "{project}" is not compatible with physical coordinates!'
+            )
 
     # Get the box size
     box_size = data.metadata.boxsize

--- a/swiftsimio/visualisation/power_spectrum.py
+++ b/swiftsimio/visualisation/power_spectrum.py
@@ -264,8 +264,15 @@ def deposition_to_power_spectrum(
 
     Returns
     -------
-    np.array[float32]
-        The power spectrum of the deposition.
+
+    kvals: unyt.unyt_array[float32]
+        The k-values of the power spectrum, with units.
+
+    power_spectrum: unyt.unyt_array[float32]
+        The power spectrum, with units.
+
+    binned_counts: np.array[int32]
+        Bin counts for the power spectrum; useful for shot noise.
 
     Notes
     -----
@@ -315,7 +322,9 @@ def deposition_to_power_spectrum(
 
     # Avoid divide by zero
     binned_amplitudes[zero_mask] = 0.0
-    binned_counts[zero_mask] = 1.0
+
+    divisor = binned_counts.copy()
+    divisor[zero_mask] = 1
 
     # Correct for folding
     binned_amplitudes *= folding ** 3
@@ -323,7 +332,11 @@ def deposition_to_power_spectrum(
     # Correct units and names
     kvals.name = "k"
     power_spectrum = unyt.unyt_array(
-        binned_amplitudes / binned_counts, units=fourier_amplitudes.units, name="P(k)"
+        binned_amplitudes / divisor, units=fourier_amplitudes.units, name="P(k)"
     )
 
-    return kvals, power_spectrum
+    import pdb
+
+    pdb.set_trace()
+
+    return kvals, power_spectrum, binned_counts

--- a/swiftsimio/visualisation/power_spectrum.py
+++ b/swiftsimio/visualisation/power_spectrum.py
@@ -241,10 +241,10 @@ def render_to_deposit(
     units = 1.0 / (
         data.metadata.boxsize[0] * data.metadata.boxsize[1] * data.metadata.boxsize[2]
     )
-    units.convert_to_units(1.0 / data.metadata.boxsize.units**3)
+    units.convert_to_units(1.0 / data.metadata.boxsize.units ** 3)
 
     units *= quantity.units
-    new_cosmo_factor = quantity.cosmo_factor / (coord_cosmo_factor**3)
+    new_cosmo_factor = quantity.cosmo_factor / (coord_cosmo_factor ** 3)
 
     return cosmo_array(
         deposition, comoving=comoving, cosmo_factor=new_cosmo_factor, units=units
@@ -343,7 +343,7 @@ def folded_depositions_to_power_spectrum(
         _, folded_power_spectrum, folded_counts = deposition_to_power_spectrum(
             deposition=depositions[folding],
             box_size=box_size,
-            folding=2.0**folding,
+            folding=2.0 ** folding,
             wavenumber_bins=wavenumber_bins,
         )
 
@@ -363,7 +363,7 @@ def folded_depositions_to_power_spectrum(
 
         # For debugging, we calculate an effective fold number.
         folding_tracker[use_bins] = (
-            (folding_tracker * previous_counts + (2.0**folding) * folded_counts)
+            (folding_tracker * previous_counts + (2.0 ** folding) * folded_counts)
             / transition_norm
         )[use_bins]
 
@@ -438,7 +438,7 @@ def deposition_to_power_spectrum(
         else np.fft.fftn(cross_deposition.v / np.prod(deposition.shape)).conj()
     )
 
-    fourier_amplitudes = (fft * conj_fft).real * box_size**3
+    fourier_amplitudes = (fft * conj_fft).real * box_size ** 3
 
     # Calculate k-value spacing (centered FFT)
     dk = 2 * np.pi / (box_size)
@@ -473,7 +473,7 @@ def deposition_to_power_spectrum(
     divisor[zero_mask] = 1
 
     # Correct for folding
-    binned_amplitudes *= folding**3
+    binned_amplitudes *= folding ** 3
 
     # Correct units and names
     kvals.name = "k"

--- a/swiftsimio/visualisation/power_spectrum.py
+++ b/swiftsimio/visualisation/power_spectrum.py
@@ -282,7 +282,6 @@ def deposition_to_power_spectrum(
 
     box_size = box_size[0] / folding
     npix = deposition.shape[0]
-    pixel_size = box_size / npix
 
     # Convert to overdensity
     mean_deposition = np.mean(deposition.v)
@@ -290,8 +289,6 @@ def deposition_to_power_spectrum(
 
     fft = np.fft.fftn(overdensity / np.prod(deposition.shape))
     fourier_amplitudes = (fft * fft.conj()).real * box_size ** 3
-
-    kfreq = np.fft.fftfreq(n=npix, d=pixel_size)
 
     # Calculate k-value spacing (centered FFT)
     dk = 2 * np.pi / (box_size)

--- a/swiftsimio/visualisation/volume_render.py
+++ b/swiftsimio/visualisation/volume_render.py
@@ -113,7 +113,7 @@ def scatter(
     drop_to_single_cell = pixel_width * 0.5
 
     # Pre-calculate this constant for use with the above
-    inverse_cell_volume = res * res * res
+    inverse_cell_volume = float_res * float_res * float_res
 
     if box_x == 0.0:
         xshift_min = 0

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -616,7 +616,7 @@ def test_dark_matter_power_spectrum(filename, save=True):
     for folding in [8.0, 64.0]:#, 8.0, 512.0]:
         # Deposit the particles
         deposition = render_to_deposit(
-            data.dark_matter, 256, project="masses", folding=folding, parallel=False
+            data.dark_matter, 128, project="masses", folding=folding, parallel=False
         ).to("Msun / Mpc**3")
 
         # Calculate the power spectrum
@@ -633,7 +633,7 @@ def test_dark_matter_power_spectrum(filename, save=True):
             plt.plot(k, power_spectrum, label=f"Npix {npix}")
 
         for fold_id, (k, power_spectrum) in folding_output.items():
-            plt.plot(k, power_spectrum, label=f"Fold {fold_id} (Npix 256)", ls='dotted')
+            plt.plot(k, power_spectrum, label=f"Fold {fold_id} (Npix 128)", ls='dotted')
         plt.xlabel("k")
         plt.loglog()
         plt.axvline(2 * np.pi / data.metadata.boxsize[0].to("Mpc"), color="black", linestyle="--")

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -19,9 +19,7 @@ from swiftsimio.visualisation.power_spectrum import (
     render_to_deposit,
     folded_depositions_to_power_spectrum,
 )
-from swiftsimio.visualisation.smoothing_length_generation import (
-    generate_smoothing_lengths,
-)
+from swiftsimio.visualisation.smoothing_length import generate_smoothing_lengths
 from swiftsimio.visualisation.projection_backends import (
     backends as projection_backends,
     backends_parallel as projection_backends_parallel,

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -587,7 +587,7 @@ def test_volume_render_and_unfolded_deposit_with_units(filename):
 
 
 @requires("cosmo_volume_example.hdf5")
-def test_dark_matter_power_spectrum(filename, save=True):
+def test_dark_matter_power_spectrum(filename, save=False):
     data = load(filename)
 
     data.dark_matter.smoothing_lengths = generate_smoothing_lengths(

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -530,7 +530,7 @@ def test_volume_render_and_unfolded_deposit():
         boxsize,
         boxsize,
         boxsize,
-    ) / (res ** 3)
+    )
 
     assert np.allclose(deposition, volume)
 
@@ -582,14 +582,7 @@ def test_volume_render_and_unfolded_deposit_with_units(filename):
 
     assert np.isclose(mean_density_deposit, mean_density_calculated)
     assert np.isclose(mean_density_volume, mean_density_calculated, rtol=0.2)
-
     assert np.isclose(mean_density_deposit, mean_density_volume, rtol=0.2)
-
-    # assert np.isclose(deposition.to(volume.units)[0, 0, 0].v, volume[0, 0, 0].v, rtol=0.2)
-
-    # assert np.isclose(deposition.to(volume.units).v, volume.v, rtol=0.2).any()
-
-    # assert np.isclose(deposition.to(volume.units).v, volume.v, rtol=0.2).all()
 
 
 @requires("cosmo_volume_example.hdf5")

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -601,12 +601,12 @@ def test_dark_matter_power_spectrum(filename, save=False):
     for npix in [32, 64, 128, 256]:
         # Deposit the particles
         deposition = render_to_deposit(
-            data.dark_matter, npix, project="masses", folding=1.0, parallel=False
+            data.dark_matter, npix, project="masses", folding=0, parallel=False
         ).to("Msun / Mpc**3")
 
         # Calculate the power spectrum
         k, power_spectrum, scatter = deposition_to_power_spectrum(
-            deposition, data.metadata.boxsize, folding=1.0
+            deposition, data.metadata.boxsize, folding=0
         )
 
         if npix == 32:
@@ -619,16 +619,12 @@ def test_dark_matter_power_spectrum(filename, save=False):
     for folding in [2, 4, 6, 8]:  # , 8.0, 512.0]:
         # Deposit the particles
         deposition = render_to_deposit(
-            data.dark_matter,
-            32,
-            project="masses",
-            folding=2.0 ** folding,
-            parallel=False,
+            data.dark_matter, 32, project="masses", folding=folding, parallel=False
         ).to("Msun / Mpc**3")
 
         # Calculate the power spectrum
         k, power_spectrum, scatter = deposition_to_power_spectrum(
-            deposition, data.metadata.boxsize, folding=2.0 ** folding
+            deposition, data.metadata.boxsize, folding=folding
         )
 
         folds[folding] = deposition

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -88,7 +88,7 @@ def test_scatter_mass_conservation():
 
     for resolution in resolutions:
         image = scatter(x, y, m, h, resolution, 1.0, 1.0)
-        mass_in_image = image.sum() / (resolution**2)
+        mass_in_image = image.sum() / (resolution ** 2)
 
         # Check mass conservation to 5%
         assert np.isclose(mass_in_image, total_mass, 0.05)
@@ -346,7 +346,7 @@ def test_comoving_versus_physical(filename):
         # conversion in this case
         img = func(data, resolution=256, project=None)
         assert img.comoving
-        assert img.cosmo_factor.expr == a**aexp
+        assert img.cosmo_factor.expr == a ** aexp
         img = func(data, resolution=256, project="densities")
         assert img.comoving
         assert img.cosmo_factor.expr == a ** (aexp - 3.0)
@@ -364,7 +364,7 @@ def test_comoving_versus_physical(filename):
         img = func(data, resolution=256, project="masses")
         # check that we get a physical result
         assert not img.comoving
-        assert img.cosmo_factor.expr == a**aexp
+        assert img.cosmo_factor.expr == a ** aexp
         # densities are still compatible with physical
         img = func(data, resolution=256, project="densities")
         assert not img.comoving
@@ -587,8 +587,8 @@ def test_volume_render_and_unfolded_deposit_with_units(filename):
     # Volume render the particles
     volume = render_gas(data, npix, parallel=False).to_physical()
 
-    mean_density_deposit = (np.sum(deposition) / npix**3).to("Msun / kpc**3").v
-    mean_density_volume = (np.sum(volume) / npix**3).to("Msun / kpc**3").v
+    mean_density_deposit = (np.sum(deposition) / npix ** 3).to("Msun / kpc**3").v
+    mean_density_volume = (np.sum(volume) / npix ** 3).to("Msun / kpc**3").v
     mean_density_calculated = (
         (np.sum(data.gas.masses) / (data.metadata.boxsize[0] * data.metadata.a) ** 3)
         .to("Msun / kpc**3")
@@ -615,8 +615,7 @@ def test_dark_matter_power_spectrum(filename, save=False):
     max_k = 1e2 / unyt.Mpc
 
     bins = unyt.unyt_array(
-        np.logspace(np.log10(min_k.v), np.log10(max_k.v), 32),
-        units=min_k.units,
+        np.logspace(np.log10(min_k.v), np.log10(max_k.v), 32), units=min_k.units
     )
 
     output = {}
@@ -651,7 +650,7 @@ def test_dark_matter_power_spectrum(filename, save=False):
 
         folds[folding] = deposition
 
-        folding_output[2**folding] = (k, power_spectrum, scatter)
+        folding_output[2 ** folding] = (k, power_spectrum, scatter)
 
     # Now try doing them all together at once.
 
@@ -684,11 +683,7 @@ def test_dark_matter_power_spectrum(filename, save=False):
             norm = LogNorm()
             colors = cmap(norm(folding_tracker))
             plt.scatter(
-                all_centers,
-                all_ps,
-                label="Full Fold",
-                color=colors,
-                edgecolor="pink",
+                all_centers, all_ps, label="Full Fold", color=colors, edgecolor="pink"
             )
             plt.colorbar(
                 mappable=ScalarMappable(norm=norm, cmap=cmap),

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -567,7 +567,7 @@ def test_volume_render_and_unfolded_deposit_with_units(filename):
 
     # Deposit the particles
     deposition = render_to_deposit(
-        data.gas, npix, project="masses", folding=1.0, parallel=False
+        data.gas, npix, project="masses", folding=0, parallel=False
     ).to_physical()
 
     # Volume render the particles

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -593,7 +593,7 @@ def test_volume_render_and_unfolded_deposit_with_units(filename):
 
 
 @requires("cosmo_volume_example.hdf5")
-def test_dark_matter_power_spectrum(filename, save=True):
+def test_dark_matter_power_spectrum(filename, save=False):
     data = load(filename)
 
     data.dark_matter.smoothing_lengths = generate_smoothing_lengths(

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -619,7 +619,11 @@ def test_dark_matter_power_spectrum(filename, save=False):
     for folding in [2, 4, 6, 8]:  # , 8.0, 512.0]:
         # Deposit the particles
         deposition = render_to_deposit(
-            data.dark_matter, 32, project="masses", folding=2.0 ** folding, parallel=False
+            data.dark_matter,
+            32,
+            project="masses",
+            folding=2.0 ** folding,
+            parallel=False,
         ).to("Msun / Mpc**3")
 
         # Calculate the power spectrum
@@ -645,9 +649,8 @@ def test_dark_matter_power_spectrum(filename, save=False):
         log_wavenumber_bins=True,
     )
 
-
     # import pdb; pdb.set_trace()
-    
+
     if save:
         import matplotlib.pyplot as plt
         from matplotlib.colors import LogNorm
@@ -666,12 +669,18 @@ def test_dark_matter_power_spectrum(filename, save=False):
             norm = LogNorm()
             colors = cmap(norm(folding_tracker))
             plt.scatter(
-                all_centers, all_ps, label="Full Fold",
+                all_centers,
+                all_ps,
+                label="Full Fold",
                 color=colors,
                 edgecolor="pink",
-                zorder=10
+                zorder=10,
             )
-            plt.colorbar(mappable=ScalarMappable(norm=norm, cmap=cmap), ax=plt.gca(), label="Folding")
+            plt.colorbar(
+                mappable=ScalarMappable(norm=norm, cmap=cmap),
+                ax=plt.gca(),
+                label="Folding",
+            )
 
             plt.loglog()
             plt.axvline(

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -601,11 +601,11 @@ def test_dark_matter_power_spectrum(filename, save=False):
         ).to("Msun / Mpc**3")
 
         # Calculate the power spectrum
-        k, power_spectrum = deposition_to_power_spectrum(
+        k, power_spectrum, scatter = deposition_to_power_spectrum(
             deposition, data.metadata.boxsize, folding=1.0
         )
 
-        output[npix] = (k, power_spectrum)
+        output[npix] = (k, power_spectrum, scatter)
 
     folding_output = {}
 
@@ -616,20 +616,20 @@ def test_dark_matter_power_spectrum(filename, save=False):
         ).to("Msun / Mpc**3")
 
         # Calculate the power spectrum
-        k, power_spectrum = deposition_to_power_spectrum(
+        k, power_spectrum, scatter = deposition_to_power_spectrum(
             deposition, data.metadata.boxsize, folding=folding
         )
 
-        folding_output[int(folding)] = (k, power_spectrum)
+        folding_output[int(folding)] = (k, power_spectrum, scatter)
 
     if save:
         import matplotlib.pyplot as plt
 
         with unyt.matplotlib_support:
-            for npix, (k, power_spectrum) in output.items():
+            for npix, (k, power_spectrum, _) in output.items():
                 plt.plot(k, power_spectrum, label=f"Npix {npix}")
 
-            for fold_id, (k, power_spectrum) in folding_output.items():
+            for fold_id, (k, power_spectrum, _) in folding_output.items():
                 plt.plot(
                     k, power_spectrum, label=f"Fold {fold_id} (Npix 128)", ls="dotted"
                 )

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -80,7 +80,7 @@ def test_scatter_mass_conservation():
 
     for resolution in resolutions:
         image = scatter(x, y, m, h, resolution, 1.0, 1.0)
-        mass_in_image = image.sum() / (resolution ** 2)
+        mass_in_image = image.sum() / (resolution**2)
 
         # Check mass conservation to 5%
         assert np.isclose(mass_in_image, total_mass, 0.05)
@@ -335,7 +335,7 @@ def test_comoving_versus_physical(filename):
         # conversion in this case
         img = func(data, resolution=256, project=None)
         assert img.comoving
-        assert img.cosmo_factor.expr == a ** aexp
+        assert img.cosmo_factor.expr == a**aexp
         img = func(data, resolution=256, project="densities")
         assert img.comoving
         assert img.cosmo_factor.expr == a ** (aexp - 3.0)
@@ -353,7 +353,7 @@ def test_comoving_versus_physical(filename):
         img = func(data, resolution=256, project="masses")
         # check that we get a physical result
         assert not img.comoving
-        assert img.cosmo_factor.expr == a ** aexp
+        assert img.cosmo_factor.expr == a**aexp
         # densities are still compatible with physical
         img = func(data, resolution=256, project="densities")
         assert not img.comoving
@@ -573,8 +573,8 @@ def test_volume_render_and_unfolded_deposit_with_units(filename):
     # Volume render the particles
     volume = render_gas(data, npix, parallel=False).to_physical()
 
-    mean_density_deposit = (np.sum(deposition) / npix ** 3).to("Msun / kpc**3").v
-    mean_density_volume = (np.sum(volume) / npix ** 3).to("Msun / kpc**3").v
+    mean_density_deposit = (np.sum(deposition) / npix**3).to("Msun / kpc**3").v
+    mean_density_volume = (np.sum(volume) / npix**3).to("Msun / kpc**3").v
     mean_density_calculated = (
         (np.sum(data.gas.masses) / (data.metadata.boxsize[0] * data.metadata.a) ** 3)
         .to("Msun / kpc**3")
@@ -587,7 +587,7 @@ def test_volume_render_and_unfolded_deposit_with_units(filename):
 
 
 @requires("cosmo_volume_example.hdf5")
-def test_dark_matter_power_spectrum(filename, save=True):
+def test_dark_matter_power_spectrum(filename, save=False):
     data = load(filename)
 
     data.dark_matter.smoothing_lengths = generate_smoothing_lengths(
@@ -596,7 +596,6 @@ def test_dark_matter_power_spectrum(filename, save=True):
 
     # Collate a bunch of raw depositions
     folds = {}
-
 
     min_k = 1e-2 / unyt.Mpc
     max_k = 1e2 / unyt.Mpc
@@ -638,7 +637,7 @@ def test_dark_matter_power_spectrum(filename, save=True):
 
         folds[folding] = deposition
 
-        folding_output[2 ** folding] = (k, power_spectrum, scatter)
+        folding_output[2**folding] = (k, power_spectrum, scatter)
 
     # Now try doing them all together at once.
 


### PR DESCRIPTION
I don't understand why this isn't working. This version has significant dependences on the number of pixels used for voxelization of the underlying particle data, and as a function of folding:

![dark_matter_power_spectrum](https://github.com/SWIFTSIM/swiftsimio/assets/7839515/d8ab494a-2559-4c71-92d2-ee208281e4c8)

This plot is made with `cosmo_volume_example.hdf5` that we have hosted on IOExamples.