### PR TITLE
Expose rotation submodule

### DIFF
--- a/swiftsimio/visualisation/__init__.py
+++ b/swiftsimio/visualisation/__init__.py
@@ -4,6 +4,7 @@ from .projection import project_gas, project_pixel_grid
 from .slice import slice_gas
 from .volume_render import render_gas
 from .smoothing_length import generate_smoothing_lengths
+from . import rotation
 
 __all__ = [
     "project_gas",
@@ -11,4 +12,5 @@ __all__ = [
     "slice_gas",
     "render_gas",
     "generate_smoothing_lengths",
+    "rotation",
 ]


### PR DESCRIPTION
Rotations had to be imported explicitly, which I don't think should be required.

```
In [1]: import swiftsimio as sw
sw.
In [2]: sw.visualisation.rotation
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[2], line 1
----> 1 sw.visualisation.rotation

AttributeError: module 'swiftsimio.visualisation' has no attribute 'rotation'

In [3]: import swiftsimio.visualisation.rotation
```