### PR TITLE
Relax tolerance on cosmo_factor match to 1 in 1e6.

### DIFF
--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -790,7 +790,7 @@ class cosmo_factor(object):
         elif self.a_factor is None or b.a_factor is None:
             # we know they're not both None from previous case
             a_factor_match = False
-        elif np.isclose(self.a_factor, b.a_factor, rtol=1e-9):
+        elif np.isclose(self.a_factor, b.a_factor, rtol=1e-6):
             a_factor_match = True
         else:
             a_factor_match = False


### PR DESCRIPTION
Previously the tolerance for "the same scale factor" was 1 in 1e9, which led to some user-reported errors (e.g. halo catalogues recording the scale factor to a different precision than the snapshot led to `ValueError: Arguments have cosmo_factors that differ: a at a=0.507213 and a at a=0.5072126781084283.`). Relaxing this to 1e-6 should alleviate this kind of issue without causing any other problems.