### PR TITLE
Propagate cosmo_array attributes through more copy-like functions

### DIFF
--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -882,6 +882,7 @@ class cosmo_array(unyt_array):
     __getitem__ = _propagate_cosmo_array_attributes(unyt_array.__getitem__)
     __copy__ = _propagate_cosmo_array_attributes(unyt_array.__copy__)
     __deepcopy__ = _propagate_cosmo_array_attributes(unyt_array.__deepcopy__)
+    in_cgs = _propagate_cosmo_array_attributes(unyt_array.in_cgs)
     astype = _propagate_cosmo_array_attributes(unyt_array.astype)
     in_units = _propagate_cosmo_array_attributes(unyt_array.in_units)
     byteswap = _propagate_cosmo_array_attributes(unyt_array.byteswap)

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -332,7 +332,7 @@ def _arctan2_cosmo_factor(ca_cf1, ca_cf2, **kwargs):
         raise ValueError(
             f"Ufunc arguments have cosmo_factors that differ: {cf1} and {cf2}."
         )
-    return cosmo_factor(a ** 0, scale_factor=cf1.scale_factor)
+    return cosmo_factor(a**0, scale_factor=cf1.scale_factor)
 
 
 def _comparison_cosmo_factor(ca_cf1, ca_cf2=None, inputs=None):
@@ -569,7 +569,7 @@ class cosmo_factor:
         return b.__truediv__(self)
 
     def __pow__(self, p):
-        return cosmo_factor(expr=self.expr ** p, scale_factor=self.scale_factor)
+        return cosmo_factor(expr=self.expr**p, scale_factor=self.scale_factor)
 
     def __lt__(self, b):
         return self.a_factor < b.a_factor
@@ -880,6 +880,8 @@ class cosmo_array(unyt_array):
     # Wrap functions that return copies of cosmo_arrays so that our
     # attributes get passed through:
     __getitem__ = _propagate_cosmo_array_attributes(unyt_array.__getitem__)
+    __copy__ = _propagate_cosmo_array_attributes(unyt_array.__copy__)
+    __deepcopy__ = _propagate_cosmo_array_attributes(unyt_array.__deepcopy__)
     astype = _propagate_cosmo_array_attributes(unyt_array.astype)
     in_units = _propagate_cosmo_array_attributes(unyt_array.in_units)
     byteswap = _propagate_cosmo_array_attributes(unyt_array.byteswap)

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -332,7 +332,7 @@ def _arctan2_cosmo_factor(ca_cf1, ca_cf2, **kwargs):
         raise ValueError(
             f"Ufunc arguments have cosmo_factors that differ: {cf1} and {cf2}."
         )
-    return cosmo_factor(a**0, scale_factor=cf1.scale_factor)
+    return cosmo_factor(a ** 0, scale_factor=cf1.scale_factor)
 
 
 def _comparison_cosmo_factor(ca_cf1, ca_cf2=None, inputs=None):
@@ -569,7 +569,7 @@ class cosmo_factor:
         return b.__truediv__(self)
 
     def __pow__(self, p):
-        return cosmo_factor(expr=self.expr**p, scale_factor=self.scale_factor)
+        return cosmo_factor(expr=self.expr ** p, scale_factor=self.scale_factor)
 
     def __lt__(self, b):
         return self.a_factor < b.a_factor

--- a/tests/test_cosmo_array.py
+++ b/tests/test_cosmo_array.py
@@ -84,3 +84,19 @@ class TestCosmoArrayCopy:
         assert arr.units == copy_arr.units
         assert arr.cosmo_factor == copy_arr.cosmo_factor
         assert arr.comoving == copy_arr.comoving
+
+    def test_to_cgs(self):
+        """
+        Check that using to_cgs properly preserves attributes.
+        """
+        units = u.Mpc
+        arr = cosmo_array(
+            u.unyt_array(np.ones(5), units=units),
+            cosmo_factor=cosmo_factor(a ** 1, 1),
+            comoving=False,
+        )
+        cgs_arr = arr.in_cgs()
+        assert np.allclose(arr.to_value(u.cm), cgs_arr.to_value(u.cm))
+        assert cgs_arr.units == u.cm
+        assert cgs_arr.cosmo_factor == arr.cosmo_factor
+        assert cgs_arr.comoving == arr.comoving

--- a/tests/test_cosmo_array.py
+++ b/tests/test_cosmo_array.py
@@ -11,7 +11,10 @@ from copy import copy, deepcopy
 class TestCosmoArrayInit:
     def test_init_from_ndarray(self):
         arr = cosmo_array(
-            np.ones(5), units=u.Mpc, cosmo_factor=cosmo_factor(a**1, 1), comoving=False
+            np.ones(5),
+            units=u.Mpc,
+            cosmo_factor=cosmo_factor(a ** 1, 1),
+            comoving=False,
         )
         assert hasattr(arr, "cosmo_factor")
         assert hasattr(arr, "comoving")
@@ -21,7 +24,7 @@ class TestCosmoArrayInit:
         arr = cosmo_array(
             [1, 1, 1, 1, 1],
             units=u.Mpc,
-            cosmo_factor=cosmo_factor(a**1, 1),
+            cosmo_factor=cosmo_factor(a ** 1, 1),
             comoving=False,
         )
         assert hasattr(arr, "cosmo_factor")
@@ -31,7 +34,7 @@ class TestCosmoArrayInit:
     def test_init_from_unyt_array(self):
         arr = cosmo_array(
             u.unyt_array(np.ones(5), units=u.Mpc),
-            cosmo_factor=cosmo_factor(a**1, 1),
+            cosmo_factor=cosmo_factor(a ** 1, 1),
             comoving=False,
         )
         assert hasattr(arr, "cosmo_factor")
@@ -41,7 +44,7 @@ class TestCosmoArrayInit:
     def test_init_from_list_of_unyt_arrays(self):
         arr = cosmo_array(
             [u.unyt_array(1, units=u.Mpc) for _ in range(5)],
-            cosmo_factor=cosmo_factor(a**1, 1),
+            cosmo_factor=cosmo_factor(a ** 1, 1),
             comoving=False,
         )
         assert hasattr(arr, "cosmo_factor")
@@ -57,7 +60,7 @@ class TestCosmoArrayCopy:
         units = u.Mpc
         arr = cosmo_array(
             u.unyt_array(np.ones(5), units=units),
-            cosmo_factor=cosmo_factor(a**1, 1),
+            cosmo_factor=cosmo_factor(a ** 1, 1),
             comoving=False,
         )
         copy_arr = copy(arr)
@@ -73,7 +76,7 @@ class TestCosmoArrayCopy:
         units = u.Mpc
         arr = cosmo_array(
             u.unyt_array(np.ones(5), units=units),
-            cosmo_factor=cosmo_factor(a**1, 1),
+            cosmo_factor=cosmo_factor(a ** 1, 1),
             comoving=False,
         )
         copy_arr = deepcopy(arr)

--- a/tests/test_cosmo_array.py
+++ b/tests/test_cosmo_array.py
@@ -5,6 +5,7 @@ Tests the initialisation of a cosmo_array.
 import numpy as np
 import unyt as u
 from swiftsimio.objects import cosmo_array, cosmo_factor
+from copy import copy, deepcopy
 
 
 class TestCosmoArrayInit:
@@ -46,3 +47,37 @@ class TestCosmoArrayInit:
         assert hasattr(arr, "cosmo_factor")
         assert hasattr(arr, "comoving")
         assert isinstance(arr, cosmo_array)
+
+
+class TestCosmoArrayCopy:
+    def test_copy(self):
+        """
+        Check that when we copy a cosmo_array it preserves its values and attributes.
+        """
+        units = u.Mpc
+        arr = cosmo_array(
+            u.unyt_array(np.ones(5), units=units),
+            cosmo_factor=cosmo_factor("a^1", 1),
+            comoving=False,
+        )
+        copy_arr = copy(arr)
+        assert np.allclose(arr.to_value(units), copy_arr.to_value(units))
+        assert arr.units == copy_arr.units
+        assert arr.cosmo_factor == copy_arr.cosmo_factor
+        assert arr.comoving == copy_arr.comoving
+
+    def test_deepcopy(self):
+        """
+        Check that when we deepcopy a cosmo_array it preserves its values and attributes
+        """
+        units = u.Mpc
+        arr = cosmo_array(
+            u.unyt_array(np.ones(5), units=units),
+            cosmo_factor=cosmo_factor("a^1", 1),
+            comoving=False,
+        )
+        copy_arr = deepcopy(arr)
+        assert np.allclose(arr.to_value(units), copy_arr.to_value(units))
+        assert arr.units == copy_arr.units
+        assert arr.cosmo_factor == copy_arr.cosmo_factor
+        assert arr.comoving == copy_arr.comoving

--- a/tests/test_cosmo_array.py
+++ b/tests/test_cosmo_array.py
@@ -4,14 +4,14 @@ Tests the initialisation of a cosmo_array.
 
 import numpy as np
 import unyt as u
-from swiftsimio.objects import cosmo_array, cosmo_factor
+from swiftsimio.objects import cosmo_array, cosmo_factor, a
 from copy import copy, deepcopy
 
 
 class TestCosmoArrayInit:
     def test_init_from_ndarray(self):
         arr = cosmo_array(
-            np.ones(5), units=u.Mpc, cosmo_factor=cosmo_factor("a^1", 1), comoving=False
+            np.ones(5), units=u.Mpc, cosmo_factor=cosmo_factor(a**1, 1), comoving=False
         )
         assert hasattr(arr, "cosmo_factor")
         assert hasattr(arr, "comoving")
@@ -21,7 +21,7 @@ class TestCosmoArrayInit:
         arr = cosmo_array(
             [1, 1, 1, 1, 1],
             units=u.Mpc,
-            cosmo_factor=cosmo_factor("a^1", 1),
+            cosmo_factor=cosmo_factor(a**1, 1),
             comoving=False,
         )
         assert hasattr(arr, "cosmo_factor")
@@ -31,7 +31,7 @@ class TestCosmoArrayInit:
     def test_init_from_unyt_array(self):
         arr = cosmo_array(
             u.unyt_array(np.ones(5), units=u.Mpc),
-            cosmo_factor=cosmo_factor("a^1", 1),
+            cosmo_factor=cosmo_factor(a**1, 1),
             comoving=False,
         )
         assert hasattr(arr, "cosmo_factor")
@@ -41,7 +41,7 @@ class TestCosmoArrayInit:
     def test_init_from_list_of_unyt_arrays(self):
         arr = cosmo_array(
             [u.unyt_array(1, units=u.Mpc) for _ in range(5)],
-            cosmo_factor=cosmo_factor("a^1", 1),
+            cosmo_factor=cosmo_factor(a**1, 1),
             comoving=False,
         )
         assert hasattr(arr, "cosmo_factor")
@@ -57,7 +57,7 @@ class TestCosmoArrayCopy:
         units = u.Mpc
         arr = cosmo_array(
             u.unyt_array(np.ones(5), units=units),
-            cosmo_factor=cosmo_factor("a^1", 1),
+            cosmo_factor=cosmo_factor(a**1, 1),
             comoving=False,
         )
         copy_arr = copy(arr)
@@ -73,7 +73,7 @@ class TestCosmoArrayCopy:
         units = u.Mpc
         arr = cosmo_array(
             u.unyt_array(np.ones(5), units=units),
-            cosmo_factor=cosmo_factor("a^1", 1),
+            cosmo_factor=cosmo_factor(a**1, 1),
             comoving=False,
         )
         copy_arr = deepcopy(arr)


### PR DESCRIPTION
Some functions that return copies of a `cosmo_array` failed to propagate the `cosmo_array` attributes properly, this PR fixes this issue.

Closes #184 

Closes #185 