### PR TITLE
Use https to fetch test data

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import pytest
 
-webstorage_location = "http://virgodb.cosma.dur.ac.uk/swift-webstorage/IOExamples/"
+webstorage_location = "https://virgodb.cosma.dur.ac.uk/swift-webstorage/IOExamples/"
 test_data_location = "test_data/"
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def cosmological_volume():
 
 @pytest.fixture
 def cosmological_volume_dithered():
-    yield _requires("cosmological_volume.hdf5")
+    yield _requires("cosmological_volume_dithered.hdf5")
 
 
 @pytest.fixture


### PR DESCRIPTION
The server on cosma will no longer serve data through a `wget` request to the http address, we need to use https.

Also caught a bug where the "dithered" file wasn't properly fetched.