### PR TITLE
Revise docs with new visualisation backend locations

### DIFF
--- a/docs/source/visualisation/projection.rst
+++ b/docs/source/visualisation/projection.rst
@@ -357,17 +357,16 @@ smoothing lengths, and smoothed quantities, to generate a pixel grid that
 represents the smoothed version of the data.
 
 This API is available through
-:obj:`swiftsimio.visualisation.projection_backends.backends["scatter"]` and
-:obj:`swiftsimio.visualisation.projection_backends.backends_parallel["scatter"]` for the parallel
-version. The parallel version uses significantly more memory as it allocates
+:obj:`swiftsimio.visualisation.projection_backends.backends` and
+:obj:`swiftsimio.visualisation.projection_backends.backends_parallel` for parallel implementations. The parallel versions use significantly more memory as they allocate
 a thread-local image array for each thread, summing them in the end. Here we
-will only describe the ``scatter`` variant, but they behave in the exact same way.
+will only describe the ``fast`` variant, but they behave in the exact same way.
 
-By default this uses the "fast" backend. To use the others, you can select them
+The default backend used by :mod:`swiftsimio` is ``fast``. To use the others (e.g. ``histogram``, ``subsampled``, ``gpu``, etc.), you can select them
 manually from the module, or by using the ``backends`` and ``backends_parallel``
 dictionaries in :mod:`swiftsimio.visualisation.projection_backends`.
 
-To use this function, you will need:
+To use these functions, you will need:
 
 + x-positions of all of your particles, ``x``.
 + y-positions of all of your particles, ``y``.
@@ -385,12 +384,13 @@ they will not crash the code, and may even contribute to the image if their
 smoothing lengths overlap with [0, 1]. You will need to re-scale your data
 such that it lives within this range. You should also pass raw numpy arrays (not
 :class:`~swiftsimio.objects.cosmo_array` or :class:`~unyt.array.unyt_array`, the
-inputs are dimensionless). Then you may use the function as follows:
+inputs are dimensionless). Then you may use the functions as follows:
 
 .. code-block:: python
 
-   from swiftsimio.visualisation.projection import scatter
+   from swiftsimio.visualisation.projection_backends import backends
 
+   scatter = backends["fast"]
    # Using the variable names from above
    out = scatter(x=x, y=y, h=h, m=m, res=res)
 

--- a/docs/source/visualisation/slice.rst
+++ b/docs/source/visualisation/slice.rst
@@ -211,11 +211,11 @@ smoothing lengths, and smoothed quantities, to generate a pixel grid that
 represents the smoothed, sliced, version of the data.
 
 This API is available through
-:func:`swiftsimio.visualisation.slice_backends.backends["sph"]` and
-:func:`swiftsimio.visualisation.slice_backends.backends_parallel["sph"]` for the parallel
-version. The parallel version uses significantly more memory as it allocates
+:obj:`swiftsimio.visualisation.slice_backends.backends` and
+:obj:`swiftsimio.visualisation.slice_backends.backends_parallel` for parallel
+implementations. The parallel versions uses significantly more memory as they allocate
 a thread-local image array for each thread, summing them in the end. Here we
-will only describe the ``scatter`` variant, but they behave in the exact same way.
+will only describe the ``sph`` variant, but they behave in the exact same way.
 
 To use this function, you will need:
 
@@ -243,8 +243,9 @@ Then you may use the function as follows:
 
 .. code-block:: python
 
-   from swiftsimio.visualisation.slice import slice_scatter
+   from swiftsimio.visualisation.slice_backends import backends
 
+   slice_scatter = backends["sph"]
    # Using the variable names from above
    out = slice_scatter(x=x, y=y, z=z, h=h, m=m, z_slice=z_slice, res=res)
 

--- a/docs/source/visualisation/volume_render.rst
+++ b/docs/source/visualisation/volume_render.rst
@@ -280,11 +280,11 @@ smoothing lengths, and smoothed quantities, to generate a pixel grid that
 represents the smoothed, volume rendered, version of the data.
 
 This API is available through
-:func:`swiftsimio.visualisation.volume_render_backends.backends["scatter"]` and
-:func:`swiftsimio.visualisation.volume_render_backends.backends_parallel["scatter"]` for the parallel
-version. The parallel version uses significantly more memory as it allocates
+:obj:`swiftsimio.visualisation.volume_render_backends.backends` and
+:obj:`swiftsimio.visualisation.volume_render_backends.backends_parallel` for parallel
+implementations. The parallel versions use significantly more memory as they allocate
 a thread-local image array for each thread, summing them in the end. Here we
-will only describe the ``scatter`` variant, but they behave in the exact same way.
+will only describe the ``scatter`` variant (currently the only option).
 
 To use this function, you will need:
 
@@ -309,10 +309,11 @@ Then you may use the function as follows:
 
 .. code-block:: python
 
-   from swiftsimio.visualisation.volume_render import scatter
+   from swiftsimio.visualisation.volume_render_backends import backends
 
+   volume_render_scatter = backends["scatter"]
    # Using the variable names from above
-   out = scatter(x=x, y=y, z=z, h=h, m=m, res=res)
+   out = volume_render_scatter(x=x, y=y, z=z, h=h, m=m, res=res)
 
 ``out`` will be a 3D :class:`~numpy.ndarray` grid of shape ``[res, res, res]``. You will
 need to re-scale this back to your original dimensions to get it in the


### PR DESCRIPTION
Closes #240 

I missed out updating a couple of documentation examples during the refactor of the visualisation tools in v10. Thanks to Will for spotting this - the example imports should all work now.