### PR TITLE
Update github workflows cache version

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip


### PR DESCRIPTION
`cache@v2` has been completely deprecated in github workflows, so our test suite cannot run. This PR updates to use `cache@v4`.