### PR TITLE
Pin python version in CI to != 3.13.4

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "~3.13.0 < 3.13.3 || ~3.13.5"]  # exclude 3.13.4
 
     steps:
     - name: Checkout swiftsimio

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "~3.13.0 < 3.13.3 || ~3.13.5"]  # exclude 3.13.4
+        python-version: ["3.10", "3.11", "3.12", "~3.13.0 <= 3.13.3 || ~3.13.5"]  # exclude 3.13.4
 
     steps:
     - name: Checkout swiftsimio


### PR DESCRIPTION
Python 3.13.4 has some [known issues](https://www.python.org/downloads/release/python-3134/) (see also [this](https://github.com/numba/numba/issues/10101)). The version used in CI currently defaults to 3.13.4; this PR sets the version requirement to the latest available *except* 3.13.4.