### PR TITLE
Better comoving-physical conversion syntax

### DIFF
--- a/docs/source/cosmo_array/index.rst
+++ b/docs/source/cosmo_array/index.rst
@@ -36,16 +36,36 @@ the scale factor. The conversion factors can be accessed like this:
    print(rho_gas.cosmo_factor.expr)
 
 which will output ``132651.002785671`` and ``a**(-3.0)``. Converting an array to/from physical/comoving
-is done with the :meth:`~swiftsimio.objects.cosmo_array.to_physical`, :meth:`~swiftsimio.objects.cosmo_array.to_comoving`, :meth:`~swiftsimio.objects.cosmo_array.convert_to_physical` and :meth:`~swiftsimio.objects.cosmo_array.to_comoving` methods, for instance:
+is done with the :meth:`~swiftsimio.objects.cosmo_array.to_physical`, :meth:`~swiftsimio.objects.cosmo_array.to_comoving`, :meth:`~swiftsimio.objects.cosmo_array.convert_to_physical` and :meth:`~swiftsimio.objects.cosmo_array.to_comoving` methods. These can also convert units at the same time, for instance:
 
 .. code-block:: python
 
-   physical_rho_gas = rho_gas.to_physical()
+   import unyt as u
 
-   # Convert in-place
-   rho_gas.convert_to_physical()
+   # Create copies:
+   physical_rho_gas = rho_gas.to_physical()  # preserves current units
+   physical_rho_gas_cgs = rho_gas.to_physical(u.g / u.cm**3)
 
-If you instead want to get the raw array values in either physical or comoving units, the :meth:`~swiftsimio.objects.cosmo_array.to_physical_value` and :meth:`~swiftsimio.objects.cosmo_array.to_comoving_value` are provided, analogous to the :meth:`~unyt.unyt_array.unyt_array.to_value`.
+   # Convert in-place:
+   rho_gas.convert_to_physical()  # preserves current units
+   rho_gas.convert_to_physical(u.g / u.cm ** 2)
+
+Equivalently, the :meth:`~swiftsimio.objects.cosmo_array.to` can accept a comoving argument:
+
+.. code-block:: python
+
+   # Create copies:
+   physical_rho_gas = rho_gas.to(comoving=False)  # preserves current unit
+   physical_rho_gas_cgs = rho_gas.to(u.g / u.cm**3, comoving=False)
+
+If you instead want to get the raw array values in either physical or comoving units, the :meth:`~swiftsimio.objects.cosmo_array.to_physical_value` and :meth:`~swiftsimio.objects.cosmo_array.to_comoving_value` are provided, analogous to the :meth:`~unyt.unyt_array.unyt_array.to_value` (which also has a ``comoving`` argument available):
+
+.. code-block:: python
+
+   physical_rho_gas_cgs = rho_gas.to_physical_value(u.g / u.cm**3)
+   comoving_rho_gas_cgs = rho_gas.to_comoving_value(u.g / u.cm**3)
+   # Or:
+   physical_rho_gas_cgs = rho_gas.to_value(u.g / u.cm**3, comoving=False)
 
 The ``valid_transform`` is a boolean flag that is set to ``False`` for some arrays that don't make sense to convert to comoving.
 

--- a/swiftsimio/_array_functions.py
+++ b/swiftsimio/_array_functions.py
@@ -192,8 +192,10 @@ def _propagate_cosmo_array_attributes_to_result(func: Callable) -> Callable:
     """
 
     def wrapped(
-        obj: object, *args: tuple[Any], **kwargs: dict[str, Any]
-    ) -> object:  # # noqa numpydoc ignore=GL08
+        obj: object,
+        *args: tuple[Any],
+        **kwargs: dict[str, Any],
+    ) -> object:  # noqa numpydoc ignore=GL08
         # omit docstring so that sphinx picks up docstring of wrapped function
         return _copy_cosmo_array_attributes_if_present(obj, func(obj, *args, **kwargs))
 
@@ -886,9 +888,9 @@ def _prepare_array_func_args(
     -------
     dict
         A dictionary containing the input ``args`` and ``kwargs`` coerced to a common
-        state, and lists of their ``cosmo_factor`` attributes, and ``comoving`` and
-        ``compression`` values that can be used in return values for wrapped functions,
-        when relevant.
+        state, and lists of their ``cosmo_factor`` attributes, and ``comoving``,
+        ``valid_transform`` and ``compression`` values that can be used in return values
+        for wrapped functions, when relevant.
 
     Raises
     ------
@@ -897,6 +899,7 @@ def _prepare_array_func_args(
     """
     cms = [(hasattr(arg, "comoving"), getattr(arg, "comoving", None)) for arg in args]
     cfs = [getattr(arg, "cosmo_factor", None) for arg in args]
+    vts = [getattr(arg, "valid_transform", True) for arg in args]
     comps = [
         (hasattr(arg, "compression"), getattr(arg, "compression", None)) for arg in args
     ]
@@ -905,6 +908,7 @@ def _prepare_array_func_args(
         for k, kwarg in kwargs.items()
     }
     kw_cfs = {k: getattr(kwarg, "cosmo_factor", None) for k, kwarg in kwargs.items()}
+    kw_vts = {k: getattr(kwarg, "valid_transform", True) for k, kwarg in kwargs.items()}
     kw_comps = {
         k: (hasattr(kwarg, "compression"), getattr(kwarg, "compression", None))
         for k, kwarg in kwargs.items()
@@ -955,20 +959,22 @@ def _prepare_array_func_args(
                 for k, kwarg in kwargs.items()
             }
             ret_cm = False
+    ret_vt = all(vts + list(kw_vts.values()))  # if any False, then False
     if len(set(comps + list(kw_comps.values()))) == 1:
         # all compressions identical, preserve it
         ret_comp = (comps + list(kw_comps.values()))[0]
     else:
         # mixed compressions, strip it off
         ret_comp = None
-    return dict(
-        args=args,
-        kwargs=kwargs,
-        cfs=cfs,
-        kw_cfs=kw_cfs,
-        comoving=ret_cm,
-        compression=ret_comp,
-    )
+    return {
+        "args": args,
+        "kwargs": kwargs,
+        "cfs": cfs,
+        "kw_cfs": kw_cfs,
+        "comoving": ret_cm,
+        "valid_transform": ret_vt,
+        "compression": ret_comp,
+    }
 
 
 def implements(numpy_function: Callable) -> Callable:
@@ -1044,10 +1050,12 @@ def _return_helper(
     if isinstance(res, objects.cosmo_array):  # also recognizes cosmo_quantity
         res.comoving = helper_result["comoving"]
         res.cosmo_factor = ret_cf
+        res.valid_transform = helper_result["valid_transform"]
         res.compression = helper_result["compression"]
     if isinstance(out, objects.cosmo_array):  # also recognizes cosmo_quantity
         out.comoving = helper_result["comoving"]
         out.cosmo_factor = ret_cf
+        out.valid_transform = helper_result["valid_transform"]
         out.compression = helper_result["compression"]
     return res
 
@@ -1351,6 +1359,7 @@ def histogram(  # noqa: ANN202
     if isinstance(counts, objects.cosmo_array):  # also recognizes cosmo_quantity
         counts.comoving = helper_result["comoving"]
         counts.cosmo_factor = ret_cf_counts
+        counts.valid_transform = helper_result["valid_transform"]
         counts.compression = helper_result["compression"]
     return counts, _return_helper(bins, helper_result, ret_cf_bins)
 
@@ -1408,6 +1417,7 @@ def histogram2d(  # noqa: ANN202
             ):  # also recognizes cosmo_quantity
                 counts.comoving = helper_result_w["comoving"]
                 counts.cosmo_factor = ret_cf_w
+                counts.valid_transform = helper_result_w["valid_transform"]
                 counts.compression = helper_result_w["compression"]
     else:  # density=True
         # now x, y and weights must be compatible because they will combine
@@ -1453,6 +1463,7 @@ def histogram2d(  # noqa: ANN202
         if isinstance(counts, objects.cosmo_array):  # also recognizes cosmo_quantity
             counts.comoving = helper_result["comoving"]
             counts.cosmo_factor = ret_cf_counts
+            counts.valid_transform = helper_result["valid_transform"]
             counts.compression = helper_result["compression"]
     return (
         counts,
@@ -1514,6 +1525,7 @@ def histogramdd(  # noqa: ANN202
             if isinstance(counts, objects.cosmo_array):
                 counts.comoving = helper_result_w["comoving"]
                 counts.cosmo_factor = ret_cf_w
+                counts.valid_transform = helper_result_w["valid_transform"]
                 counts.compression = helper_result_w["compression"]
     else:  # density=True
         # now sample and weights must be compatible because they will combine
@@ -1543,6 +1555,7 @@ def histogramdd(  # noqa: ANN202
         if isinstance(counts, objects.cosmo_array):  # also recognizes cosmo_quantity
             counts.comoving = helper_result["comoving"]
             counts.cosmo_factor = ret_cf_counts
+            counts.valid_transform = helper_result["valid_transform"]
             counts.compression = helper_result["compression"]
     return (
         counts,
@@ -1620,6 +1633,7 @@ def _prepare_array_block_args(lst: list, recursing: bool = False) -> dict:
     if recursing:
         return helper_results
     cms = [hr["comoving"] for hr in helper_results]
+    vts = [hr["valid_transform"] for hr in helper_results]
     comps = [hr["compression"] for hr in helper_results]
     cfs = [hr["cfs"] for hr in helper_results]
     convert_to_cm = False
@@ -1638,6 +1652,7 @@ def _prepare_array_block_args(lst: list, recursing: bool = False) -> dict:
         # mix of True and False only
         ret_cm = True
         convert_to_cm = True
+    ret_vt = all(vts)
     if len(set(comps)) == 1:
         ret_comp = comps[0]
     else:
@@ -1650,13 +1665,14 @@ def _prepare_array_block_args(lst: list, recursing: bool = False) -> dict:
         ret_lst = _recursive_to_comoving(lst)
     else:
         ret_lst = lst
-    return dict(
-        args=ret_lst,
-        kwargs=dict(),
-        comoving=ret_cm,
-        cosmo_factor=ret_cf,
-        compression=ret_comp,
-    )
+    return {
+        "args": ret_lst,
+        "kwargs": dict(),
+        "comoving": ret_cm,
+        "cosmo_factor": ret_cf,
+        "valid_transform": ret_vt,
+        "compression": ret_comp,
+    }
 
 
 @implements(np.block)

--- a/swiftsimio/_array_functions.py
+++ b/swiftsimio/_array_functions.py
@@ -1667,7 +1667,7 @@ def _prepare_array_block_args(lst: list, recursing: bool = False) -> dict:
         ret_lst = lst
     return {
         "args": ret_lst,
-        "kwargs": dict(),
+        "kwargs": {},
         "comoving": ret_cm,
         "cosmo_factor": ret_cf,
         "valid_transform": ret_vt,

--- a/swiftsimio/conversions.py
+++ b/swiftsimio/conversions.py
@@ -1,7 +1,7 @@
 """Convert between SWIFT internal values and :mod:`astropy` cosmologies."""
 
 from swiftsimio.optional_packages import ASTROPY_AVAILABLE
-from swiftsimio.objects import cosmo_quantity
+from unyt import unyt_quantity
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -77,7 +77,7 @@ if ASTROPY_AVAILABLE:
             An instance of ``astropy.cosmology.Cosmology`` filled with the
             correct parameters.
         """
-        H0 = cosmo_quantity(cosmo["H0 [internal units]"][0], units=1.0 / units.time)
+        H0 = unyt_quantity(cosmo["H0 [internal units]"][0], units=1.0 / units.time)
 
         Omega_b = cosmo["Omega_b"][0]
         Omega_lambda = cosmo["Omega_lambda"][0]

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -141,7 +141,8 @@ def _verify_valid_transform_validity(obj: "cosmo_array") -> None:
     Check that ``comoving`` and ``valid_transform`` attributes are compatible.
 
     Comoving arrays must be able to transform, while arrays that don't transform must
-    be physical. This function raises if this is not the case.
+    be physical. Arrays with ``comoving`` set to ``None`` must not be allowed to
+    transform. This function raises if this is not the case.
 
     Parameters
     ----------
@@ -150,16 +151,17 @@ def _verify_valid_transform_validity(obj: "cosmo_array") -> None:
 
     Raises
     ------
-    AssertionError
+    InvalidConversionError
         When an invalid combination of ``comoving`` and ``valid_transform`` is found.
     """
-    if not obj.valid_transform:
-        assert not obj.comoving, (
-            "Cosmo arrays without a valid transform to comoving units must be physical"
+    if obj.comoving is None and obj.valid_transform:
+        raise InvalidConversionError(
+            "Cosmo arrays must have comoving!=None to have valid_transform==True"
         )
-    if obj.comoving:
-        assert obj.valid_transform, (
-            "Comoving cosmo_arrays must be able to be transformed to physical"
+    elif obj.valid_transform is False and obj.comoving is True:
+        raise InvalidConversionError(
+            "Cosmo arrays without a valid transform to comoving units must be physical,"
+            " and comoving cosmo_arrays must be able to be transformed to physcial."
         )
 
 
@@ -1134,7 +1136,7 @@ class cosmo_array(unyt_array):
 
         valid_transform : bool
             Flag to indicate whether this array can be converted to comoving. If
-            ``False``, then ``comoving`` must be ``False``.
+            ``False``, then ``comoving`` must be ``False`` (or ``None``).
 
         compression : str
             Description of the compression filters that were applied to that array in the
@@ -1163,6 +1165,14 @@ class cosmo_array(unyt_array):
 
         if isinstance(input_array, cosmo_array):
             obj = input_array.view(cls)
+            if comoving is None:
+                # we could be dealing with unyt creating an object for us so copy the
+                # value across to avoid defaulting to None
+                obj.comoving = input_array.comoving
+
+            # let's trust what the input_array tells us about valid_transform.
+            # copy explicitly in case unyt is creating an object for us.
+            obj.valid_transform = input_array.valid_transform
 
             # do cosmo_factor first since it can be used in comoving/physical conversion:
             cosmo_factor = (
@@ -1177,7 +1187,10 @@ class cosmo_array(unyt_array):
             )
             if cosmo_factor is not None:
                 obj.cosmo_factor = cosmo_factor
-            # else is already copied from input_array
+            else:
+                # we could be dealing with unyt creating an object for us so copy the
+                # value across to avoid defaulting to None
+                obj.cosmo_factor = input_array.cosmo_factor
 
             if comoving is True:
                 obj.convert_to_comoving()
@@ -1189,7 +1202,6 @@ class cosmo_array(unyt_array):
             # transformations raise:
             obj.valid_transform = valid_transform
             _verify_valid_transform_validity(obj)
-
             obj.compression = (
                 compression if compression is not None else obj.compression
             )
@@ -1201,16 +1213,17 @@ class cosmo_array(unyt_array):
 
             # ndarray with object dtype goes to next case to properly handle e.g.
             # ndarrays containing cosmo_quantities
-
             cosmo_factor = _parse_cosmo_factor_args(
                 cf=cosmo_factor,
                 scale_factor=scale_factor,
                 scale_exponent=scale_exponent,
             )
+            valid_transform = valid_transform if comoving is not None else False
 
         elif _iterable(input_array):
             # if _prepare_array_func_args finds cosmo_array input it will convert to:
             default_cm = comoving if comoving is not None else True
+            default_vt = comoving is not None
 
             # coerce any cosmo_array inputs to consistency:
             helper_result = _prepare_array_func_args(
@@ -1235,7 +1248,8 @@ class cosmo_array(unyt_array):
                 helper_result["compression"] if compression is None else compression
             )
             # valid_transform has a non-None default, so we have to decide to always
-            # respect it
+            # respect it, unless comoving is None
+            valid_transform = valid_transform if comoving is not None else default_vt
         else:
             # if the input isn't even iterable, this is an error
             raise ValueError(
@@ -1375,6 +1389,7 @@ class cosmo_array(unyt_array):
     copy = _propagate_cosmo_array_attributes_to_result(unyt_array.copy)
     __deepcopy__ = _propagate_cosmo_array_attributes_to_result(unyt_array.__deepcopy__)
     in_cgs = _propagate_cosmo_array_attributes_to_result(unyt_array.in_cgs)
+    in_base = _propagate_cosmo_array_attributes_to_result(unyt_array.in_base)
     take = _propagate_cosmo_array_attributes_to_result(
         _ensure_result_is_cosmo_array_or_quantity(unyt_array.take)
     )
@@ -1392,8 +1407,44 @@ class cosmo_array(unyt_array):
     ua = property(_propagate_cosmo_array_attributes_to_result(np.ones_like))
     unit_array = property(_propagate_cosmo_array_attributes_to_result(np.ones_like))
 
-    def convert_to_comoving(self) -> None:
-        """Convert the internal data in-place to be in comoving units."""
+    def convert_to_comoving(
+        self,
+        units: unyt.Unit | str | None = None,
+        *,
+        equivalence: str | None = None,
+        **kwargs: dict[str, Any],
+    ) -> None:
+        """
+        Convert the internal data in-place to be in comoving units.
+
+        Optionaly, an equivalence can be specified to convert to an equivalent quantity
+        which is not in the same dimensions.
+
+        Parameters
+        ----------
+        units : ~unyt.Unit or str, optional
+            The desired units for the converted array. If omitted the units are preserved.
+
+        equivalence : str, optional
+            The equivalence to use. To see which equivalences are supported for this
+            quantity, try the :meth:`~unyt.array.unyt_array.list_equivalencies` method.
+
+        **kwargs : dict
+            Any additional keyword arguments are supplied to the equivalence.
+
+        Returns
+        -------
+        ~swiftsimio.objects.cosmo_array
+            This array in the requested comoving units, transformed in place.
+
+        Raises
+        ------
+        UnitConversionError
+            If the provided ``units`` does not have the same dimensions as the array and
+            cannot be converted via a provided ``equivalence``.
+        """
+        if units is not None:
+            self.convert_to_units(units, equivalence=equivalence, **kwargs)
         if self.comoving:
             return
         if not self.valid_transform or self.comoving is None:
@@ -1404,8 +1455,44 @@ class cosmo_array(unyt_array):
         values /= self.cosmo_factor.a_factor
         self.comoving = True
 
-    def convert_to_physical(self) -> None:
-        """Convert the internal data in-place to be in physical units."""
+    def convert_to_physical(
+        self,
+        units: unyt.Unit | str | None = None,
+        *,
+        equivalence: str | None = None,
+        **kwargs: dict[str, Any],
+    ) -> None:
+        """
+        Convert the internal data in-place to be in physical units.
+
+        Optionaly, an equivalence can be specified to convert to an equivalent quantity
+        which is not in the same dimensions.
+
+        Parameters
+        ----------
+        units : ~unyt.Unit or str, optional
+            The desired units for the converted array. If omitted the units are preserved.
+
+        equivalence : str, optional
+            The equivalence to use. To see which equivalences are supported for this
+            quantity, try the :meth:`~unyt.array.unyt_array.list_equivalencies` method.
+
+        **kwargs : dict
+            Any additional keyword arguments are supplied to the equivalence.
+
+        Returns
+        -------
+        ~swiftsimio.objects.cosmo_array
+            This array in the requested physical units, transformed in place.
+
+        Raises
+        ------
+        UnitConversionError
+            If the provided ``units`` does not have the same dimensions as the array and
+            cannot be converted via a provided ``equivalence``.
+        """
+        if units is not None:
+            self.convert_to_units(units, equivalence=equivalence, **kwargs)
         if self.comoving is None:
             raise InvalidConversionError
         elif not self.comoving:
@@ -1417,67 +1504,323 @@ class cosmo_array(unyt_array):
             values *= self.cosmo_factor.a_factor
             self.comoving = False
 
-    def to_physical(self) -> "cosmo_array":
+    def to_physical(
+        self,
+        units: unyt.Unit | str | None = None,
+        *,
+        equivalence: str | None = None,
+        **kwargs: dict[str, Any],
+    ) -> "cosmo_array":
         """
         Create a copy of the data in physical units.
+
+        Parameters
+        ----------
+        units : ~unyt.Unit or str, optional
+            The desired units for the new array. If omitted the units are preserved.
+
+        equivalence : str, optional
+            The equivalence to use. To see which equivalences are supported for this
+            quantity, try the :meth:`~unyt.array.unyt_array.list_equivalencies` method.
+
+        **kwargs : dict
+            Any additional keyword arguments are supplied to the equivalence.
 
         Returns
         -------
         ~swiftsimio.objects.cosmo_array
-            Copy of this array in physical units.
+            Copy of this array in the requested physical units.
+
+        Raises
+        ------
+        UnitConversionError
+            If the provided ``units`` does not have the same dimensions as the array and
+            cannot be converted via a provided ``equivalence``.
         """
-        copied_data = self.in_units(self.units, cosmo_factor=self.cosmo_factor)
+        if not self.valid_transform and self.comoving:
+            raise InvalidConversionError
+        copied_data = self.in_units(
+            self.units if units is None else units, equivalence=equivalence, **kwargs
+        )
         copied_data.convert_to_physical()
 
         return copied_data
 
-    def to_comoving(self) -> "cosmo_array":
+    def to_comoving(
+        self,
+        units: unyt.Unit | str | None = None,
+        *,
+        equivalence: str | None = None,
+        **kwargs: dict[str, Any],
+    ) -> "cosmo_array":
         """
         Create a copy of the data in comoving units.
+
+        Parameters
+        ----------
+        units : ~unyt.Unit or str, optional
+            The desired units for the new array. If omitted the units are preserved.
+
+        equivalence : str, optional
+            The equivalence to use. To see which equivalences are supported for this
+            quantity, try the :meth:`~unyt.array.unyt_array.list_equivalencies` method.
+
+        **kwargs : dict
+            Any additional keyword arguments are supplied to the equivalence.
 
         Returns
         -------
         ~swiftsimio.objects.cosmo_array
-            Copy of this array in comoving units.
+            Copy of this array in the requested comoving units.
+
+        Raises
+        ------
+        UnitConversionError
+            If the provided ``units`` does not have the same dimensions as the array and
+            cannot be converted via a provided ``equivalence``.
         """
-        if not self.valid_transform:
+        if not self.valid_transform and self.comoving is not False:
             raise InvalidConversionError
-        copied_data = self.in_units(self.units, cosmo_factor=self.cosmo_factor)
+        copied_data = self.in_units(
+            self.units if units is None else units, equivalence=equivalence, **kwargs
+        )
         copied_data.convert_to_comoving()
 
         return copied_data
 
-    def to_physical_value(self, units: Unit) -> np.ndarray:
+    def to(
+        self,
+        units: unyt.Unit | str | None = None,
+        *,
+        equivalence: str | None = None,
+        comoving: bool | None = None,
+        **kwargs: dict[str, Any],
+    ) -> "cosmo_array":
         """
-        Return a copy of the array values in the specified physical units.
+        Create a copy of the data in specified comoving or physical units.
+
+        Optionally, an equivalence can be specified to convert to an equivalent quantity
+        which is not in the same dimensions.
+
+        .. note::
+
+            All additional keyword arguments are passed to the equivalency, which should
+            be used if that particular equivalency requires them.
 
         Parameters
         ----------
-        units : unyt.unit_object.Unit
-            Units to convert to.
+        units : ~unyt.Unit or str, optional
+            The desired units for the new array.
+
+        equivalence : str, optional
+            The equivalence to use. To see which equivalences are supported for this
+            quantity, try the :meth:`~unyt.array.unyt_array.list_equivalencies` method.
+
+        comoving : bool, optional
+            If ``True``, the result is comoving, if ``False`` it is physical. By default
+            the ``comoving`` status of the array is preserved.
+
+        **kwargs : dict
+            Any additional keyword arguments are supplied to the equivalence.
 
         Returns
         -------
-        np.ndarray
-            Copy of the array values in the specified physical units.
-        """
-        return self.to_physical().to_value(units)
+        ~swiftsimio.objects.cosmo_array
+            Copy of this array in comoving or physical units.
 
-    def to_comoving_value(self, units: Unit) -> np.ndarray:
+        Raises
+        ------
+        UnitConversionError
+            If the provided ``units`` does not have the same dimensions as the array and
+            cannot be converted via a provided ``equivalence``.
+        
+        Examples
+        --------
+        .. code-block:: python
+
+           >>> import unyt as u
+           >>> d = cosmo_quantity(
+           ...     1,
+           ...     u.Mpc,
+           ...     comoving=True,
+           ...     scale_factor=0.5,
+           ...     scale_exponent=1
+           ... )
+           >>> d.to(u.kpc, comoving=False)
+           cosmo_quantity(500., 'kpc', comoving='False', cosmo_factor='a at a=0.5', \
+           valid_transform='True')
         """
-        Return a copy of the array values in the specified comoving units.
+        if not self.valid_transform and (comoving != self.comoving):
+            raise InvalidConversionError
+        if units is None:
+            arr_copy = self.copy()
+        else:
+            arr_copy = _copy_cosmo_array_attributes_if_present(
+                self,
+                _ensure_result_is_cosmo_array_or_quantity(super().to)(
+                    units, equivalence=equivalence, **kwargs
+                ),
+            )
+        # do comoving conversion in-place since we already made a copy.
+        # if comoving is not None and self.comoving is None this will (and should) raise.
+        if comoving is True:
+            arr_copy.convert_to_comoving()
+        elif comoving is False:  # can't use else in case comoving is None
+            arr_copy.convert_to_physical()
+        else:  # comoving is None - keep whatever self had
+            pass  # attribute was already copied above
+        return arr_copy
+
+    def to_value(
+        self,
+        units: unyt.Unit | str | None = None,
+        *,
+        equivalence: str | None = None,
+        comoving: bool | None = None,
+        **kwargs: dict[str, Any],
+    ) -> np.ndarray:
+        """
+        Create a copy of the data in specified comoving or physical units.
+
+        The copy is then returned with the values as a bare :mod:`~numpy` array.
+
+        Optionally, an equivalence can be specified to convert to an equivalent quantity
+        which is not in the same dimensions.
+
+        .. note::
+
+            All additional keyword arguments are passed to the equivalency, which should
+            be used if that particular equivalency requires them.
 
         Parameters
         ----------
-        units : unyt.unit_object.Unit
-            Units to convert to.
+        units : ~unyt.Unit or str
+            The desired units for the new array.
+
+        equivalence : str, optional
+            The equivalence to use. To see which equivalences are supported for this
+            quantity, try the :meth:`~unyt.array.unyt_array.list_equivalencies` method.
+
+        comoving : bool, optional
+            If ``True``, the result is comoving, if ``False`` it is physical. By default
+            the ``comoving`` status of the array is preserved.
+
+        **kwargs : dict
+            Any additional keyword arguments are supplied to the equivalence.
+
+        Returns
+        -------
+        ~swiftsimio.objects.cosmo_array
+            Copy of this array in comoving or physical units.
+
+        Raises
+        ------
+        UnitConversionError
+            If the provided ``units`` does not have the same dimensions as the array and
+            cannot be converted via a provided ``equivalence``.
+
+        Examples
+        --------
+        .. code-block:: python
+
+           >>> import unyt as u
+           >>> d = cosmo_quantity(
+           ...     1,
+           ...     u.Mpc,
+           ...     comoving=True,
+           ...     scale_factor=0.5,
+           ...     scale_exponent=1
+           ... )
+           >>> d.to_value(u.kpc, comoving=False)
+           500.0
+        """
+        return np.array(
+            self.to(units, equivalence=equivalence, comoving=comoving, **kwargs)
+        )
+
+    def to_physical_value(
+        self,
+        units: Unit | str,
+        equivalence: str | None = None,
+        **kwargs: dict[str, Any],
+    ) -> np.ndarray:
+        """
+        Return a copy of the array values in the specified physical units.
+
+        Optionally, an equivalence can be specified to convert to an equivalent quantity
+        which is not in the same dimensions.
+
+        .. note::
+
+            All additional keyword arguments are passed to the equivalency, which should
+            be used if that particular equivalency requires them.
+
+        Parameters
+        ----------
+        units : ~unyt.Unit or str
+            The desired units for the new array.
+
+        equivalence : str, optional
+            The equivalence to use. To see which equivalences are supported for this
+            quantity, try the :meth:`~unyt.array.unyt_array.list_equivalencies` method.
+
+        **kwargs : dict
+            Any additional keyword arguments are supplied to the equivalence.
+
+        Returns
+        -------
+        ~swiftsimio.objects.cosmo_array
+            Copy of the array values in the specified physical units.
+
+        Raises
+        ------
+        UnitConversionError
+            If the provided ``units`` does not have the same dimensions as the array and
+            cannot be converted via a provided ``equivalence``.
+        """
+        return self.to_value(units, equivalence=equivalence, comoving=False, **kwargs)
+
+    def to_comoving_value(
+        self,
+        units: Unit | str,
+        equivalence: str | None = None,
+        **kwargs: dict[str, Any],
+    ) -> np.ndarray:
+        """
+        Return a copy of the array values in the specified comoving units.
+
+        Optionally, an equivalence can be specified to convert to an equivalent quantity
+        which is not in the same dimensions.
+
+        .. note::
+
+            All additional keyword arguments are passed to the equivalency, which should
+            be used if that particular equivalency requires them.
+
+        Parameters
+        ----------
+        units : ~unyt.Unit or str
+            The desired units for the new array.
+
+        equivalence : str, optional
+            The equivalence to use. To see which equivalences are supported for this
+            quantity, try the :meth:`~unyt.array.unyt_array.list_equivalencies` method.
+
+        **kwargs : dict
+            Any additional keyword arguments are supplied to the equivalence.
 
         Returns
         -------
         np.ndarray
             Copy of the array values in the specified comoving units.
+
+        Raises
+        ------
+        UnitConversionError
+            If the provided ``units`` does not have the same dimensions as the array and
+            cannot be converted via a provided ``equivalence``.
         """
-        return self.to_comoving().to_value(units)
+        return self.to_value(units, equivalence=equivalence, comoving=True, **kwargs)
 
     def compatible_with_comoving(self) -> bool:
         """
@@ -1546,7 +1889,7 @@ class cosmo_array(unyt_array):
 
         valid_transform : bool
             Flag to indicate whether this array can be converted to comoving. If
-            ``False``, then ``comoving`` must be ``False``.
+            ``False``, then ``comoving`` must be ``False`` (or ``None``).
 
         Returns
         -------
@@ -1601,7 +1944,7 @@ class cosmo_array(unyt_array):
             hdf5 file.
         valid_transform : bool
             Flag to indicate whether this array can be converted to comoving. If
-            ``False``, then ``comoving`` must be ``False``.
+            ``False``, then ``comoving`` must be ``False`` (or ``None``).
 
         Returns
         -------
@@ -1633,14 +1976,15 @@ class cosmo_array(unyt_array):
 
     @classmethod
     def __unyt_ufunc_prepare__(
-        cls, ufunc: np.ufunc, method: str, *inputs: tuple, **kwargs: dict
+        cls, ufunc: np.ufunc, method: str, *inputs: tuple, **kwargs: dict[str, Any]
     ) -> tuple[np.ufunc, str, tuple, dict]:
         """
         Prepare arguments for a ufunc call.
 
         This function gives us the opportunity to pre-process arguments to a ufunc call
-        before handing control off to :mod:`unyt`. The arguments and kwargs are checked for
-        consistent ``cosmo_factor`` attributes and coerced to a common comoving/physical state.
+        before handing control off to :mod:`unyt`. The arguments and kwargs are checked
+        for consistent ``cosmo_factor`` attributes and coerced to a common
+        comoving/physical state.
 
         Parameters
         ----------
@@ -1680,7 +2024,7 @@ class cosmo_array(unyt_array):
         ufunc: np.ufunc,
         method: str,
         *inputs: tuple,
-        **kwargs: dict,
+        **kwargs: dict[str, Any],
     ) -> "tuple | cosmo_array":
         """
         Finalize results after a ufunc call.
@@ -1752,6 +2096,7 @@ class cosmo_array(unyt_array):
                 if isinstance(r, cosmo_array):  # also recognizes cosmo_quantity
                     r.comoving = helper_result["comoving"]
                     r.cosmo_factor = ret_cf
+                    r.valid_transform = helper_result["valid_transform"]
                     r.compression = helper_result["compression"]
         elif isinstance(result, unyt_array):  # also recognizes cosmo_quantity
             if not isinstance(result, cosmo_array):
@@ -1762,6 +2107,7 @@ class cosmo_array(unyt_array):
                 )
             result.comoving = helper_result["comoving"]
             result.cosmo_factor = ret_cf
+            result.valid_transform = helper_result["valid_transform"]
             result.compression = helper_result["compression"]
         if "out" in kwargs:
             out = kwargs.pop("out")
@@ -1776,6 +2122,7 @@ class cosmo_array(unyt_array):
                 if isinstance(out, cosmo_array):  # also recognizes cosmo_quantity
                     out.comoving = helper_result["comoving"]
                     out.cosmo_factor = ret_cf
+                    out.valid_transform = helper_result["valid_transform"]
                     out.compression = helper_result["compression"]
             else:
                 out = tuple(
@@ -1794,6 +2141,7 @@ class cosmo_array(unyt_array):
                     if isinstance(o, cosmo_array):  # also recognizes cosmo_quantity
                         o.comoving = helper_result["comoving"]
                         o.cosmo_factor = ret_cf
+                        o.valid_transform = helper_result["valid_transform"]
                         o.compression = helper_result["compression"]
         return result
 
@@ -1865,10 +2213,12 @@ class cosmo_array(unyt_array):
                 if isinstance(r, cosmo_array):  # also recognizes cosmo_quantity
                     r.comoving = helper_result["comoving"]
                     r.cosmo_factor = ret_cf
+                    r.valid_transform = helper_result["valid_transform"]
                     r.compression = helper_result["compression"]
         elif isinstance(result, cosmo_array):  # also recognizes cosmo_quantity
             result.comoving = helper_result["comoving"]
             result.cosmo_factor = ret_cf
+            result.valid_transform = helper_result["valid_transform"]
             result.compression = helper_result["compression"]
         if "out" in kwargs:
             out = kwargs.pop("out")
@@ -1877,12 +2227,14 @@ class cosmo_array(unyt_array):
                 if isinstance(out, cosmo_array):  # also recognizes cosmo_quantity
                     out.comoving = helper_result["comoving"]
                     out.cosmo_factor = ret_cf
+                    out.valid_transform = helper_result["valid_transform"]
                     out.compression = helper_result["compression"]
             else:
                 for o in out:
                     if isinstance(o, cosmo_array):  # also recognizes cosmo_quantity
                         o.comoving = helper_result["comoving"]
                         o.cosmo_factor = ret_cf
+                        o.valid_transform = helper_result["valid_transform"]
                         o.compression = helper_result["compression"]
 
         return result
@@ -2107,7 +2459,7 @@ class cosmo_quantity(cosmo_array, unyt_quantity):
 
         valid_transform : bool
             Flag to indicate whether this array can be converted to comoving. If
-            ``False``, then ``comoving`` must be ``False``.
+            ``False``, then ``comoving`` must be ``False`` (or ``None``).
 
         compression : str
             Description of the compression filters that were applied to that array in the
@@ -2152,7 +2504,7 @@ class cosmo_quantity(cosmo_array, unyt_quantity):
         valid_transform = (
             getattr(input_scalar, "valid_transform", None)
             if valid_transform is None
-            else valid_transform
+            else (valid_transform if comoving is not None else False)
         )
         compression = (
             getattr(input_scalar, "compression", None)

--- a/swiftsimio/visualisation/_vistools.py
+++ b/swiftsimio/visualisation/_vistools.py
@@ -63,17 +63,17 @@ def _get_region_info(
     dict
         A dictionary of kwargs for use with backend visualisation functions.
     """
-    boxsize = data.metadata.boxsize
-    if region is not None:
-        region = cosmo_array(region)
+    # do not use in-place conversion for region - changes user's input!
+    if region is not None and not (isinstance(region, cosmo_array)):
+        raise ValueError("Specify the region as a `cosmo_array`.")
     if data.coordinates.comoving:
-        boxsize.convert_to_comoving()
-        if region is not None:
-            region.convert_to_comoving()
+        boxsize = data.metadata.boxsize.to_comoving()
+        region = region.to_comoving() if region is not None else None
     elif data.coordinates.comoving is False:  # compare to False in case None
-        boxsize.convert_to_physical()
-        if region is not None:
-            region.convert_to_physical()
+        boxsize = data.metadata.boxsize.to_physical()
+        region = region.to_physical() if region is not None else None
+    else:
+        boxsize = data.metadata.boxsize
     box_x, box_y, box_z = boxsize
     if region is not None:
         x_min, x_max, y_min, y_max = region[:4]
@@ -230,7 +230,7 @@ def backend_restore_cosmo_and_units(
                     "lengths. Converting smoothing lengths to comoving."
                 )
             kwargs["h"].convert_to_comoving()
-            norm.convert_to_comoving()
+            converted_norm = norm.to_comoving()
         elif comoving is False:  # don't use else in case None
             if kwargs["x"].comoving or kwargs["y"].comoving:
                 warn(
@@ -245,14 +245,16 @@ def backend_restore_cosmo_and_units(
                     "lengths. Converting smoothing lengths to physical."
                 )
             kwargs["h"].convert_to_physical()
-            norm.convert_to_physical()
+            converted_norm = norm.to_physical()
+        else:
+            converted_norm = 1.0
         return (
             _copy_cosmo_array_attributes_if_present(
                 kwargs["m"],
                 backend_func(*args, **kwargs).view(cosmo_array),
                 copy_units=True,
             )
-            / norm
+            / converted_norm
         )
 
     return wrapper

--- a/swiftsimio/visualisation/_vistools.py
+++ b/swiftsimio/visualisation/_vistools.py
@@ -64,14 +64,12 @@ def _get_region_info(
         A dictionary of kwargs for use with backend visualisation functions.
     """
     # do not use in-place conversion for region - changes user's input!
-    if region is not None and not (isinstance(region, cosmo_array)):
-        raise ValueError("Specify the region as a `cosmo_array`.")
     if data.coordinates.comoving:
         boxsize = data.metadata.boxsize.to_comoving()
-        region = region.to_comoving() if region is not None else None
+        region = getattr(region, "to_comoving", lambda: region)()
     elif data.coordinates.comoving is False:  # compare to False in case None
         boxsize = data.metadata.boxsize.to_physical()
-        region = region.to_physical() if region is not None else None
+        region = getattr(region, "to_physical", lambda: region)()
     else:
         boxsize = data.metadata.boxsize
     box_x, box_y, box_z = boxsize
@@ -170,7 +168,7 @@ def _get_rotated_and_wrapped_coordinates(
     else:
         coords = data.coordinates
     if periodic:
-        coords %= data.metadata.boxsize
+        coords %= data.metadata.boxsize.to(comoving=coords.comoving)
     return coords.T
 
 

--- a/tests/test_cosmo_array.py
+++ b/tests/test_cosmo_array.py
@@ -8,7 +8,13 @@ import numpy as np
 import unyt as u
 from copy import copy, deepcopy
 import pickle
-from swiftsimio.objects import cosmo_array, cosmo_quantity, cosmo_factor, a
+from swiftsimio.objects import (
+    cosmo_array,
+    cosmo_quantity,
+    cosmo_factor,
+    a,
+    InvalidConversionError,
+)
 from importlib.metadata import version
 from packaging.version import Version
 
@@ -1265,3 +1271,102 @@ class TestPickle:
                 os.remove("ca.pkl")
         for attr_name, attr_value in attrs.items():
             assert getattr(unpickled_ca, attr_name) == attr_value
+
+
+class TestPhysicalComovingConversion:
+    """Test converting between comoving and physical quantities."""
+
+    @pytest.mark.parametrize("starting_comoving", (True, False, None))
+    @pytest.mark.parametrize("target_comoving", (True, False, None))
+    @pytest.mark.parametrize("valid_transform", (True, False))
+    def test_to(self, starting_comoving, target_comoving, valid_transform):
+        """Test conversion through the ``to`` method."""
+        try:
+            arr = cosmo_array(
+                np.ones(5),
+                u.Mpc,
+                scale_factor=0.5,
+                scale_exponent=1,
+                comoving=starting_comoving,
+                valid_transform=valid_transform,
+            )
+        except InvalidConversionError:
+            # can't initialize an array like this
+            return
+        if (starting_comoving != target_comoving and not valid_transform) or (
+            starting_comoving is None and target_comoving is not None
+        ):
+            with pytest.raises(InvalidConversionError):
+                arr.to(u.kpc, comoving=target_comoving)
+            return
+        arr_copy = arr.to(u.kpc, comoving=target_comoving)
+        if starting_comoving == target_comoving or target_comoving is None:
+            # keep what was passed in
+            asserted = True
+            assert np.allclose(arr.value, arr_copy.value / 1000)
+        elif starting_comoving is True and target_comoving is False:
+            asserted = True
+            assert np.allclose(arr.value, arr_copy.value / 1000 * 2)
+        elif starting_comoving is False and target_comoving is True:
+            asserted = True
+            assert np.allclose(arr.value, arr_copy.value / 1000 / 2)
+        assert asserted
+
+    @pytest.mark.parametrize("valid_transform", (True, False))
+    @pytest.mark.parametrize("starting_comoving", (True, False, None))
+    def test_to_comoving(self, starting_comoving, valid_transform):
+        """Test that we can make a copy in comoving coordinates."""
+        try:
+            arr = cosmo_array(
+                np.ones(5),
+                u.Mpc,
+                scale_factor=0.5,
+                scale_exponent=1,
+                comoving=starting_comoving,
+                valid_transform=valid_transform,
+            )
+        except InvalidConversionError:
+            # can't initialize an array like this
+            return
+        if not valid_transform or starting_comoving is None:
+            with pytest.raises(InvalidConversionError):
+                arr.to_comoving()
+            return
+        arr_copy = arr.to_comoving()
+        if starting_comoving is True:
+            assert np.allclose(arr.value, arr_copy.value)
+        elif starting_comoving is False:
+            print(arr, arr_copy)
+            assert np.allclose(arr.value, arr_copy.value / 2)
+
+    @pytest.mark.parametrize("valid_transform", (True, False))
+    @pytest.mark.parametrize("starting_comoving", (True, False, None))
+    def test_to_physical(self, starting_comoving, valid_transform):
+        """Test that we can make a copy in physical coordinates."""
+        try:
+            arr = cosmo_array(
+                np.ones(5),
+                u.Mpc,
+                scale_factor=0.5,
+                scale_exponent=1,
+                comoving=starting_comoving,
+                valid_transform=valid_transform,
+            )
+        except InvalidConversionError:
+            # can't initialize an array like this
+            return
+        if not valid_transform and starting_comoving is not False:
+            with pytest.raises(InvalidConversionError):
+                arr.to_physical()
+            return
+        if valid_transform and starting_comoving is None:
+            # cosmo_array.__new__ will set arr.valid_transform = False in this case
+            with pytest.raises(InvalidConversionError):
+                arr.to_physical()
+            return
+        arr_copy = arr.to_physical()
+        if starting_comoving is False:
+            assert np.allclose(arr.value, arr_copy.value)
+        elif starting_comoving is True:
+            print(arr, arr_copy)
+            assert np.allclose(arr.value, arr_copy.value * 2)

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -1536,3 +1536,26 @@ class TestProjectionBackends:
         assert np.allclose(
             repeating_img, np.block([[ref_img, ref_img], [ref_img, ref_img]])
         )
+
+
+def test_input_region_unmutated(cosmological_volume_only_single_local):
+    """
+    Check that the image region input by the user is not mutated.
+
+    Regression test for https://github.com/SWIFTSIM/swiftsimio/issues/314
+    """
+    data = load(cosmological_volume_only_single_local)
+    assert data.metadata.scale_factor < 1  # success trivial otherwise
+    size = (data.metadata.boxsize[0] * 0.25).to_physical_value(unyt.Mpc)  # as a float
+    float_region = [0, size, 0, size]
+    # now make a cosmo_array in physical Mpc:
+    im_region = cosmo_array(
+        float_region,
+        unyt.Mpc,
+        comoving=False,
+        scale_factor=data.metadata.scale_factor,
+        scale_exponent=1,
+    )
+    assert np.allclose(im_region.to_physical_value(unyt.Mpc), float_region)
+    project_gas(data, 16, region=im_region, periodic=False)
+    assert np.allclose(im_region.to_physical_value(unyt.Mpc), float_region)


### PR DESCRIPTION
This refactors some `cosmo_array` functions for more flexible conversion between comoving and physical quantities. As a summary, these previously unavailable syntax options now work:
``` python
arr.to_comoving(u.kpc)
arr.to_physical(u.kpc)
arr.to_comoving_value(u.kpc)
arr.to_physical_value(u.kpc)
arr.to(u.kpc, comoving=False)
arr.to_value(u.kpc, comoving=False)
arr.convert_to_comoving(u.kpc)
arr.convert_to_physical(u.kpc)
```
This also leads to performance improvements where possible, by avoiding a second copy. For example this would have copied twice: `arr.to(u.kpc).to_physical()` while `arr.to_physical(u.kpc)` only copies once.

The docs are updated to reflect this, and I've added some more tests for these methods.

There's also some housekeeping around the `valid_transform` flag, which I think must have been added after the big extension of `cosmo_array` a while back.

Finally, it closes #314... this PR might have happened because I got sidetracked while being more careful about using in-place conversions in the visualisation tools. Possibly.