### PR TITLE
Comoving parameter of cosmo_array defaults to None instead of True

### DIFF
--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -728,7 +728,7 @@ class cosmo_array(unyt_array):
         input_units=None,
         name=None,
         cosmo_factor=None,
-        comoving=True,
+        comoving=None,
         valid_transform=True,
         compression=None,
     ):


### PR DESCRIPTION
Title pretty much says it - it's a one-line code change. Rationale explained in related issue: closes #168 

Doesn't seem to break anything in the test suite, and this is a sufficiently fundamental change that I would have expected it to break something in there if it was going to. The main reader functions already set the parameter explicitly.