### PR TITLE
Conversion of arrays with no valid transform

### DIFF
--- a/docs/source/citing/index.rst
+++ b/docs/source/citing/index.rst
@@ -1,5 +1,5 @@
-Citing SWIFTGalaxy
-==================
+Citing swiftsimio
+=================
 
 .. include:: ../../../README.rst
    :start-after: CITING_START_LABEL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ packages = [
 
 [project]
 name = "swiftsimio"
-version="12.1.1"
+version="12.1.2"
 authors = [
     { name="Josh Borrow", email="josh@joshborrow.com" },
 ]

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -1650,7 +1650,11 @@ class cosmo_array(unyt_array):
            cosmo_quantity(500., 'kpc', comoving='False', cosmo_factor='a at a=0.5', \
            valid_transform='True')
         """
-        if not self.valid_transform and (comoving != self.comoving):
+        if (
+            (comoving is not None)
+            and (not self.valid_transform)
+            and (comoving != self.comoving)
+        ):
             raise InvalidConversionError
         if units is None:
             arr_copy = self.copy()

--- a/tests/test_cosmo_array.py
+++ b/tests/test_cosmo_array.py
@@ -1293,9 +1293,11 @@ class TestPhysicalComovingConversion:
         except InvalidConversionError:
             # can't initialize an array like this
             return
-        if (starting_comoving != target_comoving and not valid_transform) or (
-            starting_comoving is None and target_comoving is not None
-        ):
+        if (
+            target_comoving is not None
+            and starting_comoving != target_comoving
+            and not valid_transform
+        ) or (starting_comoving is None and target_comoving is not None):
             with pytest.raises(InvalidConversionError):
                 arr.to(u.kpc, comoving=target_comoving)
             return


### PR DESCRIPTION
Changes in https://github.com/SWIFTSIM/swiftsimio/pull/315 mean it is no longer possible to call `.to` on objects without a valid transform.
```
import swiftsimio as sw
import unyt as u

cq = sw.cosmo_quantity(
    1,
    u.m,
    comoving=False,
    scale_factor=1.0,
    scale_exponent=0,
    valid_transform=False,
)

cq.to('Mpc')
```
gives
```
Traceback (most recent call last):
  File "/cosma/home/dp004/dc-mcgi1/swiftsimio/example.py", line 13, in <module>
    cq.to('Mpc')
  File "/cosma/home/dp004/dc-mcgi1/swiftsimio/swiftsimio/objects.py", line 1654, in to
    raise InvalidConversionError
swiftsimio.objects.InvalidConversionError
```
This is due to a check that should be skipped if `comoving=None` (i.e. we don't want to convert the array)