### PR TITLE
Bugfix: load empty datasets correctly

### DIFF
--- a/swiftsimio/reader.py
+++ b/swiftsimio/reader.py
@@ -162,6 +162,12 @@ def generate_getter(
                             ),
                         )
                     else:
+                        # we explicitly reshape to handle the zero-length case
+                        output_shape = (
+                            handle[field][:, columns].shape
+                            if handle[field].ndim > 1
+                            else handle[field].shape
+                        )
                         setattr(
                             self,
                             f"_{name}",
@@ -172,7 +178,7 @@ def generate_getter(
                                     handle[field][:, columns]
                                     if handle[field].ndim > 1
                                     else handle[field][:]
-                                ),
+                                ).reshape(output_shape),
                                 unit,
                                 cosmo_factor=cosmo_factor,
                                 name=description,

--- a/swiftsimio/reader.py
+++ b/swiftsimio/reader.py
@@ -136,18 +136,12 @@ def generate_getter(
             with h5py.File(filename, "r") as handle:
                 try:
                     if mask is not None:
-                        # First, need to calculate data shape (which may be
-                        # non-trivial), so we read in the first value
-                        first_value = handle[field][0]
-
-                        output_type = first_value.dtype
-                        output_size = first_value.size
-
-                        if output_size != 1 and not use_columns:
-                            output_shape = (mask_size, output_size)
-                        else:
-                            output_shape = mask_size
-
+                        output_type = handle[field].dtype
+                        output_shape = (
+                            (mask_size, handle[field].shape[1])
+                            if handle[field].ndim > 1 and not use_columns
+                            else mask_size
+                        )
                         setattr(
                             self,
                             f"_{name}",

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -16,9 +16,9 @@ def create_in_memory_hdf5(filename="f1"):
     return h5py.File(filename, driver="core", mode="a", backing_store=False)
 
 
-def create_single_particle_dataset(filename: str, output_name: str):
+def create_n_particle_dataset(filename: str, output_name: str, num_parts: int = 2):
     """
-    Create an hdf5 snapshot with two particles at an identical location
+    Create an hdf5 snapshot with a desired number of identical particles.
 
     Parameters
     ----------
@@ -26,6 +26,8 @@ def create_single_particle_dataset(filename: str, output_name: str):
         name of file from which to copy metadata
     output_name: str
         name of single particle snapshot
+    num_parts: int
+        number of particles to create (default: 2)
     """
     # Create a dummy mask in order to write metadata
     data_mask = mask(filename)
@@ -41,12 +43,12 @@ def create_single_particle_dataset(filename: str, output_name: str):
 
     # Write a single particle
     particle_coords = cosmo_array(
-        [[1, 1, 1], [1, 1, 1]], data_mask.metadata.units.length
+        [[1, 1, 1]] * num_parts, data_mask.metadata.units.length
     )
-    particle_masses = cosmo_array([1, 1], data_mask.metadata.units.mass)
+    particle_masses = cosmo_array([1] * num_parts, data_mask.metadata.units.mass)
     mean_h = mean(infile["/PartType0/SmoothingLengths"])
     particle_h = cosmo_array([mean_h, mean_h], data_mask.metadata.units.length)
-    particle_ids = [1, 2]
+    particle_ids = list(range(1, num_parts + 1))
 
     coords = outfile.create_dataset("/PartType0/Coordinates", data=particle_coords)
     for name, value in infile["/PartType0/Coordinates"].attrs.items():
@@ -67,8 +69,8 @@ def create_single_particle_dataset(filename: str, output_name: str):
     # Get rid of all traces of DM
     del outfile["/Cells/Counts/PartType1"]
     del outfile["/Cells/Offsets/PartType1"]
-    nparts_total = [2, 0, 0, 0, 0, 0]
-    nparts_this_file = [2, 0, 0, 0, 0, 0]
+    nparts_total = [num_parts, 0, 0, 0, 0, 0]
+    nparts_this_file = [num_parts, 0, 0, 0, 0, 0]
     outfile["/Header"].attrs["NumPart_Total"] = nparts_total
     outfile["/Header"].attrs["NumPart_ThisFile"] = nparts_this_file
 

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -47,22 +47,30 @@ def create_n_particle_dataset(filename: str, output_name: str, num_parts: int = 
     )
     particle_masses = cosmo_array([1] * num_parts, data_mask.metadata.units.mass)
     mean_h = mean(infile["/PartType0/SmoothingLengths"])
-    particle_h = cosmo_array([mean_h, mean_h], data_mask.metadata.units.length)
+    particle_h = cosmo_array([mean_h] * num_parts, data_mask.metadata.units.length)
     particle_ids = list(range(1, num_parts + 1))
 
-    coords = outfile.create_dataset("/PartType0/Coordinates", data=particle_coords)
+    coords = outfile.create_dataset(
+        "/PartType0/Coordinates", data=particle_coords, shape=(num_parts, 3)
+    )
     for name, value in infile["/PartType0/Coordinates"].attrs.items():
         coords.attrs.create(name, value)
 
-    masses = outfile.create_dataset("/PartType0/Masses", data=particle_masses)
+    masses = outfile.create_dataset(
+        "/PartType0/Masses", data=particle_masses, shape=(num_parts,)
+    )
     for name, value in infile["/PartType0/Masses"].attrs.items():
         masses.attrs.create(name, value)
 
-    h = outfile.create_dataset("/PartType0/SmoothingLengths", data=particle_h)
+    h = outfile.create_dataset(
+        "/PartType0/SmoothingLengths", data=particle_h, shape=(num_parts,)
+    )
     for name, value in infile["/PartType0/SmoothingLengths"].attrs.items():
         h.attrs.create(name, value)
 
-    ids = outfile.create_dataset("/PartType0/ParticleIDs", data=particle_ids)
+    ids = outfile.create_dataset(
+        "/PartType0/ParticleIDs", data=particle_ids, shape=(num_parts,)
+    )
     for name, value in infile["/PartType0/ParticleIDs"].attrs.items():
         ids.attrs.create(name, value)
 
@@ -71,8 +79,10 @@ def create_n_particle_dataset(filename: str, output_name: str, num_parts: int = 
     del outfile["/Cells/Offsets/PartType1"]
     nparts_total = [num_parts, 0, 0, 0, 0, 0]
     nparts_this_file = [num_parts, 0, 0, 0, 0, 0]
+    can_have_types = [1, 0, 0, 0, 0, 0]
     outfile["/Header"].attrs["NumPart_Total"] = nparts_total
     outfile["/Header"].attrs["NumPart_ThisFile"] = nparts_this_file
+    outfile["/Header"].attrs["CanHaveTypes"] = can_have_types
 
     # Tidy up
     infile.close()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -15,6 +15,7 @@ from numpy import logical_and, isclose, float64
 from numpy import array as numpy_array
 
 from swiftsimio.objects import cosmo_array, cosmo_factor, a
+from tests.helper import create_n_particle_dataset
 
 
 def test_cosmology_metadata(cosmological_volume):
@@ -160,7 +161,6 @@ def test_cell_metadata_is_valid(cosmological_volume):
     start_offset = offsets
     stop_offset = offsets + counts
 
-    print(mask_region.centers)
     for center, start, stop in zip(
         mask_region.centers.to(data.gas.coordinates.units), start_offset, stop_offset
     ):
@@ -332,3 +332,16 @@ def test_reading_select_region_metadata_not_spatial_only(cosmological_volume):
     ).all()
 
     return
+
+
+def test_reading_empty_dataset(cosmological_volume):
+    """
+    Test that we can read in a zero-particle dataset (e.g. Type4 or Type5 present in
+    snapshot but no particles exist yet). Here we make a snapshot file with Type1
+    present but empty.
+    """
+    output_filename = "zero_particle.hdf5"
+    create_n_particle_dataset(cosmological_volume, output_filename, num_parts=0)
+    data = load(output_filename)
+    assert data.gas.masses.shape == (0,)
+    assert data.gas.coordinates.shape == (0, 3)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -205,7 +205,7 @@ def test_dithered_cell_metadata_is_valid(cosmological_volume_dithered):
     boxsize = cosmo_array(
         boxsize,
         comoving=True,
-        cosmo_factor=cosmo_factor(a**1, mask_region.metadata.a),
+        cosmo_factor=cosmo_factor(a ** 1, mask_region.metadata.a),
     )
     offsets = mask_region.offsets["dark_matter"]
     counts = mask_region.counts["dark_matter"]
@@ -248,7 +248,7 @@ def test_reading_select_region_metadata(cosmological_volume):
     boxsize = cosmo_array(
         full_data.metadata.boxsize,
         comoving=True,
-        cosmo_factor=cosmo_factor(a**1, full_data.metadata.a),
+        cosmo_factor=cosmo_factor(a ** 1, full_data.metadata.a),
     )
     restrict = cosmo_array([boxsize * 0.2, boxsize * 0.8]).T
 
@@ -299,7 +299,7 @@ def test_reading_select_region_metadata_not_spatial_only(cosmological_volume):
     boxsize = cosmo_array(
         full_data.metadata.boxsize,
         comoving=True,
-        cosmo_factor=cosmo_factor(a**1, full_data.metadata.a),
+        cosmo_factor=cosmo_factor(a ** 1, full_data.metadata.a),
     )
     restrict = cosmo_array([boxsize * 0.26, boxsize * 0.74]).T
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -7,6 +7,7 @@ be read in.
 
 import numpy as np
 from swiftsimio import load, mask
+from os import remove
 
 import h5py
 
@@ -204,7 +205,7 @@ def test_dithered_cell_metadata_is_valid(cosmological_volume_dithered):
     boxsize = cosmo_array(
         boxsize,
         comoving=True,
-        cosmo_factor=cosmo_factor(a ** 1, mask_region.metadata.a),
+        cosmo_factor=cosmo_factor(a**1, mask_region.metadata.a),
     )
     offsets = mask_region.offsets["dark_matter"]
     counts = mask_region.counts["dark_matter"]
@@ -247,7 +248,7 @@ def test_reading_select_region_metadata(cosmological_volume):
     boxsize = cosmo_array(
         full_data.metadata.boxsize,
         comoving=True,
-        cosmo_factor=cosmo_factor(a ** 1, full_data.metadata.a),
+        cosmo_factor=cosmo_factor(a**1, full_data.metadata.a),
     )
     restrict = cosmo_array([boxsize * 0.2, boxsize * 0.8]).T
 
@@ -298,7 +299,7 @@ def test_reading_select_region_metadata_not_spatial_only(cosmological_volume):
     boxsize = cosmo_array(
         full_data.metadata.boxsize,
         comoving=True,
-        cosmo_factor=cosmo_factor(a ** 1, full_data.metadata.a),
+        cosmo_factor=cosmo_factor(a**1, full_data.metadata.a),
     )
     restrict = cosmo_array([boxsize * 0.26, boxsize * 0.74]).T
 
@@ -345,3 +346,4 @@ def test_reading_empty_dataset(cosmological_volume):
     data = load(output_filename)
     assert data.gas.masses.shape == (0,)
     assert data.gas.coordinates.shape == (0, 3)
+    remove(output_filename)

--- a/tests/test_rotate_visualisations.py
+++ b/tests/test_rotate_visualisations.py
@@ -1,4 +1,4 @@
-from tests.helper import create_single_particle_dataset
+from tests.helper import create_n_particle_dataset
 from swiftsimio import load
 from swiftsimio.visualisation.projection import project_gas
 from swiftsimio.visualisation.slice import slice_gas
@@ -20,7 +20,7 @@ def test_project(cosmological_volume):
     """
     # Start from the beginning, open the file
     output_filename = "single_particle.hdf5"
-    create_single_particle_dataset(cosmological_volume, output_filename)
+    create_n_particle_dataset(cosmological_volume, output_filename)
     data = load(output_filename)
 
     unrotated = project_gas(
@@ -58,7 +58,7 @@ def test_slice(cosmological_volume):
     """
     # Start from the beginning, open the file
     output_filename = "single_particle.hdf5"
-    create_single_particle_dataset(cosmological_volume, output_filename)
+    create_n_particle_dataset(cosmological_volume, output_filename)
     data = load(output_filename)
 
     unrotated = slice_gas(
@@ -106,7 +106,7 @@ def test_render(cosmological_volume):
     """
     # Start from the beginning, open the file
     output_filename = "single_particle.hdf5"
-    create_single_particle_dataset(cosmological_volume, output_filename)
+    create_n_particle_dataset(cosmological_volume, output_filename)
     data = load(output_filename)
 
     unrotated = render_gas(


### PR DESCRIPTION
A recent(ish?) addition to SWIFT is that it reports which particle types can be present in a file with `CanHaveTypes` in the header. `swiftsimio` will recognize these and enable accessing particle types with no particles present, e.g. `data.stars` in a simulation snapshot where no stars have formed yet. Trying to access an actual field, however, had some issues:
- When no mask is active, reading a multidimensional dataset (like `coordinates`) would give a 1D result with shape `(0,)`. The desired result should be a shape of `(0, 3)`.
- When a mask is active the code would read the first row in the dataset and inspect that to determine data type and shape. If there are 0 particles, there is no first row, and this caused a crash.

I've fixed both of these cases and added test coverage. When no mask is active, the data that is read is explicitly reshaped to match the dataset shape. When a mask is active, the dataset is inspected to determine its datatype and shape, instead of inspecting the first row after reading it.