### PR TITLE
Fix check for dropping to single cell in volume render

### DIFF
--- a/swiftsimio/visualisation/volume_render_backends/scatter.py
+++ b/swiftsimio/visualisation/volume_render_backends/scatter.py
@@ -96,7 +96,7 @@ def scatter(
     float_res_64 = np.float64(res)
 
     # If the kernel width is smaller than this, we drop to just PIC method
-    drop_to_single_cell = pixel_width * 0.5
+    drop_to_single_cell = pixel_width * np.sqrt(3.0) / 2.0
 
     # Pre-calculate this constant for use with the above
     inverse_cell_volume = float_res * float_res * float_res
@@ -317,6 +317,7 @@ def scatter_limited_z(
     float_res_z_64 = np.float64(res_z)
 
     # If the kernel width is smaller than this, we drop to just PIC method
+    # TODO: Check that this actually works!
     drop_to_single_cell = pixel_width * 0.5
     drop_to_single_cell_z = pixel_width_z * 0.5
 


### PR DESCRIPTION
The volume render was sometimes missing particles altogether because their smoothing kernels did not encompass any cell centers. This is due to an incorrect one-half factor instead of sqrt(3) / 2 when checking how big the kernel is relative to the cell sizes. 

I did not modify the `scatter_limited_z` function, since that one isn't used at the moment and is not working anyways as far as I am aware.