### PR TITLE
Fix mass table initialisation

### DIFF
--- a/swiftsimio/metadata/objects.py
+++ b/swiftsimio/metadata/objects.py
@@ -377,7 +377,9 @@ class MassTable(object):
 
         # TODO: Extract these names from the files themselves if possible.
 
-        for index, name in metadata.particle_types.particle_name_underscores.items():
+        for index, name in enumerate(
+            metadata.particle_types.particle_name_underscores.values()
+        ):
             try:
                 setattr(
                     self,


### PR DESCRIPTION
When loading the mass table the array of values was being indexed with a string not an int, e.g. "PartType1" instead of 1