### PR TITLE
Add an entry for new `sidm` particle type to required fields for writer

### DIFF
--- a/swiftsimio/metadata/writer/required_fields.py
+++ b/swiftsimio/metadata/writer/required_fields.py
@@ -32,3 +32,5 @@ stars = {
 black_holes = {**_shared}
 
 neutrinos = {**_shared}
+
+sidm = {**_shared}

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -4,6 +4,8 @@ import os
 import pytest
 import numpy as np
 from swiftsimio import load, cosmo_array, cosmo_quantity, Writer
+from swiftsimio.metadata.particle.particle_types import particle_name_underscores
+from swiftsimio.metadata.writer import required_fields
 from .helper import create_minimal_writer
 import unyt as u
 
@@ -481,3 +483,9 @@ def test_mismatched_boxsize_dimension(boxsize):
             dimension=2,
             scale_factor=a,
         )
+
+
+def test_all_particle_types_required_fields_defined():
+    """Check that all available particle types have a required_fields listing."""
+    for particle_name in particle_name_underscores.values():
+        assert hasattr(required_fields, particle_name)


### PR DESCRIPTION
Pretty much as the subject says, this was missed when the new type was added. I added a test to catch similar issues in the future.

@JBorrow this breaks the whole swiftgalaxy test suite which relies on the writer, so perhaps a patch release? I don't think it's totally breaking things: I don't think it breaks the writer itself, or swiftgalaxy itself, I think I have a loop over particles types that isn't happy. But anyway, trivial fix.