### PR TITLE
Fix a deprecated import and an unclosed file in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
+    "astropy>=5.0",
     "numpy>=2.1.0",
     "h5py",
     "unyt>=3.0.4",

--- a/swiftsimio/conversions.py
+++ b/swiftsimio/conversions.py
@@ -8,7 +8,7 @@ from swiftsimio.objects import cosmo_quantity
 
 if ASTROPY_AVAILABLE:
     from astropy.cosmology import w0waCDM
-    from astropy.cosmology.core import Cosmology
+    from astropy.cosmology import Cosmology
     import astropy.constants as const
     import astropy.units as astropy_units
     import numpy as np

--- a/tests/test_cosmo_array.py
+++ b/tests/test_cosmo_array.py
@@ -1146,8 +1146,10 @@ class TestPickle:
         }
         ca = cosmo_array([123, 456], u.Mpc, **attrs)
         try:
-            pickle.dump(ca, open("ca.pkl", "wb"))
-            unpickled_ca = pickle.load(open("ca.pkl", "rb"))
+            with open("ca.pkl", "wb") as pickle_handle:
+                pickle.dump(ca, pickle_handle)
+            with open("ca.pkl", "rb") as pickle_handle:
+                unpickled_ca = pickle.load(pickle_handle)
         finally:
             if os.path.isfile("ca.pkl"):
                 os.remove("ca.pkl")


### PR DESCRIPTION
Just two straightforward fixes for warnings cropping up in the test suite.