### PR TITLE
Behaviour when combining physical and comoving arrays

### DIFF
--- a/swiftsimio/_array_functions.py
+++ b/swiftsimio/_array_functions.py
@@ -872,7 +872,6 @@ def _prepare_array_func_args(*args, _default_cm: bool = True, **kwargs) -> dict:
             for arg in args:
                 if not arg.valid_transform:
                     _default_cm = False
-                    # TODO: Raise warning?
                     break
         if _default_cm:
             args = [

--- a/tests/test_physical_conversion.py
+++ b/tests/test_physical_conversion.py
@@ -43,7 +43,9 @@ def test_convert_to_value(cosmological_volume_only_single):
 
 def test_combine_physical_comoving(cosmological_volume_only_single):
     """
-    Check that we can combine physical and comoving quantities.
+    When combining a physical and comoving array we default to converting them
+    both to comoving if possible. Check that we can still combine a physical-only
+    array (valid_transform=False) with a comoving array.
     """
     comoving_arr = cosmo_array(
         u.unyt_array(np.ones(5), units=u.kpc),


### PR DESCRIPTION
When combining a physical array which cannot be converted to comoving (e.g. luminosities) with a comoving array (e.g. masses) we get an `InvalidConversionError`. This happens because we try and convert the physical array to comoving rather than converting the comoving array to physical. Forcing the conversion to physical works fine (e.g. `snap.stars.luminosities.GAMA_r / snap.stars.masses.to_physical()` runs with no issue). Thanks to @VictorForouhar for finding

I've kept the default as trying to convert the arrays to comoving, but added a fallback if that isn't possible. Do we want to throw a warning in this case?