### PR TITLE
Use re match

### DIFF
--- a/swiftsimio/metadata/objects.py
+++ b/swiftsimio/metadata/objects.py
@@ -1157,7 +1157,7 @@ class SWIFTSnapshotMetadata(SWIFTMetadata):
         compiled = re.compile(regex)
 
         for key, data in zip(available_keys, available_data):
-            matched = compiled.matched(key)
+            matched = compiled.match(key)
             snake_case = _convert_snake_to_camel(key)
 
             if matched:


### PR DESCRIPTION
I tried to open a COLIBRE file using `10.7.0` and get the following error

```---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
File /tmp/ipython_swiftsimio.py:3
      1 import swiftsimio as sw
      2 filename = '/cosma8/data/dp004/colibre/Runs/L0025N0188/Thermal/snapshots/colibre_0127/colibre_0127.hdf5'
----> 3 data = sw.load(filename)

File ~/swiftsimio/swiftsimio/__init__.py:179, in load(filename, mask)
    176     filename = Path(filename)
    178 with h5py.File(filename, "r") as handle:
--> 179     data = SWIFTDataset(filename, mask=mask, handle=handle)
    181 return data

File ~/swiftsimio/swiftsimio/reader.py:682, in SWIFTDataset.__init__(self, filename, mask, handle)
    679     self.mask.convert_masks_to_ranges()
    681 self.get_units()
--> 682 self.get_metadata()
    683 self.create_datasets()
    685 self._close_handle_if_manager()

File ~/swiftsimio/swiftsimio/reader.py:730, in SWIFTDataset.get_metadata(self)
    728     self.metadata = self.mask.metadata
    729 else:
--> 730     self.metadata = _metadata_discriminator(
    731         self.filename, self.units, handle=self.handle
    732     )
    734 return

File ~/swiftsimio/swiftsimio/metadata/objects.py:1068, in _metadata_discriminator(filename, units, handle)
   1065     file_type = file_type.decode("utf-8")
   1067 if file_type in ["FullVolume"]:
-> 1068     return SWIFTSnapshotMetadata(filename, units, handle=handle)
   1069 elif file_type in ["SOAP"]:
   1070     return SWIFTSOAPMetadata(filename, units, handle=handle)

File ~/swiftsimio/swiftsimio/metadata/objects.py:1106, in SWIFTSnapshotMetadata.__init__(self, filename, units, handle)
   1104 self.get_metadata()
   1105 self.get_named_column_metadata()
-> 1106 self.get_mapping_metadata()
   1108 self.postprocess_header()
   1110 self.load_groups()

File ~/swiftsimio/swiftsimio/metadata/objects.py:1160, in SWIFTSnapshotMetadata.get_mapping_metadata(self)
   1157 compiled = re.compile(regex)
   1159 for key, data in zip(available_keys, available_data):
-> 1160     matched = compiled.matched(key)
   1161     snake_case = _convert_snake_to_camel(key)
   1163     if matched:

AttributeError: 're.Pattern' object has no attribute 'matched'
```

This was introduced during the refactor in https://github.com/SWIFTSIM/swiftsimio/pull/265. I guess we need to add a test, but I don't have time this afternoon sorry. I can do it next week, but could we maybe merge this and release in the meantime, since people won't be able to open colibre snapshots with this version