### PR TITLE
Pickle/unpickle the compression attribute along with others.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ black_formatting_env/*
 # Leftovers
 *.png
 *.hdf5
+*.pkl

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -1343,7 +1343,15 @@ class cosmo_array(unyt_array):
         np_ret = super(cosmo_array, self).__reduce__()
         obj_state = np_ret[2]
         cosmo_state = (
-            ((self.cosmo_factor, self.comoving, self.valid_transform),) + obj_state[:],
+            (
+                (
+                    self.cosmo_factor,
+                    self.comoving,
+                    self.compression,
+                    self.valid_transform,
+                ),
+            )
+            + obj_state[:],
         )
         new_ret = np_ret[:2] + cosmo_state + np_ret[3:]
         return new_ret
@@ -1361,7 +1369,9 @@ class cosmo_array(unyt_array):
             A :obj:`tuple` containing the extra state information.
         """
         super(cosmo_array, self).__setstate__(state[1:])
-        self.cosmo_factor, self.comoving, self.valid_transform = state[0]
+        self.cosmo_factor, self.comoving, self.compression, self.valid_transform = state[
+            0
+        ]
 
     # Wrap functions that return copies of cosmo_arrays so that our
     # attributes get passed through:

--- a/tests/test_cosmo_array.py
+++ b/tests/test_cosmo_array.py
@@ -121,7 +121,7 @@ class TestCosmoArrayInit:
         arr = cosmo_array(
             np.ones(5),
             units=u.Mpc,
-            cosmo_factor=cosmo_factor(a**1, 1.0),
+            cosmo_factor=cosmo_factor(a ** 1, 1.0),
             comoving=False,
         )
         assert hasattr(arr, "cosmo_factor")
@@ -146,7 +146,7 @@ class TestCosmoArrayInit:
         arr = cosmo_array(
             [1, 1, 1, 1, 1],
             units=u.Mpc,
-            cosmo_factor=cosmo_factor(a**1, 1.0),
+            cosmo_factor=cosmo_factor(a ** 1, 1.0),
             comoving=False,
         )
         assert hasattr(arr, "cosmo_factor")
@@ -169,7 +169,7 @@ class TestCosmoArrayInit:
         # also with a cosmo_factor argument instead of scale_factor & scale_exponent
         arr = cosmo_array(
             u.unyt_array(np.ones(5), units=u.Mpc),
-            cosmo_factor=cosmo_factor(a**1, 1.0),
+            cosmo_factor=cosmo_factor(a ** 1, 1.0),
             comoving=False,
         )
         assert hasattr(arr, "cosmo_factor")
@@ -195,7 +195,7 @@ class TestCosmoArrayInit:
         # also with a cosmo_factor argument instead of scale_factor & scale_exponent
         arr = cosmo_array(
             [u.unyt_array(1, units=u.Mpc) for _ in range(5)],
-            cosmo_factor=cosmo_factor(a**1, 1.0),
+            cosmo_factor=cosmo_factor(a ** 1, 1.0),
             comoving=False,
         )
         assert hasattr(arr, "cosmo_factor")
@@ -219,7 +219,7 @@ class TestCosmoArrayInit:
         )
         assert isinstance(arr, cosmo_array)
         assert hasattr(arr, "cosmo_factor") and arr.cosmo_factor == cosmo_factor(
-            a**1, 1
+            a ** 1, 1
         )
         assert hasattr(arr, "comoving") and arr.comoving is False
         # also with a cosmo_factor argument instead of scale_factor & scale_exponent
@@ -229,14 +229,14 @@ class TestCosmoArrayInit:
                     [1],
                     units=u.Mpc,
                     comoving=False,
-                    cosmo_factor=cosmo_factor(a**1, 1.0),
+                    cosmo_factor=cosmo_factor(a ** 1, 1.0),
                 )
                 for _ in range(5)
             ]
         )
         assert isinstance(arr, cosmo_array)
         assert hasattr(arr, "cosmo_factor") and arr.cosmo_factor == cosmo_factor(
-            a**1, 1
+            a ** 1, 1
         )
         assert hasattr(arr, "comoving") and arr.comoving is False
 
@@ -845,9 +845,9 @@ class TestNumpyFunctions:
             assert (
                 result[0].cosmo_factor
                 == {
-                    np.histogram: cosmo_factor(a**-1, 1.0),
-                    np.histogram2d: cosmo_factor(a**-3, 1.0),
-                    np.histogramdd: cosmo_factor(a**-6, 1.0),
+                    np.histogram: cosmo_factor(a ** -1, 1.0),
+                    np.histogram2d: cosmo_factor(a ** -3, 1.0),
+                    np.histogramdd: cosmo_factor(a ** -6, 1.0),
                 }[func]
             )
         elif density and isinstance(weights, cosmo_array):
@@ -855,9 +855,9 @@ class TestNumpyFunctions:
             assert (
                 result[0].cosmo_factor
                 == {
-                    np.histogram: cosmo_factor(a**0, 1.0),
-                    np.histogram2d: cosmo_factor(a**-2, 1.0),
-                    np.histogramdd: cosmo_factor(a**-5, 1.0),
+                    np.histogram: cosmo_factor(a ** 0, 1.0),
+                    np.histogram2d: cosmo_factor(a ** -2, 1.0),
+                    np.histogramdd: cosmo_factor(a ** -5, 1.0),
                 }[func]
             )
         elif not density and isinstance(weights, cosmo_array):
@@ -865,9 +865,9 @@ class TestNumpyFunctions:
             assert (
                 result[0].cosmo_factor
                 == {
-                    np.histogram: cosmo_factor(a**1, 1.0),
-                    np.histogram2d: cosmo_factor(a**1, 1.0),
-                    np.histogramdd: cosmo_factor(a**1, 1.0),
+                    np.histogram: cosmo_factor(a ** 1, 1.0),
+                    np.histogram2d: cosmo_factor(a ** 1, 1.0),
+                    np.histogramdd: cosmo_factor(a ** 1, 1.0),
                 }[func]
             )
         ret_bins = {
@@ -879,9 +879,9 @@ class TestNumpyFunctions:
             ret_bins,
             (
                 [
-                    cosmo_factor(a**1, 1.0),
-                    cosmo_factor(a**2, 1.0),
-                    cosmo_factor(a**3, 1.0),
+                    cosmo_factor(a ** 1, 1.0),
+                    cosmo_factor(a ** 2, 1.0),
+                    cosmo_factor(a ** 3, 1.0),
                 ]
             ),
         ):
@@ -914,7 +914,7 @@ class TestNumpyFunctions:
         res = ca(np.arange(3)).dot(ca(np.arange(3)))
         assert isinstance(res, cosmo_quantity)
         assert res.comoving is False
-        assert res.cosmo_factor == cosmo_factor(a**2, 0.5)
+        assert res.cosmo_factor == cosmo_factor(a ** 2, 0.5)
         assert res.valid_transform is True
 
 
@@ -954,7 +954,7 @@ class TestCosmoQuantity:
         )
         res = getattr(cq, func)(*args)
         assert res.comoving is False
-        assert res.cosmo_factor == cosmo_factor(a**1, 1.0)
+        assert res.cosmo_factor == cosmo_factor(a ** 1, 1.0)
         assert res.valid_transform is True
 
     def test_round(self):
@@ -972,7 +972,7 @@ class TestCosmoQuantity:
         res = round(cq)
         assert res.value == 1.0
         assert res.comoving is False
-        assert res.cosmo_factor == cosmo_factor(a**1, 1.0)
+        assert res.cosmo_factor == cosmo_factor(a ** 1, 1.0)
         assert res.valid_transform is True
 
     def test_scalar_return_func(self):
@@ -1006,7 +1006,7 @@ class TestCosmoQuantity:
         )
         res = getattr(cq, prop)
         assert res.comoving is False
-        assert res.cosmo_factor == cosmo_factor(a**1, 1.0)
+        assert res.cosmo_factor == cosmo_factor(a ** 1, 1.0)
         assert res.valid_transform is True
 
 
@@ -1085,7 +1085,7 @@ class TestMultiplicationByUnyt:
         multiplied_by_quantity = ca * (1 * u.Mpc)  # parentheses very important here
         # get the same result twice through left-sided multiplication and division:
         lmultiplied_by_unyt = ca * u.Mpc
-        ldivided_by_unyt = ca / u.Mpc**-1
+        ldivided_by_unyt = ca / u.Mpc ** -1
 
         for multiplied_by_unyt in (lmultiplied_by_unyt, ldivided_by_unyt):
             assert isinstance(multiplied_by_quantity, cosmo_array)
@@ -1121,7 +1121,7 @@ class TestMultiplicationByUnyt:
         multiplied_by_quantity = ca * (1 * u.Mpc)  # parentheses very important here
         # get 2x the same result through right-sided multiplication and division:
         rmultiplied_by_unyt = u.Mpc * ca
-        rdivided_by_unyt = u.Mpc**2 / ca
+        rdivided_by_unyt = u.Mpc ** 2 / ca
 
         for multiplied_by_unyt in (rmultiplied_by_unyt, rdivided_by_unyt):
             assert isinstance(multiplied_by_quantity, cosmo_array)
@@ -1140,7 +1140,7 @@ class TestPickle:
     def test_pickle(self):
         attrs = {
             "comoving": False,
-            "cosmo_factor": cosmo_factor(a**1, 0.5),
+            "cosmo_factor": cosmo_factor(a ** 1, 0.5),
             "compression": "FMantissa9",
             "valid_transform": True,
         }

--- a/tests/test_cosmo_array.py
+++ b/tests/test_cosmo_array.py
@@ -8,6 +8,7 @@ import warnings
 import numpy as np
 import unyt as u
 from copy import copy, deepcopy
+import pickle
 from swiftsimio.objects import cosmo_array, cosmo_quantity, cosmo_factor, a
 
 savetxt_file = "saved_array.txt"
@@ -120,7 +121,7 @@ class TestCosmoArrayInit:
         arr = cosmo_array(
             np.ones(5),
             units=u.Mpc,
-            cosmo_factor=cosmo_factor(a ** 1, 1.0),
+            cosmo_factor=cosmo_factor(a**1, 1.0),
             comoving=False,
         )
         assert hasattr(arr, "cosmo_factor")
@@ -145,7 +146,7 @@ class TestCosmoArrayInit:
         arr = cosmo_array(
             [1, 1, 1, 1, 1],
             units=u.Mpc,
-            cosmo_factor=cosmo_factor(a ** 1, 1.0),
+            cosmo_factor=cosmo_factor(a**1, 1.0),
             comoving=False,
         )
         assert hasattr(arr, "cosmo_factor")
@@ -168,7 +169,7 @@ class TestCosmoArrayInit:
         # also with a cosmo_factor argument instead of scale_factor & scale_exponent
         arr = cosmo_array(
             u.unyt_array(np.ones(5), units=u.Mpc),
-            cosmo_factor=cosmo_factor(a ** 1, 1.0),
+            cosmo_factor=cosmo_factor(a**1, 1.0),
             comoving=False,
         )
         assert hasattr(arr, "cosmo_factor")
@@ -194,7 +195,7 @@ class TestCosmoArrayInit:
         # also with a cosmo_factor argument instead of scale_factor & scale_exponent
         arr = cosmo_array(
             [u.unyt_array(1, units=u.Mpc) for _ in range(5)],
-            cosmo_factor=cosmo_factor(a ** 1, 1.0),
+            cosmo_factor=cosmo_factor(a**1, 1.0),
             comoving=False,
         )
         assert hasattr(arr, "cosmo_factor")
@@ -218,7 +219,7 @@ class TestCosmoArrayInit:
         )
         assert isinstance(arr, cosmo_array)
         assert hasattr(arr, "cosmo_factor") and arr.cosmo_factor == cosmo_factor(
-            a ** 1, 1
+            a**1, 1
         )
         assert hasattr(arr, "comoving") and arr.comoving is False
         # also with a cosmo_factor argument instead of scale_factor & scale_exponent
@@ -228,14 +229,14 @@ class TestCosmoArrayInit:
                     [1],
                     units=u.Mpc,
                     comoving=False,
-                    cosmo_factor=cosmo_factor(a ** 1, 1.0),
+                    cosmo_factor=cosmo_factor(a**1, 1.0),
                 )
                 for _ in range(5)
             ]
         )
         assert isinstance(arr, cosmo_array)
         assert hasattr(arr, "cosmo_factor") and arr.cosmo_factor == cosmo_factor(
-            a ** 1, 1
+            a**1, 1
         )
         assert hasattr(arr, "comoving") and arr.comoving is False
 
@@ -844,9 +845,9 @@ class TestNumpyFunctions:
             assert (
                 result[0].cosmo_factor
                 == {
-                    np.histogram: cosmo_factor(a ** -1, 1.0),
-                    np.histogram2d: cosmo_factor(a ** -3, 1.0),
-                    np.histogramdd: cosmo_factor(a ** -6, 1.0),
+                    np.histogram: cosmo_factor(a**-1, 1.0),
+                    np.histogram2d: cosmo_factor(a**-3, 1.0),
+                    np.histogramdd: cosmo_factor(a**-6, 1.0),
                 }[func]
             )
         elif density and isinstance(weights, cosmo_array):
@@ -854,9 +855,9 @@ class TestNumpyFunctions:
             assert (
                 result[0].cosmo_factor
                 == {
-                    np.histogram: cosmo_factor(a ** 0, 1.0),
-                    np.histogram2d: cosmo_factor(a ** -2, 1.0),
-                    np.histogramdd: cosmo_factor(a ** -5, 1.0),
+                    np.histogram: cosmo_factor(a**0, 1.0),
+                    np.histogram2d: cosmo_factor(a**-2, 1.0),
+                    np.histogramdd: cosmo_factor(a**-5, 1.0),
                 }[func]
             )
         elif not density and isinstance(weights, cosmo_array):
@@ -864,9 +865,9 @@ class TestNumpyFunctions:
             assert (
                 result[0].cosmo_factor
                 == {
-                    np.histogram: cosmo_factor(a ** 1, 1.0),
-                    np.histogram2d: cosmo_factor(a ** 1, 1.0),
-                    np.histogramdd: cosmo_factor(a ** 1, 1.0),
+                    np.histogram: cosmo_factor(a**1, 1.0),
+                    np.histogram2d: cosmo_factor(a**1, 1.0),
+                    np.histogramdd: cosmo_factor(a**1, 1.0),
                 }[func]
             )
         ret_bins = {
@@ -878,9 +879,9 @@ class TestNumpyFunctions:
             ret_bins,
             (
                 [
-                    cosmo_factor(a ** 1, 1.0),
-                    cosmo_factor(a ** 2, 1.0),
-                    cosmo_factor(a ** 3, 1.0),
+                    cosmo_factor(a**1, 1.0),
+                    cosmo_factor(a**2, 1.0),
+                    cosmo_factor(a**3, 1.0),
                 ]
             ),
         ):
@@ -913,7 +914,7 @@ class TestNumpyFunctions:
         res = ca(np.arange(3)).dot(ca(np.arange(3)))
         assert isinstance(res, cosmo_quantity)
         assert res.comoving is False
-        assert res.cosmo_factor == cosmo_factor(a ** 2, 0.5)
+        assert res.cosmo_factor == cosmo_factor(a**2, 0.5)
         assert res.valid_transform is True
 
 
@@ -953,7 +954,7 @@ class TestCosmoQuantity:
         )
         res = getattr(cq, func)(*args)
         assert res.comoving is False
-        assert res.cosmo_factor == cosmo_factor(a ** 1, 1.0)
+        assert res.cosmo_factor == cosmo_factor(a**1, 1.0)
         assert res.valid_transform is True
 
     def test_round(self):
@@ -971,7 +972,7 @@ class TestCosmoQuantity:
         res = round(cq)
         assert res.value == 1.0
         assert res.comoving is False
-        assert res.cosmo_factor == cosmo_factor(a ** 1, 1.0)
+        assert res.cosmo_factor == cosmo_factor(a**1, 1.0)
         assert res.valid_transform is True
 
     def test_scalar_return_func(self):
@@ -1005,7 +1006,7 @@ class TestCosmoQuantity:
         )
         res = getattr(cq, prop)
         assert res.comoving is False
-        assert res.cosmo_factor == cosmo_factor(a ** 1, 1.0)
+        assert res.cosmo_factor == cosmo_factor(a**1, 1.0)
         assert res.valid_transform is True
 
 
@@ -1084,7 +1085,7 @@ class TestMultiplicationByUnyt:
         multiplied_by_quantity = ca * (1 * u.Mpc)  # parentheses very important here
         # get the same result twice through left-sided multiplication and division:
         lmultiplied_by_unyt = ca * u.Mpc
-        ldivided_by_unyt = ca / u.Mpc ** -1
+        ldivided_by_unyt = ca / u.Mpc**-1
 
         for multiplied_by_unyt in (lmultiplied_by_unyt, ldivided_by_unyt):
             assert isinstance(multiplied_by_quantity, cosmo_array)
@@ -1120,7 +1121,7 @@ class TestMultiplicationByUnyt:
         multiplied_by_quantity = ca * (1 * u.Mpc)  # parentheses very important here
         # get 2x the same result through right-sided multiplication and division:
         rmultiplied_by_unyt = u.Mpc * ca
-        rdivided_by_unyt = u.Mpc ** 2 / ca
+        rdivided_by_unyt = u.Mpc**2 / ca
 
         for multiplied_by_unyt in (rmultiplied_by_unyt, rdivided_by_unyt):
             assert isinstance(multiplied_by_quantity, cosmo_array)
@@ -1129,3 +1130,26 @@ class TestMultiplicationByUnyt:
                 multiplied_by_unyt.to_value(multiplied_by_quantity.units),
                 multiplied_by_quantity.to_value(multiplied_by_quantity.units),
             )
+
+
+class TestPickle:
+    """
+    Test that the cosmo_array attributes survive being pickled and unpickled.
+    """
+
+    def test_pickle(self):
+        attrs = {
+            "comoving": False,
+            "cosmo_factor": cosmo_factor(a**1, 0.5),
+            "compression": "FMantissa9",
+            "valid_transform": True,
+        }
+        ca = cosmo_array([123, 456], u.Mpc, **attrs)
+        try:
+            pickle.dump(ca, open("ca.pkl", "wb"))
+            unpickled_ca = pickle.load(open("ca.pkl", "rb"))
+        finally:
+            if os.path.isfile("ca.pkl"):
+                os.remove("ca.pkl")
+        for attr_name, attr_value in attrs.items():
+            assert getattr(unpickled_ca, attr_name) == attr_value


### PR DESCRIPTION
The `compression` attribute of `cosmo_array` was omitted from the list of attributes to pack/unpack in the `__setstate__` and `__getstate__` methods that are called for object (de-)serialization (e.g. pickle). This could lead to `AttributeError`s such as when using parallelization libraries such as `joblib`, see #236 

The attribute is now pickled/unpickled along with the others, and a regression test is added.