### PR TITLE
Bugfix: allow empty masks

### DIFF
--- a/swiftsimio/accelerated.py
+++ b/swiftsimio/accelerated.py
@@ -62,6 +62,9 @@ def ranges_from_array(array: np.array) -> np.ndarray:
 
     output = []
 
+    if len(array) == 0:
+        # the "empty" mask, from 0 to 0 gets 0 elements
+        return np.array([[0, 0]])
     start = array[0]
     stop = array[0]
 

--- a/swiftsimio/accelerated.py
+++ b/swiftsimio/accelerated.py
@@ -243,7 +243,6 @@ def get_chunk_ranges(
 
     """
     chunk_ranges = []
-    n_ranges = len(ranges)
     for bounds in ranges:
         lower = (bounds[0] // chunk_size) * chunk_size
         upper = min(-((-bounds[1]) // chunk_size) * chunk_size, array_length)
@@ -411,7 +410,7 @@ def read_ranges_from_file_chunked(
 
     try:
         output_shape = (chunk_range_size, output_shape[1])
-    except:
+    except TypeError:
         # Output shape is just a number, we have a 1D array.
         output_shape = chunk_range_size
 

--- a/swiftsimio/accelerated.py
+++ b/swiftsimio/accelerated.py
@@ -413,7 +413,7 @@ def read_ranges_from_file_chunked(
 
     try:
         output_shape = (chunk_range_size, output_shape[1])
-    except TypeError:
+    except (TypeError, IndexError):
         # Output shape is just a number, we have a 1D array.
         output_shape = chunk_range_size
 

--- a/tests/test_accelerated.py
+++ b/tests/test_accelerated.py
@@ -47,7 +47,7 @@ def test_ranges_from_array_empty():
     Tests the ranges from array function when the array is empty.
     """
 
-    my_array = np.array([])
+    my_array = np.array([], dtype=int)
 
     out = np.array([[0, 0]])
 

--- a/tests/test_accelerated.py
+++ b/tests/test_accelerated.py
@@ -10,7 +10,6 @@ from swiftsimio.accelerated import (
 )
 
 import numpy as np
-import h5py
 
 from .helper import create_in_memory_hdf5
 
@@ -39,6 +38,18 @@ def test_ranges_from_array_non_contiguous():
     out = np.array(
         [[77, 78], [34483, 34484], [234582, 234583], [123412341324, 123412341325]]
     )
+
+    assert (ranges_from_array(my_array) == out).all()
+
+
+def test_ranges_from_array_empty():
+    """
+    Tests the ranges from array function when the array is empty.
+    """
+
+    my_array = np.array([])
+
+    out = np.array([[0, 0]])
 
     assert (ranges_from_array(my_array) == out).all()
 

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -134,4 +134,4 @@ def test_empty_mask(cosmological_volume):  # replace with cosmoogical_volume_no_
         ),
     )
     data = load(cosmological_volume, mask=empty_mask)
-    data.gas.masses
+    assert data.gas.masses.size == 0


### PR DESCRIPTION
Straightforward fix to this bug. The root of the problem is in `ranges_from_array`, which accesses array elements out of bounds if an array of size 0 is passed. This is now guarded. The return value in this case is `np.array([[0, 0]], dtype=int)`. This works since a slice `...[0:0]` gets an empty slice. I'd initially tried returning `np.array([], dtype=int)`, which also seems intuitive, but this causes havoc throughout the rest of the package where an actual slice is expected, while the `[[0, 0]]` solution works seamlessly.

Closes #164 