### PR TITLE
Lazy-load field metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ packages = [
 
 [project]
 name = "swiftsimio"
-version="12.0.0"
+version="12.1.0"
 authors = [
     { name="Josh Borrow", email="josh@joshborrow.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ packages = [
     "swiftsimio.metadata.unit",
     "swiftsimio.metadata.writer",
     "swiftsimio.metadata.soap",
+    "swiftsimio.metadata.field",
     "swiftsimio.visualisation",
     "swiftsimio.visualisation.projection_backends",
     "swiftsimio.visualisation.slice_backends",

--- a/swiftsimio/masks.py
+++ b/swiftsimio/masks.py
@@ -5,6 +5,11 @@ import h5py
 import numpy as np
 from pathlib import Path
 
+from swiftsimio.metadata.field.attr_reader import (
+    load_field_units as _load_field_units,
+    load_field_cosmo_factor as _load_field_cosmo_factor,
+    load_field_physical as _load_field_physical,
+)
 from swiftsimio.metadata.objects import SWIFTMetadata
 from swiftsimio.objects import InvalidSnapshot, cosmo_array, cosmo_quantity
 from swiftsimio.accelerated import ranges_from_array
@@ -423,36 +428,19 @@ class SWIFTMask(HandleProvider):
         current_mask = getattr(self, data_name)
 
         group_metadata = getattr(self.metadata, f"{group_name}_properties")
-        unit_dict = {
-            k: v for k, v in zip(group_metadata.field_names, group_metadata.field_units)
-        }
-
-        unit = unit_dict[quantity]
 
         handle_dict = {
             k: v for k, v in zip(group_metadata.field_names, group_metadata.field_paths)
         }
-
         handle = handle_dict[quantity]
-
-        physical_dict = {
-            k: v
-            for k, v in zip(group_metadata.field_names, group_metadata.field_physicals)
-        }
-
-        physical = physical_dict[quantity]
-
-        cosmologies_dict = {
-            k: v
-            for k, v in zip(
-                group_metadata.field_names, group_metadata.field_cosmologies
-            )
-        }
-
-        cosmology_factor = cosmologies_dict[quantity]
 
         # Load in the relevant data.
         with self.metadata.open_file() as h5file:
+            field_attributes = h5file[handle].attrs
+            unit = _load_field_units(field_attributes, self.metadata.units)
+            physical = _load_field_physical(field_attributes)
+            cf = _load_field_cosmo_factor(field_attributes, self.metadata)
+
             if isinstance(h5file, (h5py.File, h5py.Group)):
                 # When reading from a local HDF5 file this is faster than
                 # just using the boolean indexing because h5py has slow
@@ -468,7 +456,7 @@ class SWIFTMask(HandleProvider):
             data,
             units=unit,
             comoving=not physical,
-            cosmo_factor=cosmology_factor,
+            cosmo_factor=cf,
         )
 
         new_mask = np.logical_and.reduce([data > lower, data <= upper])

--- a/swiftsimio/metadata/field/attr_reader.py
+++ b/swiftsimio/metadata/field/attr_reader.py
@@ -1,0 +1,164 @@
+"""Helper functions to read and parse the metadata attached to individual datasets."""
+
+from swiftsimio.objects import cosmo_factor
+from swiftsimio.metadata.objects import (
+    SWIFTUnits,
+    SWIFTMetadata,
+)
+
+import h5py
+import unyt
+
+
+def load_field_units(
+    field_attributes: h5py.AttributeManager, unit_metadata: SWIFTUnits
+) -> unyt.Unit:
+    """
+    Get the units from the HDF5 attribute for a field.
+
+    Parameters
+    ----------
+    field_attributes : ~h5py._hl.attrs.AttributeManager
+        The :mod:`h5py` interface to the attributes for the field.
+
+    unit_metadata : ~swiftsimio.metadata.object.SWIFTUnits
+        The metadata describing the unit system for the dataset.
+
+    Returns
+    -------
+    unyt.Unit
+        The loaded units.
+    """
+    unit_dict = {
+        "I": unit_metadata.current,
+        "L": unit_metadata.length,
+        "M": unit_metadata.mass,
+        "T": unit_metadata.temperature,
+        "t": unit_metadata.time,
+    }
+    units = unyt.dimensionless
+    for unit_type, unit in unit_dict.items():
+        # We store the 'unit exponent' in the SWIFT metadata. This corresponds to the
+        # power that we need to raise each unit to, to construct the units for this field.
+        unit_exponent = field_attributes[f"U_{unit_type} exponent"][0]
+        # Check if the exponent is 0 manually because of float precision
+        if unit_exponent != 0.0:
+            units = units * unit**unit_exponent
+    # We can simplify like this because e.g.:
+    # dimensionless / dimensionless == dimensionless
+    # and dimensionless * Mpc / dimensionless == Mpc
+    return units / unyt.dimensionless
+
+
+def load_field_description(field_attributes: h5py.AttributeManager) -> str:
+    """
+    Get the text description from the HDF5 attribute for a field.
+
+    A description of the mask is included if present (e.g. for SOAP filetypes).
+
+    Parameters
+    ----------
+    field_attributes : ~h5py._hl.attrs.AttributeManager
+        The :mod:`h5py` interface to the attributes for the field.
+
+    Returns
+    -------
+    str
+        The field description.
+    """
+    description = field_attributes.get("Description", "No description available.")
+    if hasattr(description, "decode"):
+        description = description.decode("utf-8")
+    mask_str = (
+        (
+            "Only computed for objects where "
+            f"{' + '.join(field_attributes['Mask Datasets'])} "
+            f">= {field_attributes['Mask Threshold']}."
+        )
+        if field_attributes.get("Masked", False)
+        else "Not masked."
+    )
+    return f"{description} {mask_str}"
+
+
+def load_field_compression(field_attributes: h5py.AttributeManager) -> str:
+    """
+    Get the description of the compression filters from the HDF5 attribute for a field.
+
+    Parameters
+    ----------
+    field_attributes : ~h5py._hl.attrs.AttributeManager
+        The :mod:`h5py` interface to the attributes for the field.
+
+    Returns
+    -------
+    str
+        The compression filter description.
+    """
+    if not field_attributes.get("Is Compressed", True):
+        return "Not compressed."
+    comp = field_attributes.get(
+        "Lossy compression filter", "No compression info available"
+    )
+    if hasattr(comp, "decode"):
+        comp = comp.decode("utf-8")
+    return comp
+
+
+def load_field_cosmo_factor(
+    field_attributes: h5py.AttributeManager, metadata: SWIFTMetadata
+) -> cosmo_factor:
+    """
+    Construct the :class:`~swiftsimio.objects.cosmo_factor` for a field.
+
+    Parameters
+    ----------
+    field_attributes : ~h5py._hl.attrs.AttributeManager
+        The :mod:`h5py` interface to the attributes for the field.
+
+    metadata : ~swiftsimio.metadata.objects.SWIFTMetadata
+        The metadata for the SWIFT dataset.
+
+    Returns
+    -------
+    ~swiftsimio.objects.cosmo_factor
+        The cosmology information for the field.
+    """
+    return cosmo_factor.create(
+        metadata.scale_factor, field_attributes.get("a-scale exponent", [0.0])[0]
+    )
+
+
+def load_field_physical(field_attributes: h5py.AttributeManager) -> bool:
+    """
+    Get the flag for comoving/physical coordinates from the HDF5 attribute for a field.
+
+    Parameters
+    ----------
+    field_attributes : ~h5py._hl.attrs.AttributeManager
+        The :mod:`h5py` interface to the attributes for the field.
+
+    Returns
+    -------
+    bool
+        The flag for comoving or physical coordinates.
+    """
+    return field_attributes.get("Value stored as physical", [0])[0] == 1
+
+
+def load_field_valid_transform(field_attributes: h5py.AttributeManager) -> bool:
+    """
+    Get whether to allow comoving-physical conversion from the HDF5 attribute for a field.
+
+    Parameters
+    ----------
+    field_attributes : ~h5py._hl.attrs.AttributeManager
+        The :mod:`h5py` interface to the attributes for the field.
+
+    Returns
+    -------
+    bool
+        The flag for whether comoving-physical conversion is allowed.
+    """
+    # defaults to True for backwards compatibility
+    return field_attributes.get("Property can be converted to comoving", [1])[0] == 1

--- a/swiftsimio/metadata/metadata/metadata_fields.py
+++ b/swiftsimio/metadata/metadata/metadata_fields.py
@@ -1,7 +1,7 @@
 """Define information needed to unpack metadata fields in SWIFT snapshots."""
 
 from unyt import Unit
-from ...objects import cosmo_factor
+from swiftsimio.objects import cosmo_factor
 
 metadata_fields_to_read = {
     "Code": "code",

--- a/swiftsimio/metadata/metadata/metadata_fields.py
+++ b/swiftsimio/metadata/metadata/metadata_fields.py
@@ -1,7 +1,7 @@
 """Define information needed to unpack metadata fields in SWIFT snapshots."""
 
 from unyt import Unit
-from ..objects import cosmo_factor
+from ...objects import cosmo_factor
 
 metadata_fields_to_read = {
     "Code": "code",

--- a/swiftsimio/metadata/objects.py
+++ b/swiftsimio/metadata/objects.py
@@ -660,13 +660,13 @@ class SWIFTGroupMetadata(HandleProvider):
         cosmology metadata and any custom named columns.
         """
         self.load_field_names()
-        self.load_field_units()
-        self.load_field_descriptions()
-        self.load_field_compressions()
-        self.load_cosmology()
-        self.load_physical()
-        self.load_valid_transforms()
-        self.load_named_columns()
+        # self.load_field_units()
+        # self.load_field_descriptions()
+        # self.load_field_compressions()
+        # self.load_cosmology()
+        # self.load_physical()
+        # self.load_valid_transforms()
+        # self.load_named_columns()
 
         return
 

--- a/swiftsimio/metadata/objects.py
+++ b/swiftsimio/metadata/objects.py
@@ -14,7 +14,7 @@ from unyt.array import _iterable
 
 from swiftsimio.conversions import swift_cosmology_to_astropy
 from swiftsimio import metadata
-from swiftsimio.objects import cosmo_array, cosmo_quantity, cosmo_factor
+from swiftsimio.objects import cosmo_array, cosmo_quantity
 from swiftsimio._handle_provider import HandleProvider
 from abc import ABC, abstractmethod
 
@@ -582,8 +582,8 @@ class SWIFTGroupMetadata(HandleProvider):
     Provide the metadata for one hdf5 Group.
 
     This, for instance, could be ``PartType0``, or ``gas``. This will load in
-    the names of all datasets, their units, possible named fields,
-    and their cosmology, and present them for use in the actual i/o routines.
+    the names of all datasets, possible named fields, and present them for use in the
+    actual i/o routines.
 
     Parameters
     ----------
@@ -656,17 +656,12 @@ class SWIFTGroupMetadata(HandleProvider):
         """
         Load the required metadata.
 
-        This includes loading the field names, units and descriptions, as well as the
-        cosmology metadata and any custom named columns.
+        This includes loading the field names and any custom named columns. Field-level
+        data such as units and descriptions of individual datasets are not loaded here
+        but instead lazy-loaded along with the data.
         """
         self.load_field_names()
-        # self.load_field_units()
-        # self.load_field_descriptions()
-        # self.load_field_compressions()
-        # self.load_cosmology()
-        # self.load_physical()
-        # self.load_valid_transforms()
-        # self.load_named_columns()
+        self.load_named_columns()
 
         return
 
@@ -680,234 +675,6 @@ class SWIFTGroupMetadata(HandleProvider):
             if f"{self.group}/{item}" not in self.metadata.present_groups:
                 self.field_paths.append(f"{self.group}/{item}")
                 self.field_names.append(_convert_snake_to_camel(item))
-
-        return
-
-    def load_field_units(self) -> None:
-        """Load in the units from each dataset."""
-        unit_dict = {
-            "I": self.units.current,
-            "L": self.units.length,
-            "M": self.units.mass,
-            "T": self.units.temperature,
-            "t": self.units.time,
-        }
-
-        def get_units(unit_attribute: h5py.AttributeManager) -> unyt.Unit | None:
-            """
-            Get the units from the HDF5 attributes.
-
-            Parameters
-            ----------
-            unit_attribute : h5py.AttributeManager
-                The attribute containing unit metadata.
-
-            Returns
-            -------
-            unyt.Unit or None
-                The loaded units.
-            """
-            units = 1.0
-
-            for exponent, unit in unit_dict.items():
-                # We store the 'unit exponent' in the SWIFT metadata. This corresponds
-                # to the power we need to raise each unit to, to return the correct units
-                try:
-                    # Check if the exponent is 0 manually because of float precision
-                    unit_exponent = unit_attribute[f"U_{exponent} exponent"][0]
-                    if unit_exponent != 0.0:
-                        units *= unit**unit_exponent
-                except KeyError:
-                    # Can't load that data!
-                    # We should probably warn the user here...
-                    pass
-
-            # Deal with case where we _really_ have a dimensionless quantity.
-            if not hasattr(units, "units"):
-                units = None
-
-            return units
-
-        self.field_units = [get_units(self.handle[x].attrs) for x in self.field_paths]
-
-        return
-
-    def load_field_descriptions(self) -> None:
-        """
-        Load in the text descriptions of the fields for each dataset.
-
-        For SOAP filetypes a description of the mask is included.
-        """
-
-        def get_desc(dataset: h5py.Dataset) -> str:
-            """
-            Get the description metadata.
-
-            Parameters
-            ----------
-            dataset : h5py.Dataset
-                The dataset for which to get the description.
-
-            Returns
-            -------
-            str
-                The description of the dataset.
-            """
-            try:
-                description = dataset.attrs["Description"].decode("utf-8")
-            except AttributeError:
-                # Description is saved as a string not bytes
-                description = dataset.attrs["Description"]
-            except KeyError:
-                # Can't load description!
-                description = "No description available"
-
-            is_masked = dataset.attrs.get("Masked", False)
-            if not is_masked:
-                return description + " Not masked."
-
-            mask_datasets = dataset.attrs["Mask Datasets"]
-            mask_threshold = dataset.attrs["Mask Threshold"]
-            if len(mask_datasets) == 1:
-                mask_str = (
-                    " Only computed for objects with "
-                    f"{mask_datasets[0]} >= {mask_threshold}."
-                )
-            else:
-                mask_str = (
-                    " Only computed for objects where "
-                    f"{' + '.join(mask_datasets)} >= {mask_threshold}."
-                )
-            return description + mask_str
-
-        self.field_descriptions = [get_desc(self.handle[x]) for x in self.field_paths]
-
-        return
-
-    def load_field_compressions(self) -> None:
-        """Load in the string describing the compression filters for each dataset."""
-
-        def get_comp(dataset: h5py.Dataset) -> str:
-            """
-            Load the compression metadata for a dataset.
-
-            Parameters
-            ----------
-            dataset : h5py.Dataset
-                The dataset to load the compression metadata for.
-
-            Returns
-            -------
-            str
-                The compression metadata.
-            """
-            try:
-                # SOAP catalogues can be compressed/uncompressed
-                is_compressed = dataset.attrs["Is Compressed"]
-            except KeyError:
-                is_compressed = True
-            try:
-                comp = dataset.attrs["Lossy compression filter"].decode("utf-8")
-            except AttributeError:
-                # Compression is saved as str not bytes
-                comp = dataset.attrs["Lossy compression filter"]
-            except KeyError:
-                # Can't load compression string!
-                comp = "No compression info available"
-
-            return comp if is_compressed else "Not compressed."
-
-        self.field_compressions = [get_comp(self.handle[x]) for x in self.field_paths]
-
-        return
-
-    def load_cosmology(self) -> None:
-        """Load in the field cosmologies."""
-        current_scale_factor = self.scale_factor
-
-        def get_cosmo(dataset: str) -> cosmo_factor:
-            """
-            Generate a cosmo factor from the metadata.
-
-            Parameters
-            ----------
-            dataset : str
-                The name of the dataset to read metadata for.
-
-            Returns
-            -------
-            cosmo_factor
-                A :class:`~swiftsimio.objects.cosmo_factor` setup from the metadata.
-            """
-            try:
-                cosmo_exponent = dataset.attrs["a-scale exponent"][0]
-            except KeyError:
-                # Can't load, 'graceful' fallback.
-                cosmo_exponent = 0.0
-
-            return cosmo_factor.create(current_scale_factor, cosmo_exponent)
-
-        self.field_cosmologies = [get_cosmo(self.handle[x]) for x in self.field_paths]
-
-        return
-
-    def load_physical(self) -> None:
-        """Load in whether the field is saved as comoving or physical."""
-
-        def get_physical(dataset: h5py.Dataset) -> bool:
-            """
-            Check if the metadata item is stored in physical units.
-
-            Parameters
-            ----------
-            dataset : h5py.Dataset
-                The dataset to be checked.
-
-            Returns
-            -------
-            bool
-                ``True`` if stored in physical units, else ``False``.
-            """
-            try:
-                physical = dataset.attrs["Value stored as physical"][0] == 1
-            except KeyError:
-                physical = False
-            return physical
-
-        self.field_physicals = [get_physical(self.handle[x]) for x in self.field_paths]
-
-        return
-
-    def load_valid_transforms(self) -> None:
-        """Load in whether the field can be converted to comoving."""
-
-        def get_valid_transform(dataset: h5py.Dataset) -> bool:
-            """
-            Retrieve the metadata giving whether comoving/physical conversion is allowed.
-
-            Parameters
-            ----------
-            dataset : str
-                The dataset to be checked.
-
-            Returns
-            -------
-            bool
-                ``True`` if conversion is allowed or metadata absent (old file), ``False``
-                otherwise.
-            """
-            try:
-                valid_transform = (
-                    dataset.attrs["Property can be converted to comoving"][0] == 1
-                )
-            except KeyError:
-                # For backward compatibility default to True
-                valid_transform = True
-            return valid_transform
-
-        self.field_valid_transforms = [
-            get_valid_transform(self.handle[x]) for x in self.field_paths
-        ]
 
         return
 

--- a/swiftsimio/reader.py
+++ b/swiftsimio/reader.py
@@ -539,23 +539,23 @@ def _generate_datasets(
     # Set up an iterator for us to loop over for all fields
     field_paths = group_metadata.field_paths
     field_names = group_metadata.field_names
-    field_cosmologies = group_metadata.field_cosmologies
-    field_units = group_metadata.field_units
-    field_physicals = group_metadata.field_physicals
-    field_valid_transforms = group_metadata.field_valid_transforms
-    field_descriptions = group_metadata.field_descriptions
-    field_compressions = group_metadata.field_compressions
-    field_named_columns = group_metadata.named_columns
+    # field_cosmologies = group_metadata.field_cosmologies
+    # field_units = group_metadata.field_units
+    # field_physicals = group_metadata.field_physicals
+    # field_valid_transforms = group_metadata.field_valid_transforms
+    # field_descriptions = group_metadata.field_descriptions
+    # field_compressions = group_metadata.field_compressions
+    # field_named_columns = group_metadata.named_columns
 
     dataset_iterator = zip(
         field_paths,
         field_names,
-        field_cosmologies,
-        field_units,
-        field_physicals,
-        field_valid_transforms,
-        field_descriptions,
-        field_compressions,
+        # field_cosmologies,
+        # field_units,
+        # field_physicals,
+        # field_valid_transforms,
+        # field_descriptions,
+        # field_compressions,
     )
 
     # This 'nice' piece of code ensures that our datasets have different _types_
@@ -568,14 +568,14 @@ def _generate_datasets(
     for (
         field_path,
         field_name,
-        field_cosmology,
-        field_unit,
-        field_physical,
-        field_valid_transform,
-        field_description,
-        field_compression,
+        # field_cosmology,
+        # field_unit,
+        # field_physical,
+        # field_valid_transform,
+        # field_description,
+        # field_compression,
     ) in dataset_iterator:
-        named_columns = field_named_columns[field_path]
+        named_columns = None  # field_named_columns[field_path]
 
         if named_columns is None:
             field_property = property(
@@ -583,14 +583,14 @@ def _generate_datasets(
                     filename,
                     field_name,
                     field_path,
-                    unit=field_unit,
+                    unit=None,  # field_unit,
                     mask=mask_array,
                     mask_size=mask_size,
-                    cosmo_factor=field_cosmology,
-                    description=field_description,
-                    compression=field_compression,
-                    physical=field_physical,
-                    valid_transform=field_valid_transform,
+                    cosmo_factor=None,  # field_cosmology,
+                    description=None,  # field_description,
+                    compression=None,  # field_compression,
+                    physical=None,  # field_physical,
+                    valid_transform=None,  # field_valid_transform,
                 ),
                 _generate_setter(field_name),
                 _generate_deleter(field_name),
@@ -614,14 +614,14 @@ def _generate_datasets(
                         filename,
                         column,
                         field_path,
-                        unit=field_unit,
+                        unit=None,  # field_unit,
                         mask=mask_array,
                         mask_size=mask_size,
-                        cosmo_factor=field_cosmology,
-                        description=f"{field_description} [Column {index}, {column}]",
-                        compression=field_compression,
-                        physical=field_physical,
-                        valid_transform=field_valid_transform,
+                        cosmo_factor=None,  # field_cosmology,
+                        description=None,  # f"{field_description} [Column {index}, {column}]",
+                        compression=None,  # field_compression,
+                        physical=None,  # field_physical,
+                        valid_transform=None,  # field_valid_transform,
                         columns=np.s_[index],
                     ),
                     _generate_setter(column),

--- a/swiftsimio/reader.py
+++ b/swiftsimio/reader.py
@@ -14,17 +14,25 @@ These include:
 """
 
 from swiftsimio.accelerated import read_ranges_from_file
-from swiftsimio.objects import cosmo_array, cosmo_factor
+from swiftsimio.objects import cosmo_array
 from swiftsimio.masks import SWIFTMask
 from swiftsimio.metadata.objects import (
     _metadata_discriminator,
     SWIFTUnits,
     SWIFTGroupMetadata,
 )
+from swiftsimio.metadata.field.attr_reader import (
+    load_field_units as _load_field_units,
+    load_field_description as _load_field_description,
+    load_field_compression as _load_field_compression,
+    load_field_cosmo_factor as _load_field_cosmo_factor,
+    load_field_physical as _load_field_physical,
+    load_field_valid_transform as _load_field_valid_transform,
+)
+
 from swiftsimio._handle_provider import HandleProvider
 
 import h5py
-import unyt
 import numpy as np
 
 from typing import Callable
@@ -32,18 +40,13 @@ from pathlib import Path
 
 
 def _generate_getter(
-    filename: str,
     name: str,
+    *,
+    filename: str,
     field: str,
-    unit: unyt.unyt_quantity,
-    mask: None | np.ndarray,
+    mask: np.ndarray | None,
     mask_size: int,
-    cosmo_factor: cosmo_factor,
-    description: str,
-    compression: str,
-    physical: bool,
-    valid_transform: bool,
-    columns: None | slice = None,
+    column_index: int | None = None,
 ) -> Callable[["__SWIFTGroupDataset"], cosmo_array]:
     """
     Generate a function that retrieves data from file if not already in memory.
@@ -58,47 +61,26 @@ def _generate_getter(
 
     Parameters
     ----------
+    name : str
+        Output name (snake_case) of the field.
+
     filename : str
         Filename of the HDF5 file that everything will be read from. Used to generate
         the HDF5 dataset.
-
-    name : str
-        Output name (snake_case) of the field.
 
     field : str
         Full path of field, including e.g. particle type. Examples include
         ``/PartType0/Velocities``.
 
-    unit : unyt.unyt_quantity
-        Output unit of the resultant ``cosmo_array``.
-
-    mask : None or np.ndarray
+    mask : np.ndarray, optional
         Mask to be used with ``accelerated.read_ranges_from_file``, i.e. an array of
         integers that describe ranges to be read from the file.
 
     mask_size : int
         Size of the mask if present.
 
-    cosmo_factor : cosmo_factor
-        Cosmology factor object corresponding to this array.
-
-    description : str
-        Description (read from HDF5 file) of the data.
-
-    compression : str
-        String describing the lossy compression filters that were applied to the
-        data (read from the HDF5 file).
-
-    physical : bool
-        Bool that describes whether the data in the file is stored in comoving
-        or physical units.
-
-    valid_transform : bool
-        Bool that describes whether converting this field from physical to comoving
-        units is a valid operation.
-
-    columns : np.lib.index_tricks.IndexEpression, optional
-        Index expression corresponding to which columns to read from the numpy array.
+    column_index : int, optional
+        Index specifying which columns to read from the numpy array.
         If not provided, we read all columns and return an n-dimensional array.
 
     Returns
@@ -121,10 +103,8 @@ def _generate_getter(
     # use of None as the default.
     # Here, we need to ensure that in the cases where we're using columns,
     # during a partial read, that we respect the single-column dataset nature.
-    use_columns = columns is not None
-
-    if not use_columns:
-        columns = np.s_[:]
+    use_columns = column_index is not None
+    columns = np.s_[:] if not use_columns else np.s_[column_index]
 
     def getter(self: __SWIFTGroupDataset) -> cosmo_array:
         """
@@ -147,6 +127,13 @@ def _generate_getter(
         else:
             with self.open_file() as handle:
                 try:
+                    attributes = handle[field].attrs
+                    unit = _load_field_units(attributes, self.metadata.units)
+                    cf = _load_field_cosmo_factor(attributes, self.metadata)
+                    description = _load_field_description(attributes)
+                    compression = _load_field_compression(attributes)
+                    physical = _load_field_physical(attributes)
+                    valid_transform = _load_field_valid_transform(attributes)
                     if mask is not None:
                         output_type = handle[field].dtype
                         output_shape = (
@@ -166,7 +153,7 @@ def _generate_getter(
                                     columns=columns,
                                 ),
                                 unit,
-                                cosmo_factor=cosmo_factor,
+                                cosmo_factor=cf,
                                 name=description,
                                 compression=compression,
                                 comoving=not physical,
@@ -186,8 +173,8 @@ def _generate_getter(
                                     else handle[field][:]
                                 ),
                                 unit,
-                                cosmo_factor=cosmo_factor,
-                                name=description,
+                                cosmo_factor=cf,
+                                name=f"{description} [Column {column_index}, {name}]",
                                 compression=compression,
                                 comoving=not physical,
                                 valid_transform=valid_transform,
@@ -371,6 +358,9 @@ class __SWIFTNamedColumnDataset(HandleProvider):
     field_path : str
         Path to field within hdf5 snapshot.
 
+    group_metadata : SWIFTGroupMetadata
+        The metadata for the group that this named column dataset belongs to.
+
     named_columns : list of str
         List of categories for the variable ``name``.
 
@@ -410,12 +400,15 @@ class __SWIFTNamedColumnDataset(HandleProvider):
     def __init__(
         self,
         field_path: str,
+        group_metadata: SWIFTGroupMetadata,
         named_columns: list[str],
         name: str,
         handle: h5py.File,
     ) -> None:
         super().__init__(handle.filename, handle=handle)
         self.field_path = field_path
+        self.group_metadata = group_metadata
+        self.metadata = group_metadata.metadata
         self.named_columns = named_columns
         self.name = name
 
@@ -529,34 +522,8 @@ def _generate_datasets(
     group_nice_name = group_metadata.metadata.get_nice_name(group)
 
     # Mask is an object that contains all masks for all possible datasets.
-    if mask is not None:
-        mask_array = getattr(mask, group_name)
-        mask_size = getattr(mask, f"{group_name}_size")
-    else:
-        mask_array = None
-        mask_size = -1
-
-    # Set up an iterator for us to loop over for all fields
-    field_paths = group_metadata.field_paths
-    field_names = group_metadata.field_names
-    # field_cosmologies = group_metadata.field_cosmologies
-    # field_units = group_metadata.field_units
-    # field_physicals = group_metadata.field_physicals
-    # field_valid_transforms = group_metadata.field_valid_transforms
-    # field_descriptions = group_metadata.field_descriptions
-    # field_compressions = group_metadata.field_compressions
-    # field_named_columns = group_metadata.named_columns
-
-    dataset_iterator = zip(
-        field_paths,
-        field_names,
-        # field_cosmologies,
-        # field_units,
-        # field_physicals,
-        # field_valid_transforms,
-        # field_descriptions,
-        # field_compressions,
-    )
+    mask_array = getattr(mask, group_name, None)
+    mask_size = getattr(mask, f"{group_name}_size", -1)
 
     # This 'nice' piece of code ensures that our datasets have different _types_
     # for different particle types. We initially fill a dict with the properties that
@@ -565,32 +532,18 @@ def _generate_datasets(
     this_dataset_bases = (__SWIFTGroupDataset, object)
     this_dataset_dict = {}
 
-    for (
-        field_path,
-        field_name,
-        # field_cosmology,
-        # field_unit,
-        # field_physical,
-        # field_valid_transform,
-        # field_description,
-        # field_compression,
-    ) in dataset_iterator:
-        named_columns = None  # field_named_columns[field_path]
-
+    for field_path, field_name in zip(
+        group_metadata.field_paths, group_metadata.field_names
+    ):
+        named_columns = group_metadata.named_columns[field_path]
         if named_columns is None:
             field_property = property(
                 _generate_getter(
-                    filename,
                     field_name,
-                    field_path,
-                    unit=None,  # field_unit,
+                    filename=filename,
+                    field=field_path,
                     mask=mask_array,
                     mask_size=mask_size,
-                    cosmo_factor=None,  # field_cosmology,
-                    description=None,  # field_description,
-                    compression=None,  # field_compression,
-                    physical=None,  # field_physical,
-                    valid_transform=None,  # field_valid_transform,
                 ),
                 _generate_setter(field_name),
                 _generate_deleter(field_name),
@@ -611,18 +564,12 @@ def _generate_datasets(
             for index, column in enumerate(named_columns):
                 this_named_column_dataset_dict[column] = property(
                     _generate_getter(
-                        filename,
                         column,
-                        field_path,
-                        unit=None,  # field_unit,
+                        filename=filename,
+                        field=field_path,
                         mask=mask_array,
                         mask_size=mask_size,
-                        cosmo_factor=None,  # field_cosmology,
-                        description=None,  # f"{field_description} [Column {index}, {column}]",
-                        compression=None,  # field_compression,
-                        physical=None,  # field_physical,
-                        valid_transform=None,  # field_valid_transform,
-                        columns=np.s_[index],
+                        column_index=index,
                     ),
                     _generate_setter(column),
                     _generate_deleter(column),
@@ -636,6 +583,7 @@ def _generate_datasets(
 
             field_property = ThisNamedColumnDataset(
                 handle=handle,
+                group_metadata=group_metadata,
                 field_path=field_path,
                 named_columns=named_columns,
                 name=field_name,


### PR DESCRIPTION
Read metadata for individual datasets at the same time as the data themselves.

This saves reading the units, cosmo_factor, compression, etc. for all datasets when initially opening the file, speeding up calls to `load()` (and `mask()`) substantially, especially for SOAP files with many datasets. Since most workflows do not involve reading all datasets in a file, this saves time overall.
