### PR TITLE
Add helpers to more easily create `cosmo_array` and `cosmo_quantity`

### DIFF
--- a/docs/source/cosmo_array/index.rst
+++ b/docs/source/cosmo_array/index.rst
@@ -101,6 +101,9 @@ cases a warning is produced stating that this assumption has been made.
    supported (although some might "just work"). Requests to support specific functions can
    be accommodated.
 
+Creating "cosmo" arrays and scalars
+-----------------------------------
+
 To make the most of the utility offered by the :class:`~swiftsimio.objects.cosmo_array`
 class, it is helpful to know how to create your own. A good template for this looks like:
 
@@ -120,7 +123,42 @@ class, it is helpful to know how to create your own. A good template for this lo
    # consider getting the scale factor from metadata when applicable, i.e. replace:
    # scale_factor=0.5
    # with:
-   # scale_factor=data.metadata.a
+   # scale_factor=data.metadata.scale_factor
+
+This can be long to write out. To alleviate this a helper is available in the
+``metadata``. Just like units can be multiplied with "raw" numbers/arrays to create
+arrays with units, the helper can be multiplied or divided in to attach the "cosmo"
+attributes.
+
+.. code-block:: python
+
+   dat = load("snap.hdf5")
+   a = dat.metadata.a  # best give it a short name for ease of use
+   densities = [1, 2, 3] * u.g / u.cm**3 * a.physical**-3
+
+This specifies that these densities are in physical (not comoving) units and scale as
+:math:`a^{-3}`. The shorter ``a.phys`` and ``a.com`` are also available as aliases for
+``a.physical`` and ``a.comoving``, or for the especially keystroke-averse, ``a.p`` and
+``a.c`` are also available.
+
+.. warning::
+
+   In older versions of :mod:`swiftsimio` the ``metadata.a`` attribute was an alias for
+   ``metadata.scale_factor``, and stored a ``float``. Now, trying to use this helper as
+   previously will raise an error, for example ``10 * metadata.a`` complains that you
+   need to use ``metadata.a.physical`` or ``metadata.a.comoving``, not just
+   ``metadata.a``. You can substitute ``metadata.scale_factor`` for a drop-in replacement.
+   The one exception to this is that ``cosmo_array(..., scale_factor=metadata.a)`` will
+   still work, to offer some backwards-compatibility.
+
+You can also easily define cosmology-aware units with this helper, for example:
+
+.. code-block:: python
+
+   cMpc = u.Mpc * a.comoving  # equivalently: a.comoving**1, the power of 1 is implicit
+   pMpc = u.Mpc * a.physical
+   distance = 10 * pMpc
+   number_density = 0.5 / cMpc**3
 
 There is also a very similar :class:`~swiftsimio.objects.cosmo_quantity` class designed
 for scalar values, analogous to the :class:`~unyt.array.unyt_quantity`. You may encounter
@@ -139,4 +177,6 @@ initialized similarly:
        scale_factor=0.5,
        scale_exponent=1,
    )
+   # or, equivalently:
+   my_cosmo_quantity = 2 * u.Mpc * a.physical
 

--- a/docs/source/creating_initial_conditions/index.rst
+++ b/docs/source/creating_initial_conditions/index.rst
@@ -38,60 +38,38 @@ Example
    import numpy as np
    import unyt as u
    from swiftsimio import Writer, cosmo_array
-   from swiftsimio.metadata.writer.unit_systems import cosmo_unit_system
+   from swiftsimio.metadata.writer.unit_systems import cosmo_units
 
    # number of gas particles
    n_p = 1000
    # scale factor of 1.0
-   a = 1.0
+   scale_factor = 1.0
    # Box is 100 Mpc
    lbox = 100
    boxsize = cosmo_array(
         [lbox, lbox, lbox],
         u.Mpc,
         comoving=True,
-        scale_factor=a,
+        scale_factor=scale_factor,
         scale_exponent=1,
    )
 
    # Create the Writer object. cosmo_unit_system corresponds to default Gadget-like units
    # of 10^10 Msun, Mpc, and km/s
-   w = Writer(unit_system=cosmo_unit_system, boxsize=boxsize, scale_factor=a)
+   w = Writer(unit_system=cosmo_units, boxsize=boxsize, scale_factor=a)
 
    # Randomly spaced coordinates from 0 to lbox Mpc in each direction
-   w.gas.coordinates = cosmo_array(
-       np.random.rand(n_p, 3) * lbox,
-       u.Mpc,
-       comoving=True,
-       scale_factor=w.scale_factor,
-       scale_exponent=1,
-   )
+   w.gas.coordinates = np.random.rand(n_p, 3) * lbox * u.Mpc * w.a.comoving
 
    # Random velocities from 0 to 1 km/s
-   w.gas.velocities = cosmo_array(
-       np.random.rand(n_p, 3),
-       u.km / u.s,
-       comoving=True,
-       scale_factor=w.scale_factor,
-       scale_exponent=1,
-   )
+   w.gas.velocities = np.random.rand(n_p, 3) * u.km / u.s * w.a.comoving**0
 
    # Generate uniform masses as 10^6 solar masses for each particle
-   w.gas.masses = cosmo_array(
-       np.ones(n_p, dtype=float) * 1e6,
-       u.solMass,
-       comoving=True,
-       scale_factor=w.scale_factor,
-       scale_exponent=0,
-   )
+   w.gas.masses = np.ones(n_p, dtype=float) * 1e6 * u.solMass * w.a.comoving**0
 
    # Generate internal energy corresponding to 10^4 K
-   w.gas.internal_energy = cosmo_array(
-       np.ones(n_p, dtype=float) * 1e4 / 1e6,
-       u.kb * u.K / u.solMass,
-       comoving=True,
-       scale_factor=w.scale_factor,
-       scale_exponent=-2,
+   w.gas.internal_energy = (
+       np.ones(n_p, dtype=float) * 1e4 / 1e6 * u.kb * u.K / u.solMass * w.a.comoving**-2
    )
 
    # Generate initial guess for smoothing lengths based on mean inter-particle spacing

--- a/docs/source/loading_data/index.rst
+++ b/docs/source/loading_data/index.rst
@@ -261,7 +261,6 @@ in SWIFT will be automatically read.
 
    import swiftsimio as sw
    import swiftsimio.metadata.particle as swp
-   from swiftsimio.objects import cosmo_factor, a
 
    swp.particle_name_underscores[6] = "extratype"
    swp.particle_name_class[6] = "Extratype"

--- a/docs/source/masking/index.rst
+++ b/docs/source/masking/index.rst
@@ -90,9 +90,9 @@ constraint should be imposed along that axis. For example, to select a 1 Mpc thi
 
    import unyt as u
    slab_mask = sw.mask(filename)
-   scale_factor = slab_mask.metadata.scale_factor
+   a = slab_mask.metadata.a
    slab_region = [
-       cosmo_array([1, 2], u.Mpc, comoving=True, scale_factor=scale_factor, scale_exponent=1),
+       [1, 2] * u.Mpc * a.comoving,
        None,
        None,
    ]
@@ -244,6 +244,7 @@ particles within a chosen density window.
 
    # This creates and sets up the masking object.
    mask = sw.mask("cosmological_volume.hdf5")
+   a = mask.metadata.a
 
    # This ahead-of-time creates a spatial mask based on the cell metadata.
    mask.constrain_spatial(
@@ -263,20 +264,8 @@ particles within a chosen density window.
    mask.constrain_mask(
        "gas",
        "density",
-       cosmo_quantity(
-           0.4,
-           u.g / u.cm ** 3,
-           comoving=True,
-           scale_factor=mask.metadata.scale_factor,
-           scale_exponent=-3
-       ),
-       cosmo_quantity(
-           0.8,
-           u.g / u.cm ** 3,
-           comoving=True,
-           scale_factor=mask.metadata.scale_factor,
-           scale_exponent=-3
-       ),
+       0.4 * u.g / u.cm**3 * a.comoving**-3,
+       0.8 * u.g / u.cm**3 * a.comoving**-3,
    )
 
    # Now we can grab the actual data object. This includes the mask as a parameter.
@@ -345,10 +334,10 @@ as follows
     import unyt
 
     mask = sw.mask("eagle_snapshot.hdf5")
-    scale_factor = mask.metadata.scale_factor
+    a = mask.metadata.a
     mask.constrain_spatial(
         [
-            cosmo_array([100, 200], u.kpc, comoving=True, scale_factor=scale_factor, scale_exponent=1),
+            [100, 200] * u.kpc * a.comoving,
             None,
             None,
         ]

--- a/docs/source/visualisation/projection.rst
+++ b/docs/source/visualisation/projection.rst
@@ -236,29 +236,19 @@ is shown in the ``velociraptor`` section.
    )
 
    data_mask = mask(snapshot_filename)
-   region = cosmo_array(
-       [
-           [x - size, x + size],
-           [y - size, y + size],
-           [z - size, z + size],
-       ],
-       x.units,
-       comoving=True,
-       scale_factor=data_mask.metadata.a,
-       scale_exponent=1,
-   )
+   a = data_mask.metadata.a
+   region = [
+       [x - size, x + size],
+       [y - size, y + size],
+       [z - size, z + size],
+   ] * a.comoving
 
-   visualise_region = cosmo_array(
-       [
-           x - 0.5 * size,
-           x + 0.5 * size,
-           y - 0.5 * size,
-           y + 0.5 * size,
-       ],
-       comoving=True,
-       scale_factor=data_mask.metadata.a,
-       scale_exponent=1,
-   )
+   visualise_region = [
+       x - 0.5 * size,
+       x + 0.5 * size,
+       y - 0.5 * size,
+       y + 0.5 * size,
+   ] * a.comoving
 
    data_mask.constrain_spatial(region)
    data = load(snapshot_filename, mask=data_mask)
@@ -275,9 +265,7 @@ is shown in the ``velociraptor`` section.
 
    un_rotated = project_gas(**common_arguments)
 
-   rotation_center = cosmo_array(
-       [x, y, z], comoving=True, scale_factor=data_mask.metadata.a, scale_exponent=1
-   )
+   rotation_center = [x, y, z] * a.comoving
    face_on = project_gas(
        **common_arguments,
        rotation_center=rotation_center,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "astropy>=6.0",
     "numpy>=2.1.0",
     "h5py",
-    "unyt>=3.1.0",
+    "unyt @ git+https://github.com/kyleaoman/unyt@main",  # both PR branches merged here
     "numba>=0.50.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ fixable = ["ALL"]
 unfixable = []
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
+[tool.ruff.lint.flake8-annotations]
+allow-star-arg-any = true
+
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["ANN"]
 

--- a/swiftsimio/_array_functions.py
+++ b/swiftsimio/_array_functions.py
@@ -130,8 +130,10 @@ _HANDLED_FUNCTIONS: dict[Callable, Callable] = {}
 
 
 def _copy_cosmo_array_attributes(
-    from_ca: objects.cosmo_array, to_ca: objects.cosmo_array, copy_units: bool = False
-) -> objects.cosmo_array:
+    from_ca: "objects.cosmo_array",
+    to_ca: "objects.cosmo_array",
+    copy_units: bool = False,
+) -> "objects.cosmo_array":
     """
     Copy :class:`~swiftsimio.objects.cosmo_array` attributes across two objects.
 

--- a/swiftsimio/_array_functions.py
+++ b/swiftsimio/_array_functions.py
@@ -15,6 +15,7 @@ import warnings
 from functools import reduce
 import numpy as np
 from typing import Callable, Any
+from numpy._globals import _NoValueType
 import unyt
 from unyt import unyt_quantity, unyt_array
 from swiftsimio import objects
@@ -122,15 +123,52 @@ from packaging.version import Version
 
 NUMPY_VERSION = Version(version("numpy"))
 
-_HANDLED_FUNCTIONS = {}
+_HANDLED_FUNCTIONS: dict[Callable, Callable] = {}
 
 # first we define helper functions to handle repetitive operations in wrapping unyt &
 # numpy functions (we will actually wrap the functions below):
 
 
+def _copy_cosmo_array_attributes(
+    from_ca: objects.cosmo_array, to_ca: objects.cosmo_array, copy_units: bool = False
+) -> objects.cosmo_array:
+    """
+    Copy :class:`~swiftsimio.objects.cosmo_array` attributes across two objects.
+
+    Copies the ``cosmo_factor``, ``comoving``, ``valid_transform`` and ``compression``
+    attributes across. If the objects may not have these attributes use
+    :func:`~swiftsimio._array_functions._copy_cosmo_array_attributes_if_present` instead.
+
+    Parameters
+    ----------
+    from_ca : ~swiftsimio.objects.cosmo_array
+        The source object.
+
+    to_ca : ~swiftsimio.objects.cosmo_array
+        The destination object.
+
+    copy_units : bool
+        If ``True`` also copy ``units`` attribute (usually let :mod:`unyt` handle this).
+
+    Returns
+    -------
+    ~swiftsimio.objects.cosmo_array
+        The destination object with attributes copied.
+    """
+    if copy_units:
+        to_ca.units = from_ca.units
+    to_ca.cosmo_factor = from_ca.cosmo_factor
+    to_ca.comoving = from_ca.comoving
+    to_ca.valid_transform = from_ca.valid_transform
+    to_ca.compression = from_ca.compression
+    return to_ca
+
+
 def _copy_cosmo_array_attributes_if_present(
-    from_ca: object, to_ca: object, copy_units: bool = False
-) -> object:
+    from_ca: Any,  # noqa: ANN401
+    to_ca: Any,  # noqa: ANN401
+    copy_units: bool = False,
+) -> Any:  # noqa: ANN401
     """
     Copy :class:`~swiftsimio.objects.cosmo_array` attributes across two objects.
 
@@ -140,10 +178,10 @@ def _copy_cosmo_array_attributes_if_present(
 
     Parameters
     ----------
-    from_ca : :obj:`object`
+    from_ca : Any
         The source object.
 
-    to_ca : :obj:`object`
+    to_ca : Any
         The destination object.
 
     copy_units : bool
@@ -151,7 +189,7 @@ def _copy_cosmo_array_attributes_if_present(
 
     Returns
     -------
-    :obj:`object`
+    Any
         The destination object (with attributes copied if copy occurred).
     """
     if not (
@@ -159,13 +197,7 @@ def _copy_cosmo_array_attributes_if_present(
         and isinstance(from_ca, objects.cosmo_array)
     ):
         return to_ca
-    if copy_units:
-        to_ca.units = from_ca.units
-    to_ca.cosmo_factor = from_ca.cosmo_factor
-    to_ca.comoving = from_ca.comoving
-    to_ca.valid_transform = from_ca.valid_transform
-    to_ca.compression = from_ca.compression
-    return to_ca
+    return _copy_cosmo_array_attributes(from_ca, to_ca, copy_units=copy_units)
 
 
 def _propagate_cosmo_array_attributes_to_result(func: Callable) -> Callable:
@@ -193,16 +225,16 @@ def _propagate_cosmo_array_attributes_to_result(func: Callable) -> Callable:
 
     def wrapped(
         obj: object,
-        *args: tuple[Any],
-        **kwargs: dict[str, Any],
-    ) -> object:  # noqa numpydoc ignore=GL08
+        *args: Any,
+        **kwargs: Any,
+    ) -> object:  # numpydoc ignore=GL08
         # omit docstring so that sphinx picks up docstring of wrapped function
         return _copy_cosmo_array_attributes_if_present(obj, func(obj, *args, **kwargs))
 
     return wrapped
 
 
-def _promote_unyt_to_cosmo(input_object: object) -> object:
+def _promote_unyt_to_cosmo(input_object: np.ndarray) -> np.ndarray:
     """
     Upgrade the input unyt instance to its cosmo equivalent.
 
@@ -215,8 +247,14 @@ def _promote_unyt_to_cosmo(input_object: object) -> object:
 
     Parameters
     ----------
-    input_object : :obj:`object`
+    input_object : ~numpy.ndarray
         Object to consider for promotion from unyt instance to cosmo instance.
+
+    Returns
+    -------
+    ~numpy.ndarray
+        A :class:`~swiftsimio.objects.cosmo_array` if the input was a
+        :class:`~unyt.array.unyt_array`, otherwise the input unchanged.
     """
     if isinstance(input_object, unyt_quantity) and not isinstance(
         input_object, objects.cosmo_quantity
@@ -287,9 +325,7 @@ def _ensure_result_is_cosmo_array_or_quantity(func: Callable) -> Callable:
         The wrapped function.
     """
 
-    def wrapped(
-        *args: tuple[Any], **kwargs: dict[str, Any]
-    ) -> object:  # # noqa numpydoc ignore=GL08
+    def wrapped(*args: Any, **kwargs: Any) -> object:  # numpydoc ignore=GL08
         # omit docstring so that sphinx picks up docstring of wrapped function
         result = func(*args, **kwargs)
         if isinstance(result, tuple):
@@ -306,7 +342,7 @@ def _ensure_result_is_cosmo_array_or_quantity(func: Callable) -> Callable:
 
 
 def _sqrt_cosmo_factor(
-    cf: "objects.cosmo_factor", **kwargs: dict[str, Any]
+    cf: "objects.cosmo_factor", **kwargs: Any
 ) -> "objects.cosmo_factor":
     """
     Take the square root of a :class:`~swiftsimio.objects.cosmo_factor`.
@@ -316,7 +352,7 @@ def _sqrt_cosmo_factor(
     cf : swiftsimio.objects.cosmo_factor
         :class:`~swiftsimio.objects.cosmo_factor` whose square root should be taken.
 
-    **kwargs : dict[str, Any]
+    **kwargs : Any
         Arbitrary kwargs.
 
     Returns
@@ -328,7 +364,7 @@ def _sqrt_cosmo_factor(
 
 
 def _multiply_cosmo_factor(
-    *cfs: tuple["objects.cosmo_factor"], **kwargs: dict[str, Any]
+    *cfs: "objects.cosmo_factor", **kwargs: Any
 ) -> "objects.cosmo_factor":
     """
     Recursively multiply :class:`~swiftsimio.objects.cosmo_factor`s.
@@ -341,7 +377,7 @@ def _multiply_cosmo_factor(
     *cfs : swiftsimio.objects.cosmo_factor
         :class:`~swiftsimio.objects.cosmo_factor`s to be multiplied.
 
-    **kwargs : dict[str, Any]
+    **kwargs : Any
         Arbitrary kwargs.
 
     Returns
@@ -353,7 +389,7 @@ def _multiply_cosmo_factor(
 
 
 def __binary_multiply_cosmo_factor(
-    cf1: "objects.cosmo_factor", cf2: "objects.cosmo_factor", **kwargs: dict[str, Any]
+    cf1: "objects.cosmo_factor", cf2: "objects.cosmo_factor", **kwargs: Any
 ) -> "objects.cosmo_factor":
     """
     Multiply two :class:`~swiftsimio.objects.cosmo_factor`s.
@@ -369,7 +405,7 @@ def __binary_multiply_cosmo_factor(
     cf2 : swiftsimio.objects.cosmo_factor
         The second :class:`~swiftsimio.objects.cosmo_factor`.
 
-    **kwargs : dict[str, Any]
+    **kwargs : Any
         Arbitrary kwargs.
 
     Returns
@@ -392,7 +428,7 @@ def __binary_multiply_cosmo_factor(
 
 
 def _preserve_cosmo_factor(
-    *cfs: tuple["objects.cosmo_factor"], **kwargs: dict[str, Any]
+    *cfs: "objects.cosmo_factor", **kwargs: Any
 ) -> "objects.cosmo_factor":
     """
     Preserve the :class:`~swiftsimio.objects.cosmo_factor` of input.
@@ -406,7 +442,7 @@ def _preserve_cosmo_factor(
     *cfs : swiftsimio.objects.cosmo_factor
         :class:`~swiftsimio.objects.cosmo_factor`s to be preserved.
 
-    **kwargs : dict[str, Any]
+    **kwargs : Any
         Arbitrary kwargs.
 
     Returns
@@ -418,7 +454,7 @@ def _preserve_cosmo_factor(
 
 
 def __binary_preserve_cosmo_factor(
-    cf1: "objects.cosmo_factor", cf2: "objects.cosmo_factor", **kwargs: dict[str, Any]
+    cf1: "objects.cosmo_factor", cf2: "objects.cosmo_factor", **kwargs: Any
 ) -> "objects.cosmo_factor":
     """
     Given two :class:`~swiftsimio.objects.cosmo_factor`s, get it if they match.
@@ -436,7 +472,7 @@ def __binary_preserve_cosmo_factor(
     cf2 : swiftsimio.objects.cosmo_factor
         The second :class:`~swiftsimio.objects.cosmo_factor`.
 
-    **kwargs : dict[str, Any]
+    **kwargs : Any
         Arbitrary kwargs.
 
     Returns
@@ -477,8 +513,8 @@ def __binary_preserve_cosmo_factor(
 
 def _power_cosmo_factor(
     cf1: "objects.cosmo_factor",
-    cf2: "objects.cosmo_factor",
-    inputs: "tuple[objects.cosmo_array] | None" = None,
+    cf2: "objects.cosmo_factor | None",
+    inputs: "tuple[objects.cosmo_array, objects.cosmo_array] | None" = None,
     power: float | None = None,
 ) -> "objects.cosmo_factor":
     """
@@ -515,7 +551,9 @@ def _power_cosmo_factor(
     if (inputs is not None and power is not None) or (inputs is None and power is None):
         raise ValueError
     power = inputs[1] if inputs else power
-    if hasattr(power, "units"):
+    if power is None:
+        raise ValueError
+    if isinstance(power, unyt_array):
         if not power.units.is_dimensionless:
             raise ValueError("Exponent must be dimensionless.")
         elif power.units is not unyt.dimensionless:
@@ -526,11 +564,11 @@ def _power_cosmo_factor(
         raise ValueError("Exponent has scaling with scale factor != 1.")
     if cf1 is None:
         return None
-    return np.power(cf1, power)
+    return cf1**power
 
 
 def _square_cosmo_factor(
-    cf: "objects.cosmo_factor", **kwargs: dict[str, Any]
+    cf: "objects.cosmo_factor", **kwargs: Any
 ) -> "objects.cosmo_factor":
     """
     Square a :class:`~swiftsimio.objects.cosmo_factor`.
@@ -540,7 +578,7 @@ def _square_cosmo_factor(
     cf : swiftsimio.objects.cosmo_factor
         :class:`~swiftsimio.objects.cosmo_factor` to square.
 
-    **kwargs : dict[str, Any]
+    **kwargs : Any
         Arbitrary kwargs.
 
     Returns
@@ -552,7 +590,7 @@ def _square_cosmo_factor(
 
 
 def _cbrt_cosmo_factor(
-    cf: "objects.cosmo_factor", **kwargs: dict[str, Any]
+    cf: "objects.cosmo_factor", **kwargs: Any
 ) -> "objects.cosmo_factor":
     """
     Take the cube root of a :class:`~swiftsimio.objects.cosmo_factor`.
@@ -562,7 +600,7 @@ def _cbrt_cosmo_factor(
     cf : swiftsimio.objects.cosmo_factor
         :class:`~swiftsimio.objects.cosmo_factor` whose cube root should be taken.
 
-    **kwargs : dict[str, Any]
+    **kwargs : Any
         Arbitrary kwargs.
 
     Returns
@@ -574,7 +612,7 @@ def _cbrt_cosmo_factor(
 
 
 def _divide_cosmo_factor(
-    cf1: "objects.cosmo_factor", cf2: "objects.cosmo_factor", **kwargs: dict[str, Any]
+    cf1: "objects.cosmo_factor", cf2: "objects.cosmo_factor", **kwargs: Any
 ) -> "objects.cosmo_factor":
     """
     Divide two :class:`~swiftsimio.objects.cosmo_factor`s.
@@ -587,7 +625,7 @@ def _divide_cosmo_factor(
     cf2 : swiftsimio.objects.cosmo_factor
         Denominator :class:`~swiftsimio.objects.cosmo_factor`.
 
-    **kwargs : dict[str, Any]
+    **kwargs : Any
         Arbitrary kwargs.
 
     Returns
@@ -599,7 +637,7 @@ def _divide_cosmo_factor(
 
 
 def _reciprocal_cosmo_factor(
-    cf: "objects.cosmo_factor", **kwargs: dict[str, Any]
+    cf: "objects.cosmo_factor", **kwargs: Any
 ) -> "objects.cosmo_factor":
     """
     Take the inverse of a :class:`~swiftsimio.objects.cosmo_factor`.
@@ -609,7 +647,7 @@ def _reciprocal_cosmo_factor(
     cf : swiftsimio.objects.cosmo_factor
         :class:`~swiftsimio.objects.cosmo_factor` to be inverted.
 
-    **kwargs : dict[str, Any]
+    **kwargs : Any
         Arbitrary kwargs.
 
     Returns
@@ -621,9 +659,7 @@ def _reciprocal_cosmo_factor(
 
 
 def _passthrough_cosmo_factor(
-    cf: "objects.cosmo_factor",
-    cf2: "objects.cosmo_factor | None" = None,
-    **kwargs: dict[str, Any],
+    cf: "objects.cosmo_factor", cf2: "objects.cosmo_factor | None" = None, **kwargs: Any
 ) -> "objects.cosmo_factor":
     """
     Keep the same :class:`~swiftsimio.objects.cosmo_factor`.
@@ -642,7 +678,7 @@ def _passthrough_cosmo_factor(
     cf2 : swiftsimio.objects.cosmo_factor
         Optional second :class:`~swiftsimio.objects.cosmo_factor` to check matches.
 
-    **kwargs : dict[str, Any]
+    **kwargs : Any
         Arbitrary kwargs.
 
     Returns
@@ -664,10 +700,10 @@ def _passthrough_cosmo_factor(
 
 def _return_without_cosmo_factor(
     cf: "objects.cosmo_factor",
-    cf2: "objects.cosmo_factor" = np._NoValue,
+    cf2: "objects.cosmo_factor | _NoValueType" = np._NoValue,
     zero_comparison: bool | None = None,
-    **kwargs: dict[str, Any],
-) -> None:
+    **kwargs: Any,
+) -> "objects.cosmo_factor | None":
     """
     Return ``None`` after checking compatibility.
 
@@ -698,7 +734,7 @@ def _return_without_cosmo_factor(
         If ``True``, silences warnings when exactly one of ``cf1`` and ``cf2`` is
         ``None``. Enables comparing with zero without warning.
 
-    **kwargs : dict[str, Any]
+    **kwargs : Any
         Arbitrary kwargs.
 
     Returns
@@ -741,7 +777,7 @@ def _return_without_cosmo_factor(
 
 
 def _arctan2_cosmo_factor(
-    cf1: "objects.cosmo_factor", cf2: "objects.cosmo_factor", **kwargs: dict[str, Any]
+    cf1: "objects.cosmo_factor", cf2: "objects.cosmo_factor", **kwargs: Any
 ) -> "objects.cosmo_factor":
     """
     Handle the :class:`~swiftsimio.objects.cosmo_factor`s for the ``arctan2`` ufunc.
@@ -754,7 +790,7 @@ def _arctan2_cosmo_factor(
     cf2 : swiftsimio.objects.cosmo_factor
         :class:`~swiftsimio.objects.cosmo_factor` for the second ``arctan2`` argument.
 
-    **kwargs : dict[str, Any]
+    **kwargs : Any
         Arbitrary kwargs.
 
     Returns
@@ -788,13 +824,16 @@ def _arctan2_cosmo_factor(
         raise ValueError(f"Arguments have cosmo_factors that differ: {cf1} and {cf2}.")
     elif (cf1 is not None) and (cf2 is not None) and (cf1 == cf2):
         return objects.cosmo_factor(objects.a**0, scale_factor=cf1.scale_factor)
+    else:
+        raise RuntimeError("Unexpected state, please report this.")
 
 
 def _comparison_cosmo_factor(
     cf1: "objects.cosmo_factor",
     cf2: "objects.cosmo_factor",
-    inputs: "tuple[objects.cosmo_array] | None" = None,
-) -> None:
+    *,
+    inputs: "tuple[objects.cosmo_array, objects.cosmo_array]",
+) -> "objects.cosmo_factor | None":
     """
     Enable comparisons involving :class:`~swiftsimio.objects.cosmo_factor`s.
 
@@ -821,31 +860,19 @@ def _comparison_cosmo_factor(
     None
         The :class:`~swiftsimio.objects.cosmo_factor` is discarded.
     """
-    try:
-        iter(inputs[0])
-    except TypeError:
-        input1_iszero = (
-            not getattr(inputs[0], "value", inputs[0]) and inputs[0] is not False
-        )
-    else:
-        input1_iszero = not getattr(inputs[0], "value", inputs[0]).any()
-    try:
-        iter(inputs[1])
-    except IndexError:
-        input2_iszero = None
-    except TypeError:
-        input2_iszero = (
-            not getattr(inputs[1], "value", inputs[1]) and inputs[1] is not False
-        )
-    else:
-        input2_iszero = not getattr(inputs[1], "value", inputs[1]).any()
+    input1_iszero = (
+        np.asarray(inputs[0]).dtype is not np.dtype(bool)
+        and not np.asarray(inputs[0]).any()
+    )
+    input2_iszero = (
+        np.asarray(inputs[1]).dtype is not np.dtype(bool)
+        and not np.asarray(inputs[1]).any()
+    )
     zero_comparison = input1_iszero or input2_iszero
     return _return_without_cosmo_factor(cf1, cf2=cf2, zero_comparison=zero_comparison)
 
 
-def _prepare_array_func_args(
-    *args: tuple[Any], _default_cm: bool = True, **kwargs: dict[str, Any]
-) -> dict:
+def _prepare_array_func_args(*args: Any, **kwargs: Any) -> dict:
     """
     Coerce args and kwargs to a common ``comoving`` and collect ``cosmo_factor``s.
 
@@ -874,14 +901,10 @@ def _prepare_array_func_args(
 
     Parameters
     ----------
-    *args : tuple[Any]
+    *args : Any
         Arbitrary arguments to prepare.
 
-    _default_cm : bool
-        If mixed ``comoving`` attributes are found, their data are converted such that
-        their ``comoving`` has the value of this argument.
-
-    **kwargs : dict[str, Any]
+    **kwargs : Any
         Arbitrary kwargs to prepare.
 
     Returns
@@ -897,6 +920,7 @@ def _prepare_array_func_args(
     ValueError
         If the input arrays cannot be coerced to a consistent state of ``comoving``.
     """
+    _default_cm: bool = kwargs.pop("_default_cm", True)
     # test isinstance(arg, cosmo_array) instead of hasattr(arg, "comoving"):
     # _AHelper.comoving -> _AHelper can cause problems
     cms = [
@@ -945,20 +969,20 @@ def _prepare_array_func_args(
                     _default_cm = False
                     break
         if _default_cm:
-            args = [
+            args = tuple(
                 arg.to_comoving() if cm[0] and not cm[1] else arg
                 for arg, cm in zip(args, cms)
-            ]
+            )
             kwargs = {
                 k: kwarg.to_comoving() if kw_cms[k][0] and not kw_cms[k][1] else kwarg
                 for k, kwarg in kwargs.items()
             }
             ret_cm = True
         else:
-            args = [
+            args = tuple(
                 arg.to_physical() if cm[0] and not cm[1] else arg
                 for arg, cm in zip(args, cms)
-            ]
+            )
             kwargs = {
                 k: kwarg.to_physical() if kw_cms[k][0] and not kw_cms[k][1] else kwarg
                 for k, kwarg in kwargs.items()
@@ -1023,9 +1047,9 @@ def implements(numpy_function: Callable) -> Callable:
 def _return_helper(
     res: np.ndarray,
     helper_result: dict,
-    ret_cf: "objects.cosmo_factor",
+    ret_cf: "objects.cosmo_factor | None",
     out: np.ndarray | None = None,
-) -> "objects.cosmo_array":
+) -> np.ndarray:
     """
     Attach our cosmo attributes to return values of wrapped functions.
 
@@ -1092,22 +1116,22 @@ def _default_unary_wrapper(
         The wrapped function.
     """
 
-    def wrapper(*args: tuple[Any], **kwargs: dict[str, Any]) -> Callable:
+    def wrapper(*args: Any, **kwargs: Any) -> np.ndarray:
         """
         Prepare arguments, handle ``cosmo_factor`` attributes, and attach attributes.
 
         Parameters
         ----------
-        *args : tuple[Any]
+        *args : Any
             Arbitrary arguments of the wrapped function.
 
-        **kwargs : dict[str, Any]
+        **kwargs : Any
             Arbitrary kwargs of the wrapped function.
 
         Returns
         -------
-        Callable
-            The wrapped function.
+        ~numpy.ndarray
+            The processed result.
         """
         helper_result = _prepare_array_func_args(*args, **kwargs)
         ret_cf = cosmo_factor_handler(helper_result["cfs"][0])
@@ -1147,22 +1171,22 @@ def _default_binary_wrapper(
         The wrapped function.
     """
 
-    def wrapper(*args: tuple[Any], **kwargs: dict[str, Any]) -> Callable:
+    def wrapper(*args: Any, **kwargs: Any) -> np.ndarray:
         """
         Prepare arguments, handle ``cosmo_factor`` attributes, and attach attributes.
 
         Parameters
         ----------
-        *args : tuple[Any]
+        *args : Any
             Arbitrary arguments of the wrapped function.
 
-        **kwargs : dict[str, Any]
+        **kwargs : Any
             Arbitrary kwargs of the wrapped function.
 
         Returns
         -------
-        Callable
-            The wrapped function.
+        ~numpy.ndarray
+            The processed result.
         """
         helper_result = _prepare_array_func_args(*args, **kwargs)
         ret_cf = cosmo_factor_handler(helper_result["cfs"][0], helper_result["cfs"][1])
@@ -1199,22 +1223,22 @@ def _default_comparison_wrapper(unyt_func: Callable) -> Callable:
 
     # assumes we have two primary arguments that will be handled with
     # _comparison_cosmo_factor with them as the inputs
-    def wrapper(*args: tuple[Any], **kwargs: dict[str, Any]) -> Callable:
+    def wrapper(*args: Any, **kwargs: Any) -> np.ndarray:
         """
         Prepare arguments, handle ``cosmo_factor`` attributes, and attach attributes.
 
         Parameters
         ----------
-        *args : tuple[Any]
+        *args : Any
             Arbitrary arguments of the wrapped function.
 
-        **kwargs : dict[str, Any]
+        **kwargs : Any
             Arbitrary kwargs of the wrapped function.
 
         Returns
         -------
-        Callable
-            The wrapped function.
+        ~numpy.ndarray
+            The processed result.
         """
         helper_result = _prepare_array_func_args(*args, **kwargs)
         ret_cf = _comparison_cosmo_factor(
@@ -1249,22 +1273,22 @@ def _default_oplist_wrapper(unyt_func: Callable) -> Callable:
         The wrapped function.
     """
 
-    def wrapper(*args: tuple[Any], **kwargs: dict[str, Any]) -> Callable:
+    def wrapper(*args: Any, **kwargs: Any) -> np.ndarray:
         """
         Prepare arguments, handle ``cosmo_factor`` attributes, and attach attributes.
 
         Parameters
         ----------
-        *args : tuple[Any]
+        *args : Any
             Arbitrary arguments of the wrapped function.
 
-        **kwargs : dict[str, Any]
+        **kwargs : Any
             Arbitrary kwargs of the wrapped function.
 
         Returns
         -------
-        Callable
-            The wrapped function.
+        ~numpy.ndarray
+            The processed result.
         """
         helper_result = _prepare_array_func_args(*args, **kwargs)
         helper_result_oplist = _prepare_array_func_args(*args[0])
@@ -1287,7 +1311,11 @@ def _default_oplist_wrapper(unyt_func: Callable) -> Callable:
 
 
 @implements(np.array2string)
-def array2string(a, *args, **kwargs):  # noqa numpydoc ignore=GL08
+def array2string(  # noqa: ANN202
+    a,  # noqa: ANN001
+    *args,  # noqa: ANN002
+    **kwargs,  # noqa: ANN003
+):  # numpydoc ignore=GL08
     res = unyt_array2string(a, *args, **kwargs)
     if a.comoving:
         append = " (comoving)"
@@ -1311,7 +1339,7 @@ def histogram_bin_edges(  # noqa: ANN202
     bins=10,  # noqa: ANN001
     range=None,  # noqa: ANN001
     weights=None,  # noqa: ANN001
-):  # noqa numpydoc ignore=GL08
+):  # numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(a, bins=bins, range=range, weights=weights)
     if not isinstance(bins, str) and np.ndim(bins) == 1:
         # we got bin edges as input
@@ -1346,7 +1374,7 @@ def histogram(  # noqa: ANN202
     range=None,  # noqa: ANN001
     density=None,  # noqa: ANN001
     weights=None,  # noqa: ANN001
-):  # noqa numpydoc ignore=GL08
+):  # numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(
         a, bins=bins, range=range, density=density, weights=weights
     )
@@ -1377,7 +1405,7 @@ def histogram2d(  # noqa: ANN202
     range=None,  # noqa: ANN001
     density=None,  # noqa: ANN001
     weights=None,  # noqa: ANN001
-):  # noqa numpydoc ignore=GL08
+):  # numpydoc ignore=GL08
     if range is not None:
         xrange, yrange = range
     else:
@@ -1484,7 +1512,7 @@ def histogramdd(  # noqa: ANN202
     range=None,  # noqa: ANN001
     density=None,  # noqa: ANN001
     weights=None,  # noqa: ANN001
-):  # noqa numpydoc ignore=GL08
+):  # numpydoc ignore=GL08
     D = len(sample)
     if range is not None:
         ranges = range
@@ -1611,7 +1639,7 @@ def _recursive_to_comoving(lst: list) -> list:
     return ret_lst
 
 
-def _prepare_array_block_args(lst: list, recursing: bool = False) -> dict:
+def _prepare_array_block_args(lst: list, recursing: bool = False) -> dict | list:
     """
     Block accepts only a nested list of array "blocks". We need to recurse on this.
 
@@ -1628,7 +1656,7 @@ def _prepare_array_block_args(lst: list, recursing: bool = False) -> dict:
     dict
         The prepared block argument.
     """
-    helper_results = list()
+    helper_results: list = []
     if isinstance(lst, list):
         for item in lst:
             if isinstance(item, list):
@@ -1681,7 +1709,7 @@ def _prepare_array_block_args(lst: list, recursing: bool = False) -> dict:
 
 
 @implements(np.block)
-def block(arrays):  # noqa numpydoc ignore=GL08
+def block(arrays):  # noqa: ANN001,ANN202 numpydoc ignore=GL08
     # block is a special case since we need to recurse more than one level
     # down the list of arrays.
     helper_result_block = _prepare_array_block_args(arrays)
@@ -1737,7 +1765,7 @@ implements(np.array_equiv)(_default_comparison_wrapper(unyt_array_equiv))
 
 
 @implements(np.linspace)
-def linspace(  # noqa numpydoc ignore=GL08
+def linspace(  # noqa: ANN202
     start,  # noqa: ANN001
     stop,  # noqa: ANN001
     num=50,  # noqa: ANN001
@@ -1747,7 +1775,7 @@ def linspace(  # noqa numpydoc ignore=GL08
     axis=0,  # noqa: ANN001
     *,
     device=None,  # noqa: ANN001
-):
+):  # numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(
         start,
         stop,
@@ -1775,7 +1803,7 @@ def logspace(  # noqa: ANN202
     base=10.0,  # noqa: ANN001
     dtype=None,  # noqa: ANN001
     axis=0,  # noqa: ANN001
-):  # noqa numpydoc ignore=GL08
+):  # numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(
         start, stop, num=num, endpoint=endpoint, base=base, dtype=dtype, axis=axis
     )
@@ -1790,7 +1818,12 @@ implements(np.geomspace)(
 
 
 @implements(np.copyto)
-def copyto(dst, src, casting="same_kind", where=True):  # noqa numpydoc ignore=GL08
+def copyto(  # noqa: ANN202
+    dst,  # noqa: ANN001
+    src,  # noqa: ANN001
+    casting="same_kind",  # noqa: ANN001
+    where=True,  # noqa: ANN001
+):  # numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(dst, src, casting=casting, where=where)
     if isinstance(src, objects.cosmo_array) and isinstance(dst, objects.cosmo_array):
         # if we're copyting across two
@@ -1806,7 +1839,7 @@ def copyto(dst, src, casting="same_kind", where=True):  # noqa numpydoc ignore=G
 
 
 @implements(np.prod)
-def prod(  # noqa numpydoc ignore=GL08
+def prod(  # noqa: ANN202
     a,  # noqa: ANN001
     axis=None,  # noqa: ANN001
     dtype=None,  # noqa: ANN001
@@ -1814,7 +1847,7 @@ def prod(  # noqa numpydoc ignore=GL08
     keepdims=np._NoValue,  # noqa: ANN001
     initial=np._NoValue,  # noqa: ANN001
     where=np._NoValue,  # noqa: ANN001
-):
+):  # numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(
         a,
         axis=axis,
@@ -1846,7 +1879,7 @@ implements(np.nanquantile)(
 
 
 @implements(np.linalg.det)
-def linalg_det(a):  # noqa numpydoc ignore=GL08
+def linalg_det(a):  # noqa: ANN001,ANN202 numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(a)
     ret_cf = _power_cosmo_factor(helper_result["cfs"][0], None, power=a.shape[0])
     res = unyt_linalg_det(*helper_result["args"], **helper_result["kwargs"])
@@ -1860,7 +1893,12 @@ implements(np.ptp)(_default_unary_wrapper(unyt_ptp, _preserve_cosmo_factor))
 
 
 @implements(np.pad)
-def pad(array, pad_width, mode="constant", **kwargs):  # noqa numpydoc ignore=GL08
+def pad(  # noqa: ANN202
+    array,  # noqa: ANN001
+    pad_width,  # noqa: ANN001
+    mode="constant",  # noqa: ANN001
+    **kwargs,  # noqa: ANN003
+):  # numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(array, pad_width, mode=mode, **kwargs)
     # the number of options is huge, including user defined functions to handle data
     # let's just preserve the cosmo_factor of the input `array` and trust the user...
@@ -1870,7 +1908,12 @@ def pad(array, pad_width, mode="constant", **kwargs):  # noqa numpydoc ignore=GL
 
 
 @implements(np.choose)
-def choose(a, choices, out=None, mode="raise"):  # noqa numpydoc ignore=GL08
+def choose(  # noqa: ANN202
+    a,  # noqa: ANN001
+    choices,  # noqa: ANN001
+    out=None,  # noqa: ANN001
+    mode="raise",  # noqa: ANN001
+):  # numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(a, choices, out=out, mode=mode)
     helper_result_choices = _prepare_array_func_args(*choices)
     ret_cf = _preserve_cosmo_factor(*helper_result_choices["cfs"])
@@ -1879,7 +1922,12 @@ def choose(a, choices, out=None, mode="raise"):  # noqa numpydoc ignore=GL08
 
 
 @implements(np.insert)
-def insert(arr, obj, values, axis=None):  # noqa numpydoc ignore=GL08
+def insert(  # noqa: ANN202
+    arr,  # noqa: ANN001
+    obj,  # noqa: ANN001
+    values,  # noqa: ANN001
+    axis=None,  # noqa: ANN001
+):  # numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(arr, obj, values, axis=axis)
     ret_cf = _preserve_cosmo_factor(helper_result["cfs"][0], helper_result["cfs"][2])
     res = unyt_insert(*helper_result["args"], **helper_result["kwargs"])
@@ -1887,7 +1935,11 @@ def insert(arr, obj, values, axis=None):  # noqa numpydoc ignore=GL08
 
 
 @implements(np.linalg.lstsq)
-def linalg_lstsq(a, b, rcond=None):  # noqa numpydoc ignore=GL08
+def linalg_lstsq(  # noqa: ANN202
+    a,  # noqa: ANN001
+    b,  # noqa: ANN001
+    rcond=None,  # noqa: ANN001
+):  # numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(a, b, rcond=rcond)
     ret_cf = _divide_cosmo_factor(helper_result["cfs"][1], helper_result["cfs"][0])
     resid_cf = _power_cosmo_factor(helper_result["cfs"][1], None, power=2)
@@ -1902,7 +1954,7 @@ def linalg_lstsq(a, b, rcond=None):  # noqa numpydoc ignore=GL08
 
 
 @implements(np.linalg.solve)
-def linalg_solve(a, b):  # noqa numpydoc ignore=GL08
+def linalg_solve(a, b):  # noqa: ANN001,ANN202 numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(a, b)
     ret_cf = _divide_cosmo_factor(helper_result["cfs"][1], helper_result["cfs"][0])
     res = unyt_linalg_solve(*helper_result["args"], **helper_result["kwargs"])
@@ -1910,7 +1962,7 @@ def linalg_solve(a, b):  # noqa numpydoc ignore=GL08
 
 
 @implements(np.linalg.tensorsolve)
-def linalg_tensorsolve(a, b, axes=None):  # noqa numpydoc ignore=GL08
+def linalg_tensorsolve(a, b, axes=None):  # noqa: ANN001,ANN202 numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(a, b, axes=axes)
     ret_cf = _divide_cosmo_factor(helper_result["cfs"][1], helper_result["cfs"][0])
     res = unyt_linalg_tensorsolve(*helper_result["args"], **helper_result["kwargs"])
@@ -1918,7 +1970,7 @@ def linalg_tensorsolve(a, b, axes=None):  # noqa numpydoc ignore=GL08
 
 
 @implements(np.linalg.eig)
-def linalg_eig(a):  # noqa numpydoc ignore=GL08
+def linalg_eig(a):  # noqa: ANN001,ANN202 numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(a)
     ret_cf = _preserve_cosmo_factor(helper_result["cfs"][0])
     ress = unyt_linalg_eig(*helper_result["args"], **helper_result["kwargs"])
@@ -1926,7 +1978,7 @@ def linalg_eig(a):  # noqa numpydoc ignore=GL08
 
 
 @implements(np.linalg.eigh)
-def linalg_eigh(a, UPLO="L"):  # noqa numpydoc ignore=GL08
+def linalg_eigh(a, UPLO="L"):  # noqa: ANN001,ANN202 numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(a, UPLO=UPLO)
     ret_cf = _preserve_cosmo_factor(helper_result["cfs"][0])
     ress = unyt_linalg_eigh(*helper_result["args"], **helper_result["kwargs"])
@@ -1982,7 +2034,7 @@ def savetxt(  # noqa numpydoc ignore=GL08
 
 
 @implements(np.apply_over_axes)
-def apply_over_axes(func, a, axes):  # noqa numpydoc ignore=GL08
+def apply_over_axes(func, a, axes):  # noqa:ANN001,ANN202 numpydoc ignore=GL08
     res = func(a, axes[0])
     if len(axes) > 1:
         # this function is recursive by nature,
@@ -2009,7 +2061,7 @@ implements(np.isin)(_default_comparison_wrapper(unyt_isin))
 
 
 @implements(np.place)
-def place(arr, mask, vals):  # noqa numpydoc ignore=GL08
+def place(arr, mask, vals):  # noqa: ANN001, ANN202 numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(arr, mask, vals)
     _preserve_cosmo_factor(helper_result["cfs"][0], helper_result["cfs"][2])
     # must pass arr directly here because it's modified in-place
@@ -2023,7 +2075,7 @@ def place(arr, mask, vals):  # noqa numpydoc ignore=GL08
 
 
 @implements(np.put)
-def put(a, ind, v, mode="raise"):  # noqa numpydoc ignore=GL08
+def put(a, ind, v, mode="raise"):  # noqa: ANN001,ANN202 numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(a, ind, v, mode=mode)
     _preserve_cosmo_factor(helper_result["cfs"][0], helper_result["cfs"][2])
     # must pass arr directly here because it's modified in-place
@@ -2037,7 +2089,12 @@ def put(a, ind, v, mode="raise"):  # noqa numpydoc ignore=GL08
 
 
 @implements(np.put_along_axis)
-def put_along_axis(arr, indices, values, axis):  # noqa numpydoc ignore=GL08
+def put_along_axis(  # noqa: ANN202
+    arr,  # noqa: ANN001
+    indices,  # noqa: ANN001
+    values,  # noqa: ANN001
+    axis,  # noqa: ANN001
+):  # numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(arr, indices, values, axis)
     _preserve_cosmo_factor(helper_result["cfs"][0], helper_result["cfs"][2])
     # must pass arr directly here because it's modified in-place
@@ -2051,7 +2108,7 @@ def put_along_axis(arr, indices, values, axis):  # noqa numpydoc ignore=GL08
 
 
 @implements(np.putmask)
-def putmask(a, mask, values):  # noqa numpydoc ignore=GL08
+def putmask(a, mask, values):  # noqa: ANN001,ANN202 numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(a, mask, values)
     _preserve_cosmo_factor(helper_result["cfs"][0], helper_result["cfs"][2])
     # must pass arr directly here because it's modified in-place
@@ -2070,7 +2127,7 @@ implements(np.searchsorted)(
 
 
 @implements(np.select)
-def select(condlist, choicelist, default=0):  # noqa numpydoc ignore=GL08
+def select(condlist, choicelist, default=0):  # noqa: ANN001,ANN202 numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(condlist, choicelist, default=default)
     helper_result_choicelist = _prepare_array_func_args(*choicelist)
     ret_cf = _preserve_cosmo_factor(*helper_result_choicelist["cfs"])
@@ -2088,14 +2145,14 @@ implements(np.setdiff1d)(
 
 
 @implements(np.sinc)
-def sinc(x):  # noqa numpydoc ignore=GL08
+def sinc(x):  # noqa: ANN001,ANN202 numpydoc ignore=GL08
     # unyt just casts to array and calls the numpy implementation
     # so let's just hand off to them
     return unyt_sinc(x)
 
 
 @implements(np.clip)
-def clip(  # noqa numpydoc ignore=GL08
+def clip(  # noqa: ANN202
     a,  # noqa: ANN001
     a_min=np._NoValue,  # noqa: ANN001
     a_max=np._NoValue,  # noqa: ANN001
@@ -2104,7 +2161,7 @@ def clip(  # noqa numpydoc ignore=GL08
     min=np._NoValue,  # noqa: ANN001
     max=np._NoValue,  # noqa: ANN001
     **kwargs,  # noqa: ANN003
-):
+):  # numpydoc ignore=GL08
     # can't work out how to properly handle min and max,
     # just leave them in kwargs I guess (might be a numpy version conflict?)
     helper_result = _prepare_array_func_args(
@@ -2126,7 +2183,7 @@ def clip(  # noqa numpydoc ignore=GL08
 
 
 @implements(np.where)
-def where(condition, *args):  # noqa numpydoc ignore=GL08
+def where(condition, *args):  # noqa: ANN001,ANN002,ANN202 numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(condition, *args)
     if len(args) == 0:  # just condition
         ret_cf = _return_without_cosmo_factor(helper_result["cfs"][0])
@@ -2144,7 +2201,7 @@ implements(np.tril)(_default_unary_wrapper(unyt_tril, _preserve_cosmo_factor))
 
 
 @implements(np.einsum)
-def einsum(  # noqa numpydoc ignore=GL08
+def einsum(  # noqa: ANN202
     subscripts,  # noqa: ANN001
     *operands,  # noqa: ANN002
     out=None,  # noqa: ANN001
@@ -2152,7 +2209,7 @@ def einsum(  # noqa numpydoc ignore=GL08
     order="K",  # noqa: ANN001
     casting="safe",  # noqa: ANN001
     optimize=False,  # noqa: ANN001
-):
+):  # numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(
         subscripts,
         operands,
@@ -2188,7 +2245,7 @@ def unwrap(  # noqa: ANN202
     axis=-1,  # noqa: ANN001
     *,
     period=6.283_185_307_179_586,  # noqa: ANN001
-):  # noqa numpydoc ignore=GL08
+):  # numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(
         p, discont=discont, axis=axis, period=period
     )
@@ -2202,7 +2259,14 @@ def unwrap(  # noqa: ANN202
 
 
 @implements(np.interp)
-def interp(x, xp, fp, left=None, right=None, period=None):  # noqa numpydoc ignore=GL08
+def interp(  # noqa: ANN202
+    x,  # noqa: ANN001
+    xp,  # noqa: ANN001
+    fp,  # noqa: ANN001
+    left=None,  # noqa: ANN001
+    right=None,  # noqa: ANN001
+    period=None,  # noqa: ANN001
+):  # numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(
         x, xp, fp, left=left, right=right, period=period
     )
@@ -2217,7 +2281,7 @@ def array_repr(  # noqa: ANN202
     max_line_width=None,  # noqa: ANN001
     precision=None,  # noqa: ANN001
     suppress_small=None,  # noqa: ANN001
-):  # noqa numpydoc ignore=GL08
+):  # numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(
         arr,
         max_line_width=max_line_width,
@@ -2241,7 +2305,7 @@ implements(np.linalg.outer)(
 
 
 @implements(np.trapezoid)
-def trapezoid(y, x=None, dx=1.0, axis=-1):  # noqa numpydoc ignore=GL08
+def trapezoid(y, x=None, dx=1.0, axis=-1):  # noqa: ANN001,ANN202 numpydoc ignore=GL08
     helper_result = _prepare_array_func_args(y, x=x, dx=dx, axis=axis)
     if x is None:
         ret_cf = _multiply_cosmo_factor(
@@ -2262,7 +2326,14 @@ implements(np.take)(_default_unary_wrapper(unyt_take, _preserve_cosmo_factor))
 
 
 @implements(np.average)
-def average(a, axis=None, weights=None, returned=False, *, keepdims=np._NoValue):  # noqa numpydoc ignore=GL08
+def average(  # noqa: ANN202
+    a,  # noqa: ANN001
+    axis=None,  # noqa: ANN001
+    weights=None,  # noqa: ANN001
+    returned=False,  # noqa: ANN001
+    *,
+    keepdims=np._NoValue,  # noqa: ANN001
+):  # numpydoc ignore=GL08
     # Average suffered from a bug
     # (https://github.com/SWIFTSIM/swiftsimio/issues/285)
     # Correct results depend on unyt>=3.1.0
@@ -2295,25 +2366,33 @@ def average(a, axis=None, weights=None, returned=False, *, keepdims=np._NoValue)
         return _return_helper(res, helper_result, ret_cf_avg)
 
 
-implements(np.max)(_propagate_cosmo_array_attributes_to_result(np.max._implementation))
-implements(np.min)(_propagate_cosmo_array_attributes_to_result(np.min._implementation))
+implements(np.max)(
+    _propagate_cosmo_array_attributes_to_result(getattr(np.max, "_implementation"))
+)
+implements(np.min)(
+    _propagate_cosmo_array_attributes_to_result(getattr(np.min, "_implementation"))
+)
 implements(np.mean)(
-    _propagate_cosmo_array_attributes_to_result(np.mean._implementation)
+    _propagate_cosmo_array_attributes_to_result(getattr(np.mean, "_implementation"))
 )
 implements(np.median)(
-    _propagate_cosmo_array_attributes_to_result(np.median._implementation)
+    _propagate_cosmo_array_attributes_to_result(getattr(np.median, "_implementation"))
 )
 implements(np.sort)(
-    _propagate_cosmo_array_attributes_to_result(np.sort._implementation)
+    _propagate_cosmo_array_attributes_to_result(getattr(np.sort, "_implementation"))
 )
-implements(np.sum)(_propagate_cosmo_array_attributes_to_result(np.sum._implementation))
+implements(np.sum)(
+    _propagate_cosmo_array_attributes_to_result(getattr(np.sum, "_implementation"))
+)
 implements(np.partition)(
-    _propagate_cosmo_array_attributes_to_result(np.partition._implementation)
+    _propagate_cosmo_array_attributes_to_result(
+        getattr(np.partition, "_implementation")
+    )
 )
 
 
 @implements(np.meshgrid)
-def meshgrid(*xi, **kwargs):  # noqa numpydoc ignore=GL08
+def meshgrid(*xi, **kwargs):  # noqa: ANN002,ANN003,ANN202 numpydoc ignore=GL08
     # meshgrid is a unique case: arguments never interact with each other, so we don't
     # want to use our _prepare_array_func_args helper (that will try to coerce to
     # compatible comoving, cosmo_factor).

--- a/swiftsimio/_array_functions.py
+++ b/swiftsimio/_array_functions.py
@@ -897,7 +897,12 @@ def _prepare_array_func_args(
     ValueError
         If the input arrays cannot be coerced to a consistent state of ``comoving``.
     """
-    cms = [(hasattr(arg, "comoving"), getattr(arg, "comoving", None)) for arg in args]
+    # test isinstance(arg, cosmo_array) instead of hasattr(arg, "comoving"):
+    # _AHelper.comoving -> _AHelper can cause problems
+    cms = [
+        (isinstance(arg, objects.cosmo_array), getattr(arg, "comoving", None))
+        for arg in args
+    ]
     cfs = [getattr(arg, "cosmo_factor", None) for arg in args]
     vts = [getattr(arg, "valid_transform", True) for arg in args]
     comps = [

--- a/swiftsimio/masks.py
+++ b/swiftsimio/masks.py
@@ -15,7 +15,7 @@ from swiftsimio.objects import InvalidSnapshot, cosmo_array, cosmo_quantity
 from swiftsimio.accelerated import ranges_from_array
 from swiftsimio._handle_provider import HandleProvider
 
-from typing import Callable, Sequence
+from typing import Callable, Sequence, Any
 
 _DEFAULT_SAFE_PADDING = 0.1
 _GROUPCAT_OUTPUT_TYPES = ["FOF", "SOAP", "FOFSubset", "SOAPSubset"]
@@ -39,8 +39,8 @@ def _constraint(method: Callable) -> Callable:
 
     def wrapped(
         self: "SWIFTMask",
-        *args: tuple,
-        **kwargs: dict,
+        *args: Any,
+        **kwargs: Any,
     ) -> None:  # noqa numpydoc ignore=GL08
         # omit docstring so that sphinx picks up docstring of wrapped function
         retval = method(self, *args, **kwargs)

--- a/swiftsimio/masks.py
+++ b/swiftsimio/masks.py
@@ -759,37 +759,21 @@ class SWIFTMask(HandleProvider):
 
             .. code-block:: python
 
-                restrict = cosmo_array(
-                    [
-                        [0.5, 0.7],
-                        [0.1, 0.9],
-                        [0.0, 0.1]
-                    ],
-                    u.Mpc,
-                    comoving=True,
-                    scale_factor=1.0,
-                    scale_exponent=1,
-                )
+                m = mask("snap.hdf5")
+                a = m.metadata.a
+                restrict = [
+                    [0.5, 0.7],
+                    [0.1, 0.9],
+                    [0.0, 0.1]
+                ] * u.Mpc * a.comoving
 
             If no constraint is desired along an axis, ``None`` can be given instead. For
             example, to select a "slab" in the x-y plane:
 
             .. code-block:: python
 
-                zmin = cosmo_quantity(
-                    5.0,
-                    u.Mpc,
-                    comoving=True,
-                    scale_factor=1.0,
-                    scale_exponent=1
-                )
-                zmax = cosmo_quantity(
-                    6.0,
-                    u.Mpc,
-                    comoving=True,
-                    scale_factor=1.0,
-                    scale_exponent=1
-                )
+                zmin = 5.0 * u.Mpc * a.comoving
+                zmax = 6.0 * u.Mpc * a.comoving
                 restrict = [
                     None,
                     None,

--- a/swiftsimio/metadata/objects.py
+++ b/swiftsimio/metadata/objects.py
@@ -14,7 +14,7 @@ from unyt.array import _iterable
 
 from swiftsimio.conversions import swift_cosmology_to_astropy
 from swiftsimio import metadata
-from swiftsimio.objects import cosmo_array, cosmo_quantity
+from swiftsimio.objects import cosmo_array, cosmo_quantity, _AHelper
 from swiftsimio._handle_provider import HandleProvider
 from abc import ABC, abstractmethod
 
@@ -196,12 +196,10 @@ class SWIFTMetadata(HandleProvider, ABC):
                 # Must not be present, just skip it
                 continue
         # need the scale factor first for cosmology on other header attributes
-        try:
-            self.a = self.scale_factor
-        except AttributeError:
-            # These must always be present for the initialisation of cosmology properties
-            self.a = 1.0
+        if not hasattr(self, "scale_factor"):
+            # This must always be present for the initialisation of cosmology properties
             self.scale_factor = 1.0
+        self.a = _AHelper(scale_factor=self.scale_factor)
 
         # These are just read straight in to variables
         header_unpack_arrays_units = (

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -2606,14 +2606,14 @@ class cosmo_array(unyt_array):
         if getattr(b, "is_Unit", False):
             return _copy_cosmo_array_attributes_if_present(
                 self,
-                _ensure_result_is_cosmo_array_or_quantity((b**-1).__mul__)(
+                _ensure_result_is_cosmo_array_or_quantity((1 / b).__mul__)(
                     self.view(unyt_quantity)
                     if self.shape == ()
                     else self.view(unyt_array)
                 ),
             )
         elif isinstance(b, _AHelper):
-            return (b**-1).__mul__(self)
+            return (1 / b).__mul__(self)
         else:
             return super().__truediv__(b)
 

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -363,7 +363,7 @@ class cosmo_factor:
 
         Examples
         --------
-        ::
+        .. code-block:: python
 
             >>> cosmo_factor.create(0.5, 2)
             cosmo_factor(expr=a**2, scale_factor=0.5)
@@ -2139,7 +2139,7 @@ class cosmo_array(unyt_array):
 
         Examples
         --------
-        ::
+        .. code-block:: python
 
             >>> from astropy.units import kpc
             >>> cosmo_array.from_astropy([1, 2, 3] * kpc)
@@ -2194,7 +2194,7 @@ class cosmo_array(unyt_array):
 
         Examples
         --------
-        ::
+        .. code-block:: python
 
             >>> from pint import UnitRegistry
             >>> import numpy as np
@@ -3674,11 +3674,11 @@ class _AHelper:
         --------
         .. code-block:: python
 
-           from swiftsimio import load
-           dat = load("snap.hdf5")
-           a = dat.metadata.a
-           cMpc = a.comoving * u.Mpc
-           comoving_distances = np.arange(3) * cMpc
+           >>> from swiftsimio import load
+           >>> dat = load("snap.hdf5")
+           >>> a = dat.metadata.a
+           >>> cMpc = a.comoving * u.Mpc
+           >>> comoving_distances = np.arange(3) * cMpc
         """
         return _AHelper(
             scale_factor=self._scale_factor,
@@ -3705,11 +3705,11 @@ class _AHelper:
         --------
         .. code-block:: python
 
-           from swiftsimio import load
-           dat = load("snap.hdf5")
-           a = dat.metadata.a
-           pMpc = a.physical * u.Mpc
-           physical_distances = np.arange(3) * pMpc
+           >>> from swiftsimio import load
+           >>> dat = load("snap.hdf5")
+           >>> a = dat.metadata.a
+           >>> pMpc = a.physical * u.Mpc
+           >>> physical_distances = np.arange(3) * pMpc
         """
         return _AHelper(
             scale_factor=self._scale_factor,

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -2798,11 +2798,11 @@ class _AHelper(object):
         The scale factor used to create/modify :class:`~swiftsimio.objects.cosmo_factor`
         objects as needed.
 
+    scale_exponent : int, optional
+        The exponent that the scale factor scales with, default of ``1``.
+
     units : ~unyt.Unit, optional
         The units to attach to objects.
-
-    exponent : int, optional
-        The exponent that the scale factor scales with, default of ``1``.
 
     comoving : bool, optional
         Whether to create comoving or physical objects.
@@ -3037,16 +3037,35 @@ class _AHelper(object):
         """
         Default implementation for invalid multiplications.
 
-        Raises
-        ------
-        NotImplementedError
-            When something that we cannot multiply with is encountered.
+        Parameters
+        ----------
+        other : Any
+            The object to multiply with.
+
+        Returns
+        -------
+        NotImplemented
+            This operation is not defined.
         """
         # keep message generic, we might get here through __truediv__ also
         return NotImplemented
 
     @__mul__.register
     def _(self, other: numeric_type | np.ndarray) -> cosmo_array:
+        """
+        Multiply with a number or :mod:`numpy` array.
+
+        Parameters
+        ----------
+        other : numeric_type or np.ndarray
+            The quantity to multiply with.
+
+        Returns
+        -------
+        ~swiftsimio.objects.cosmo_array
+            A cosmo array or quantity based on the content of this helper and the
+            ``other`` number or array.
+        """
         return (cosmo_quantity if np.isscalar(other) else cosmo_array)(
             other,
             units=self.units,
@@ -3057,6 +3076,20 @@ class _AHelper(object):
 
     @__mul__.register
     def _(self, other: tuple | list) -> cosmo_array:
+        """
+        Multiply with a :obj:`list` or :obj:`tuple`.
+
+        Parameters
+        ----------
+        other : tuple or list
+            The quantity to multiply with.
+
+        Returns
+        -------
+        ~swiftsimio.objects.cosmo_array
+            A cosmo array or quantity based on the content of this helper and the
+            ``other`` :obj:`tuple` or :obj:`list`.
+        """
         # leave the rest implicit, could pick up values from content of other:
         ret = cosmo_array(other)
         # now modify attributes:
@@ -3077,6 +3110,22 @@ class _AHelper(object):
 
     @__mul__.register
     def _(self, other: unyt.Unit) -> Self:
+        """
+        Multiply with a :class:`unyt.unit_object.Unit`.
+
+        These are multplied with the existing units on the helper (could be dimensionless)
+        and a new helper with these new units is returned.
+
+        Parameters
+        ----------
+        other : ~unyt.unit_object.Unit
+            The unit to multiply with.
+
+        Returns
+        -------
+        ~swiftsimio.objects._AHelper
+            A helper updated with the provided units.
+        """
         return _AHelper(
             scale_factor=self._scale_factor,
             scale_exponent=self.scale_exponent,
@@ -3086,6 +3135,20 @@ class _AHelper(object):
 
     @__mul__.register
     def _(self, other: unyt.unyt_array) -> cosmo_array:
+        """
+        Multiply with a :class:`~unyt.array.unyt_array`.
+
+        Parameters
+        ----------
+        other : ~unyt.array.unyt_array
+            The quantity to multiply with.
+
+        Returns
+        -------
+        ~swiftsimio.objects.cosmo_array
+            A cosmo array or quantity based on the content of this helper and the
+            ``other`` :class:`~unyt.array.unyt_array`.
+        """
         return (
             cosmo_quantity if isinstance(other, unyt.unyt_quantity) else cosmo_array
         )(
@@ -3097,6 +3160,20 @@ class _AHelper(object):
 
     @__mul__.register
     def _(self, other: cosmo_array) -> cosmo_array:
+        """
+        Multiply with a :class:`~swiftsimio.objects.cosmo_array`.
+
+        Parameters
+        ----------
+        other : ~swiftsimio.objects.cosmo_array
+            The quantity to multiply with.
+
+        Returns
+        -------
+        ~swiftsimio.objects.cosmo_array
+            A cosmo array or quantity based on the content of this helper and the
+            ``other`` :class:`~swiftsimio.objects.cosmo_array`.
+        """
         if self._comoving:
             other.convert_to_comoving()  # no-op if already comoving
         elif self._comoving is False:
@@ -3118,21 +3195,39 @@ class _AHelper(object):
         Just pass the operation to :meth:`~swiftsimio.objects._AHelper.__mul__` to
         handle.
 
+        Parameters
+        ----------
+        other : ~unyt.unit_object.Unit, ~unyt.array.unyt_array or \
+        ~swiftsimio.objects.cosmo_array
+            The object to multiply with.
+
         Returns
         -------
         ~swiftsimio.objects._AHelper or ~swiftsimio.objects.cosmo_aray
             The result of applying the helper to the other operand.
-
-        Raises
-        ------
-        NotImplementedError
-            When something that we cannot multiply with is encountered.
         """
         return self.__mul__(other)
 
     def __truediv__(
         self, other: unyt.Unit | unyt.unyt_array | cosmo_array
     ) -> Self | cosmo_array:
+        """
+        Divide this helper by a unit, number or array.
+
+        Just delegates the operation to :meth:`~swiftsimio.objects._AHelper.__mul__` to
+        handle.
+
+        Parameters
+        ----------
+        other : ~unyt.unit_object.Unit, ~unyt.array.unyt_array or \
+        ~swiftsimio.objects.cosmo_array
+            The object to divide by.
+
+        Returns
+        -------
+        ~swiftsimio.objects._AHelper or ~swiftsimio.objects.cosmo_aray
+            The result of applying the helper to the other operand.
+        """
         return (
             _AHelper(
                 scale_factor=self._scale_factor,
@@ -3146,6 +3241,23 @@ class _AHelper(object):
     def __rtruediv__(
         self, other: unyt.Unit | unyt.unyt_array | cosmo_array
     ) -> Self | cosmo_array:
+        """
+        Divide a unit, number or array by this helper.
+
+        Just delegates the operation to :meth:`~swiftsimio.objects._AHelper.__mul__` to
+        handle.
+
+        Parameters
+        ----------
+        other : ~unyt.unit_object.Unit, ~unyt.array.unyt_array or \
+        ~swiftsimio.objects.cosmo_array
+            The object to divide by this.
+
+        Returns
+        -------
+        ~swiftsimio.objects._AHelper or ~swiftsimio.objects.cosmo_aray
+            The result of applying the helper to the other operand.
+        """
         return other * _AHelper(
             scale_factor=self._scale_factor,
             scale_exponent=-self.scale_exponent,
@@ -3154,6 +3266,26 @@ class _AHelper(object):
         )
 
     def __pow__(self, exponent: int | float) -> Self:
+        """
+        Raise this helper to a power.
+
+        This modifies the exponent of the scale factor, so that for density scaling as
+        the inverse cube we can write e.g. (for a helper called ``a``):
+
+        .. code-block:: python
+
+           raw_density * a.comoving ** -3 * u.g * u.cm**-3
+
+        Parameters
+        ----------
+        exponent : int or float
+            The exponent to raise the scale factor to (cumulative with current exponent).
+
+        Returns
+        -------
+        ~swiftsimio.objects._AHelper
+            A new helper with the modified exponent.
+        """
         return _AHelper(
             scale_factor=self._scale_factor,
             scale_exponent=self.scale_exponent * exponent,
@@ -3163,6 +3295,28 @@ class _AHelper(object):
 
     @property
     def comoving(self) -> Self:
+        """
+        Indicate that this helper is for a comoving quantity.
+
+        This helper makes it easy to attach the cosmological scaling of quantities to
+        arrays. To do this, whether the quantity is physical or comoving must be
+        specified. This is done by accessing the ``comoving`` or ``physical`` attributes.
+
+        Returns
+        -------
+        ~swiftsimio.objects._AHelper
+            A new helper object flagged for comoving quantities.
+
+        Examples
+        --------
+        .. code-block:: python
+
+           from swiftsimio import load
+           dat = load("snap.hdf5")
+           a = dat.metadata.a
+           cMpc = a.comoving * u.Mpc
+           comoving_distances = np.arange(3) * cMpc
+        """
         return _AHelper(
             scale_factor=self._scale_factor,
             scale_exponent=self.scale_exponent,
@@ -3172,14 +3326,31 @@ class _AHelper(object):
 
     @property
     def physical(self) -> Self:
+        """
+        Indicate that this helper is for a physical quantity.
+
+        This helper makes it easy to attach the cosmological scaling of quantities to
+        arrays. To do this, whether the quantity is physical or comoving must be
+        specified. This is done by accessing the ``comoving`` or ``physical`` attributes.
+
+        Returns
+        -------
+        ~swiftsimio.objects._AHelper
+            A new helper object flagged for comoving quantities.
+
+        Examples
+        --------
+        .. code-block:: python
+
+           from swiftsimio import load
+           dat = load("snap.hdf5")
+           a = dat.metadata.a
+           pMpc = a.physical * u.Mpc
+           physical_distances = np.arange(3) * pMpc
+        """
         return _AHelper(
             scale_factor=self._scale_factor,
             scale_exponent=self.scale_exponent,
             units=self.units,
             comoving=False,
         )
-
-    def ensure_comoving_or_physical(self) -> None:
-        # want this to be a decorator...
-        if self._comoving is None:
-            raise InvalidCosmoUnit("...")

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -12,7 +12,6 @@ helpers, wrappers and implementations that enable most :mod:`numpy` and
 """
 
 import unyt
-from unyt.array import _ufunc_prepare_and_finalize
 from unyt import unyt_array, unyt_quantity, Unit
 from unyt.array import multiple_output_operators, _iterable, POWER_MAPPING
 from numbers import Number as numeric_type
@@ -2256,7 +2255,8 @@ class cosmo_array(unyt_array):
             The result of the ufunc call, with the appropriate type and cosmo attributes
             attached.
         """
-        # wonder if we could cache helper_result during __unyt_ufunc_prepare__ to use here?
+        # wonder if we could cache helper_result during __unyt_ufunc_prepare__ to use
+        # here?
         helper_result = _prepare_array_func_args(*inputs, **kwargs)
         cfs = helper_result["cfs"]
         # make sure we evaluate the cosmo_factor_ufunc_registry function:
@@ -2411,13 +2411,27 @@ class cosmo_array(unyt_array):
         if isinstance(result, tuple):
             for r in result:
                 if isinstance(r, cosmo_array):  # also recognizes cosmo_quantity
-                    r.comoving = helper_result["comoving"]
-                    r.cosmo_factor = ret_cf
+                    r.comoving = (
+                        helper_result["comoving"] if r.comoving is None else r.comoving
+                    )
+                    r.cosmo_factor = (
+                        ret_cf
+                        if r.cosmo_factor == cosmo_factor(None, None)
+                        else ret_cf * r.cosmo_factor
+                    )
                     r.valid_transform = helper_result["valid_transform"]
                     r.compression = helper_result["compression"]
         elif isinstance(result, cosmo_array):  # also recognizes cosmo_quantity
-            result.comoving = helper_result["comoving"]
-            result.cosmo_factor = ret_cf
+            result.comoving = (
+                helper_result["comoving"]
+                if result.comoving is None
+                else result.comoving
+            )
+            result.cosmo_factor = (
+                ret_cf
+                if result.cosmo_factor == cosmo_factor(None, None)
+                else ret_cf * result.cosmo_factor
+            )
             result.valid_transform = helper_result["valid_transform"]
             result.compression = helper_result["compression"]
         if "out" in kwargs:
@@ -2425,15 +2439,31 @@ class cosmo_array(unyt_array):
             if ufunc not in multiple_output_operators:
                 out = out[0]
                 if isinstance(out, cosmo_array):  # also recognizes cosmo_quantity
-                    out.comoving = helper_result["comoving"]
-                    out.cosmo_factor = ret_cf
+                    out.comoving = (
+                        helper_result["comoving"]
+                        if result.comoving is None
+                        else result.comoving
+                    )
+                    out.cosmo_factor = (
+                        ret_cf
+                        if result.cosmo_factor == cosmo_factor(None, None)
+                        else ret_cf * result.cosmo_factor
+                    )
                     out.valid_transform = helper_result["valid_transform"]
                     out.compression = helper_result["compression"]
             else:
-                for o in out:
+                for o, r in zip(out, result):
                     if isinstance(o, cosmo_array):  # also recognizes cosmo_quantity
-                        o.comoving = helper_result["comoving"]
-                        o.cosmo_factor = ret_cf
+                        o.comoving = (
+                            helper_result["comoving"]
+                            if r.comoving is None
+                            else r.comoving
+                        )
+                        o.cosmo_factor = (
+                            ret_cf
+                            if r.cosmo_factor == cosmo_factor(None, None)
+                            else ret_cf * r.cosmo_factor
+                        )
                         o.valid_transform = helper_result["valid_transform"]
                         o.compression = helper_result["compression"]
 
@@ -2925,15 +2955,31 @@ class _AHelper(object):
         for inp in inputs:
             if isinstance(inp, _AHelper):
                 a_helper_input = inp
-        ret = (cosmo_array if result.ndim else cosmo_quantity)(
-            result,
-            comoving=a_helper_input._comoving,
-            scale_factor=a_helper_input.scale_factor,
-            scale_exponent=a_helper_input.scale_exponent,
-        )
-        return ret
+        if isinstance(result, cosmo_array):
+            if result.comoving is None:
+                result.comoving = a_helper_input._comoving
+            else:
+                result.convert_to(result.units, comoving=a_helper_input._comoving)
+            result.units = result.units * a_helper_input.units
+            if result.cosmo_factor == cosmo_factor(None, None):
+                result.cosmo_factor = cosmo_factor.create(
+                    a_helper_input.scale_factor, a_helper_input.scale_exponent
+                )
+            else:
+                result.cosmo_factor = result.cosmo_factor * cosmo_factor.create(
+                    a_helper_input.scale_factor, a_helper_input.scale_exponent
+                )
+            # raise RuntimeError
+            return result
+        else:
+            return (cosmo_array if result.ndim else cosmo_quantity)(
+                result,
+                comoving=a_helper_input._comoving,
+                scale_factor=a_helper_input.scale_factor,
+                scale_exponent=a_helper_input.scale_exponent,
+            )
 
-    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs) -> cosmo_array:
         """
         Handle :mod:`numpy` ufunc calls on :class:`~swiftsimio.objects.cosmo_array` input.
 
@@ -3038,7 +3084,7 @@ class _AHelper(object):
     def _(self, other: cosmo_array) -> cosmo_array:
         if self._comoving:
             other.convert_to_comoving()  # no-op if already comoving
-        else:  # self._comoving is False, None case is guarded
+        elif self._comoving is False:
             other.convert_to_physical()  # no-op if already physical
         return other.__class__(
             other.ndview,

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -17,6 +17,7 @@ from unyt.array import multiple_output_operators, _iterable, POWER_MAPPING
 from numbers import Number as numeric_type
 from typing import Iterable, Callable, Any
 from collections.abc import Collection
+from functools import singledispatchmethod
 
 import sympy
 import numpy as np
@@ -180,6 +181,17 @@ class InvalidConversionError(Exception):
     ) -> None:
         self.message = message
 
+    def __str__(self) -> str:
+        """
+        Print error message for invalid conversion.
+
+        Returns
+        -------
+        str
+            The error message.
+        """
+        return f"{self.__class__}: {self.message}"
+
 
 class InvalidScaleFactor(Exception):
     """
@@ -197,19 +209,19 @@ class InvalidScaleFactor(Exception):
         Arbitrary arguments.
     """
 
-    def __init__(self, message: str = None, *args: tuple[Any]) -> None:
+    def __init__(self, message: str | None = None, *args: tuple[Any]) -> None:
         self.message = message
 
     def __str__(self) -> str:
         """
-        Print warning message for invalid scale factor.
+        Print error message for invalid scale factor.
 
         Returns
         -------
         str
             The error message.
         """
-        return f"InvalidScaleFactor: {self.message}"
+        return f"{self.__class__}: {self.message}"
 
 
 class InvalidSnapshot(Exception):
@@ -227,12 +239,49 @@ class InvalidSnapshot(Exception):
         Arbitrary arguments.
     """
 
-    def __init__(self, message: str = None, *args: tuple[Any]) -> None:
+    def __init__(self, message: str | None = None, *args: tuple[Any]) -> None:
         self.message = message
 
     def __str__(self) -> str:
-        """Print warning message of invalid snapshot."""
-        return f"InvalidSnapshot: {self.message}"
+        """
+        Print error message for invalid snapshot.
+
+        Returns
+        -------
+        str
+            The error message.
+        """
+        return f"{self.__class__}: {self.message}"
+
+
+class InvalidCosmoUnit(Exception):
+    """
+    Generated when a :class:`~swiftsimio.objects._AHelper` encounters an incompatibility.
+
+    For example, trying to multiply with a bare scalar.
+
+    Parameters
+    ----------
+    message : str, optional
+        Message to print in case of incompatible input.
+
+    *args : tuple[Any]
+        Arbitrary arguments.
+    """
+
+    def __init__(self, message: str | None = None, *args: tuple[Any]) -> None:
+        self.message = message
+
+    def __str__(self) -> str:
+        """
+        Print error message for incompatible input.
+
+        Returns
+        -------
+        str
+            The error message.
+        """
+        return f"{self.__class__}: {self.message}"
 
 
 class cosmo_factor(object):
@@ -2537,3 +2586,238 @@ class cosmo_quantity(cosmo_array, unyt_quantity):
     __round__ = _propagate_cosmo_array_attributes_to_result(
         _ensure_result_is_cosmo_array_or_quantity(unyt_quantity.__round__)
     )
+
+
+class _AHelper(object):
+    """
+    Offer an easy way to initialize cosmo scalars and arrays.
+
+    Using the full :class:`~swiftsimio.objects.cosmo_array` or
+    :class:`~swiftsimio.objects.cosmo_quantity` constructors can be tedious. This
+    helper offers a way to write things like ``10 * u.Mpc * a.comoving**1`` or
+    ``np.array([1, 2]) * u.g / u.cm**3 * a.physical**-3``. It is initialized with the
+    rest of the mask/dataset metadata and then stored as ``metadata.a`` so that it
+    can be easily retrieved. It also allows defining "cosmo units" such as
+    ``cMpc = u.Mpc * a.comoving``.
+
+    In most cases this class should return new instances of itself with modified
+    attributes: we should not be modifying the state of the helper assigned to
+    ``metadata.a``!
+
+    There is an important design choice around data copying.
+    :class:`~unyt.array.unyt_array` does copy data on construction:
+
+    .. code-block:: python
+
+        >>> import unyt as u
+        >>> x = np.array([1, 2])
+        >>> y = x * u.kpc
+        >>> x[0] = 999  # notice units are not checked/enforced...
+        >>> x
+        array([999, 2])
+        >>> y
+        unyt_array([1, 2], 'kpc')
+
+    But :class:`~swiftsimio.objects.cosmo_array` does not copy data, instead using a view:
+    
+    .. code-block:: python
+
+        >>> from swiftsimio import cosmo_array
+        >>> x = np.array([1, 2]) * u.kpc
+        >>> y = x * a.comoving
+        >>> x[0] = 999
+        >>> x
+        unyt_array([999, 2], 'kpc')
+        >>> y
+        cosmo_array([999, 2], 'kpc', comoving='True', cosmo_factor='a at a=1', \
+        valid_transform='True')
+
+    This helper therefore uses views to stay consistent with the
+    :class:`~swiftsimio.objects.cosmo_array` behaviour.
+
+    Parameters
+    ----------
+    scale_factor : float
+        The scale factor used to create/modify :class:`~swiftsimio.objects.cosmo_factor`
+        objects as needed.
+
+    units : ~unyt.Unit, optional
+        The units to attach to objects.
+
+    exponent : int, optional
+        The exponent that the scale factor scales with, default of ``1``.
+
+    comoving : bool, optional
+        Whether to create comoving or physical objects.
+    """
+
+    scale_factor: float
+    scale_exponent: int | float
+    units: unyt.Unit
+    comoving: bool | None
+
+    def __init__(
+        self,
+        scale_factor: float,
+        scale_exponent: int | float = 1,
+        units: unyt.Unit | None = None,
+        comoving: bool | None = None,
+    ) -> None:
+        self.scale_factor = scale_factor
+        self.scale_exponent = scale_exponent
+        self.units = units
+        self._comoving = comoving
+
+    @property
+    def _comoving_str(self) -> str:
+        """
+        Get the comoving status as a string for use in messages.
+
+        Returns
+        -------
+        str
+            The state, either ``"comoving"``, ``"physical"`` or ``"None"``.
+        """
+        if self.comoving:
+            return "comoving"
+        elif self.comoving is False:
+            return "physical"
+        else:
+            return "None"
+
+    @singledispatchmethod
+    def __mul__(self, other) -> None:  # noqa: ANN001
+        """
+        Default implementation for invalid multiplications.
+
+        Raises
+        ------
+        NotImplementedError
+            When something that we cannot multiply with is encountered.
+        """
+        # keep message generic, we might get here through __truediv__ also
+        raise NotImplementedError(
+            f"Cannot combine `a.{self._comoving_str}` with {other} of type {type(other)}"
+        )
+
+    @__mul__.register
+    def _(self, other: unyt.Unit) -> "_AHelper":
+        return _AHelper(
+            scale_factor=self.scale_factor,
+            scale_exponent=self.scale_exponent,
+            units=other.units if self.units is None else other.units * self.units,
+            comoving=self._comoving,
+        )
+
+    @__mul__.register
+    def _(self, other: unyt.unyt_array) -> cosmo_array:
+        return (
+            cosmo_quantity if isinstance(other, unyt.unyt_quantity) else cosmo_array
+        )(
+            other.ndview,
+            units=other.units * self.units if self.units is not None else other.units,
+            comoving=self._comoving,
+            cosmo_factor=cosmo_factor.create(self.scale_factor, self.scale_exponent),
+        )
+
+    @__mul__.register
+    def _(self, other: cosmo_array) -> cosmo_array:
+        if self._comoving:
+            other.convert_to_comoving()  # no-op if already comoving
+        else:  # self._comoving is False, None case is guarded
+            other.convert_to_physical()  # no-op if already physical
+        return other.__class__(
+            other.ndview,
+            units=other.units * self.units if self.units is not None else other.units,
+            comoving=self._comoving,
+            cosmo_factor=other.cosmo_factor
+            * cosmo_factor.create(self.scale_factor, self.scale_exponent),
+        )
+
+    @singledispatchmethod
+    def __rmul__(
+        self, other: unyt.Unit | unyt.unyt_array | cosmo_array
+    ) -> "_AHelper | cosmo_array":
+        """
+        Multiply with argument on the right.
+
+        Just pass the operation to :meth:`~swiftsimio.objects._AHelper.__mul__` to
+        handle.
+
+        Returns
+        -------
+        ~swiftsimio.objects._AHelper or ~swiftsimio.objects.cosmo_aray
+            The result of applying the helper to the other operand.
+
+        Raises
+        ------
+        NotImplementedError
+            When something that we cannot multiply with is encountered.
+        """
+        return self.__mul__(other)
+
+    # @__rmul__.register
+    # def _(self, other: unyt.Unit) -> "_AHelper":
+    #     raise RuntimeError("HOORAY")
+
+    # @__rmul__.register
+    # def _(self, other: unyt.unyt_array) -> cosmo_array:
+    #     raise RuntimeError("HOORAY")
+
+    # @__rmul__.register
+    # def _(self, other: cosmo_array) -> cosmo_array:
+    #     raise RuntimeError("HOORAY")
+
+    def __truediv__(
+        self, other: unyt.Unit | unyt.unyt_array | cosmo_array
+    ) -> "_AHelper | cosmo_array":
+        return (
+            _AHelper(
+                scale_factor=self.scale_factor,
+                scale_exponent=self.scale_exponent,
+                units=self.units,
+                comoving=self._comoving,
+            )
+            * other**-1
+        )
+
+    def __rtruediv__(
+        self, other: unyt.Unit | unyt.unyt_array | cosmo_array
+    ) -> "_AHelper | cosmo_array":
+        return other * _AHelper(
+            scale_factor=self.scale_factor,
+            scale_exponent=-self.scale_exponent,
+            units=self.units,
+            comoving=self._comoving,
+        )
+
+    def __pow__(self, exponent: int | float) -> "_AHelper":
+        return _AHelper(
+            scale_factor=self.scale_factor,
+            scale_exponent=self.scale_exponent * exponent,
+            units=None if self.units is None else self.units**exponent,
+            comoving=self._comoving,
+        )
+
+    @property
+    def comoving(self) -> "_AHelper":
+        return _AHelper(
+            scale_factor=self.scale_factor,
+            scale_exponent=self.scale_exponent,
+            units=self.units,
+            comoving=True,
+        )
+
+    @property
+    def physical(self) -> "_AHelper":
+        return _AHelper(
+            scale_factor=self.scale_factor,
+            scale_exponent=self.scale_exponent,
+            units=self.units,
+            comoving=False,
+        )
+
+    def ensure_comoving_or_physical(self) -> None:
+        # want this to be a decorator...
+        if self._comoving is None:
+            raise InvalidCosmoUnit("...")

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -342,10 +342,16 @@ class cosmo_factor(object):
 
     def __init__(self, expr: sympy.Expr, scale_factor: "float | _AHelper") -> None:
         self.expr = expr
-        if getattr(scale_factor, "_comoving", None) is not None:
-            # We got an `_AHelper` that had its `comoving` or `physical` attribute
-            # accessed, this is not the backwards-compatible case that we want to support
-            # and leads to ambiguity: raise.
+        try:
+            getattr(scale_factor, "_comoving")
+        except AttributeError:
+            # we're just dealing with a float, this is fine
+            pass
+        except InvalidCosmoUnit:
+            # for an _AHelper we require this, otherwise _comoving is True or False
+            pass
+        else:
+            # for an _AHelper complain that .comoving or .physical was accessed
             raise InvalidCosmoUnit("...")
         # If we got an `_AHelper`, get its `_scale_factor` attribute, bypassing the
         # checks that happen when accessing its `scale_factor` attribute: this is an
@@ -353,7 +359,7 @@ class cosmo_factor(object):
         self.scale_factor = getattr(scale_factor, "_scale_factor", scale_factor)
 
     @classmethod
-    def create(cls, scale_factor: float, exponent: numeric_type) -> "cosmo_factor":
+    def create(cls, scale_factor: float, exponent: int | float) -> "cosmo_factor":
         """
         Create :class:`~swiftsimio.objects.cosmo_factor` from scale factor and exponent.
 
@@ -2583,7 +2589,7 @@ class cosmo_array(unyt_array):
     def __imul__(
         self,
         b: "int | float | np.ndarray | unyt.unit_object.Unit | cosmo_array | _AHelper",
-    ) -> Self:
+    ) -> "cosmo_array":
         """
         Multiply this :class:`~swiftsimio.objects.cosmo_array` (in-place).
 
@@ -2668,7 +2674,7 @@ class cosmo_array(unyt_array):
     def __itruediv__(
         self,
         b: "int | float | np.ndarray | unyt.unit_object.Unit | cosmo_array | _AHelper",
-    ) -> Self:
+    ) -> "cosmo_array":
         """
         Divide this :class:`~swiftsimio.objects.cosmo_array` (in-place).
 
@@ -2923,10 +2929,10 @@ class _AHelper(object):
         Whether to create comoving or physical objects.
     """
 
-    scale_factor: float
+    _scale_factor: float
     scale_exponent: int | float
     units: unyt.Unit
-    comoving: bool | None
+    __comoving: bool | None
 
     def __init__(
         self,
@@ -2938,7 +2944,7 @@ class _AHelper(object):
         self._scale_factor = scale_factor
         self.scale_exponent = scale_exponent
         self.units = units
-        self._comoving = comoving
+        self.__comoving = comoving
 
     @property
     def scale_factor(self) -> float:
@@ -2965,9 +2971,38 @@ class _AHelper(object):
         InvalidCosmoUnit
             If access is attempted when physical or comoving has not been specified.
         """
-        if self._comoving is None:
+        if self.__comoving is None:
             raise InvalidCosmoUnit("...")
         return self._scale_factor
+
+    @property
+    def _comoving(self) -> bool:
+        """
+        Get the comoving status of the helper.
+
+        The comoving status should always be accessed through this property. This ensures
+        that the :class:`~swiftsimio.objects._AHelper` cannot be used when its
+        ``_comovin`` attriubte is ``None``, i.e. ``10 * metadata.a * u.kpc`` is invalid
+        but ``10 * metadata.a.physical * u.kpc`` is valid (the ``comoving`` and
+        ``physical`` properties return a copy with ``_comoving is not None``).
+
+        The exception is when creating new :class:`~swiftsimio.objects._AHelper` objects
+        from old ones, then ``_AHelper(comoving=self.__comoving, ...)`` is
+        needed.
+
+        Returns
+        -------
+        float
+            The comoving status.
+
+        Raises
+        ------
+        InvalidCosmoUnit
+            If access is attempted when physical or comoving has not been specified.
+        """
+        if self.__comoving is None:
+            raise InvalidCosmoUnit("...")
+        return self.__comoving
 
     @property
     def _comoving_str(self) -> str:
@@ -3080,14 +3115,14 @@ class _AHelper(object):
         """
         for inp in inputs:
             if isinstance(inp, _AHelper):
-                a_helper_input = inp
+                a_helper_input: _AHelper = inp
         if isinstance(result, cosmo_array):
             if result.comoving is None:
                 result.comoving = a_helper_input._comoving
             else:
                 result.convert_to(result.units, comoving=a_helper_input._comoving)
             result.units = result.units * a_helper_input.units
-            if result.cosmo_factor == cosmo_factor(None, None):
+            if result.cosmo_factor == NULL_CF:
                 result.cosmo_factor = cosmo_factor.create(
                     a_helper_input.scale_factor, a_helper_input.scale_exponent
                 )
@@ -3097,11 +3132,11 @@ class _AHelper(object):
                 )
             return result
         else:
-            return (cosmo_array if result.ndim else cosmo_quantity)(
+            return (cosmo_array if np.asarray(result).ndim else cosmo_quantity)(
                 result,
                 comoving=a_helper_input._comoving,
                 scale_factor=a_helper_input.scale_factor,
-                scale_exponent={np.divide: -1}.get(ufunc, 1)
+                scale_exponent=(-1 if ufunc is np.divide else 1)
                 * a_helper_input.scale_exponent,
             )
 
@@ -3323,7 +3358,7 @@ class _AHelper(object):
             scale_factor=self._scale_factor,
             scale_exponent=self.scale_exponent,
             units=other.units * self.units,
-            comoving=self._comoving,
+            comoving=self.__comoving,
         )
 
     @__mul__.register
@@ -3381,7 +3416,7 @@ class _AHelper(object):
 
     def __rmul__(
         self, other: unyt.Unit | unyt.unyt_array | cosmo_array
-    ) -> Self | cosmo_array:
+    ) -> "_AHelper | cosmo_array":
         """
         Multiply with argument on the right.
 
@@ -3403,7 +3438,7 @@ class _AHelper(object):
 
     def __truediv__(
         self, other: unyt.Unit | unyt.unyt_array | cosmo_array
-    ) -> Self | cosmo_array:
+    ) -> "_AHelper | cosmo_array":
         """
         Divide this helper by a unit, number or array.
 
@@ -3428,13 +3463,13 @@ class _AHelper(object):
                 scale_factor=self._scale_factor,
                 scale_exponent=-self.scale_exponent,
                 units=self.units,
-                comoving=self._comoving,
+                comoving=self.__comoving,
             )
         )
 
     def __rtruediv__(
         self, other: unyt.Unit | unyt.unyt_array | cosmo_array
-    ) -> Self | cosmo_array:
+    ) -> "_AHelper | cosmo_array":
         """
         Divide a unit, number or array by this helper.
 
@@ -3456,10 +3491,10 @@ class _AHelper(object):
             scale_factor=self._scale_factor,
             scale_exponent=-self.scale_exponent,
             units=self.units,
-            comoving=self._comoving,
+            comoving=self.__comoving,
         )
 
-    def __pow__(self, exponent: int | float) -> Self:
+    def __pow__(self, exponent: int | float) -> "_AHelper":
         """
         Raise this helper to a power.
 
@@ -3484,12 +3519,11 @@ class _AHelper(object):
             scale_factor=self._scale_factor,
             scale_exponent=self.scale_exponent * exponent,
             units=self.units**exponent,
-            comoving=self._comoving,
+            comoving=self.__comoving,
         )
 
-    def __imul__(
-        self, other: numeric_type | tuple | list | np.ndarray | unyt_array | cosmo_array
-    ) -> None:
+    @singledispatchmethod
+    def __imul__(self, other) -> None:  # noqa: ANN001
         """
         Do not support in-place multiplication as left operand.
 
@@ -3510,16 +3544,13 @@ class _AHelper(object):
             "argument are not supported."
         )
 
-    def __ipow__(
-        self, other: numeric_type | tuple | list | np.ndarray | unyt_array | cosmo_array
-    ) -> None:
+    def __ipow__(self, exponent: int | float) -> None:
         """
         Do not support in-place exponentiation as left operand.
 
         Parameters
         ----------
-        other : numeric_type or tuple or list or np.ndarray or ~unyt.array.unyt_array or \
-        ~swiftsimio.objects.cosmo_array
+        exponent : int or float
             The exponent to raise this to.
 
         Raises
@@ -3557,7 +3588,7 @@ class _AHelper(object):
         )
 
     @property
-    def comoving(self) -> Self:
+    def comoving(self) -> "_AHelper":
         """
         Indicate that this helper is for a comoving quantity.
 
@@ -3588,7 +3619,7 @@ class _AHelper(object):
         )
 
     @property
-    def physical(self) -> Self:
+    def physical(self) -> "_AHelper":
         """
         Indicate that this helper is for a physical quantity.
 

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -15,7 +15,7 @@ import unyt
 from unyt import unyt_array, unyt_quantity, Unit
 from unyt.array import multiple_output_operators, _iterable, POWER_MAPPING
 from numbers import Number as numeric_type
-from typing import Iterable, Callable, Any
+from typing import Iterable, Callable, Any, Self
 from collections.abc import Collection
 from functools import singledispatchmethod
 
@@ -2701,7 +2701,7 @@ class _AHelper(object):
         )
 
     @__mul__.register
-    def _(self, other: unyt.Unit) -> "_AHelper":
+    def _(self, other: unyt.Unit) -> Self:
         return _AHelper(
             scale_factor=self.scale_factor,
             scale_exponent=self.scale_exponent,
@@ -2737,7 +2737,7 @@ class _AHelper(object):
     @singledispatchmethod
     def __rmul__(
         self, other: unyt.Unit | unyt.unyt_array | cosmo_array
-    ) -> "_AHelper | cosmo_array":
+    ) -> Self | cosmo_array:
         """
         Multiply with argument on the right.
 
@@ -2757,7 +2757,7 @@ class _AHelper(object):
         return self.__mul__(other)
 
     # @__rmul__.register
-    # def _(self, other: unyt.Unit) -> "_AHelper":
+    # def _(self, other: unyt.Unit) -> Self:
     #     raise RuntimeError("HOORAY")
 
     # @__rmul__.register
@@ -2770,7 +2770,7 @@ class _AHelper(object):
 
     def __truediv__(
         self, other: unyt.Unit | unyt.unyt_array | cosmo_array
-    ) -> "_AHelper | cosmo_array":
+    ) -> Self | cosmo_array:
         return (
             _AHelper(
                 scale_factor=self.scale_factor,
@@ -2783,7 +2783,7 @@ class _AHelper(object):
 
     def __rtruediv__(
         self, other: unyt.Unit | unyt.unyt_array | cosmo_array
-    ) -> "_AHelper | cosmo_array":
+    ) -> Self | cosmo_array:
         return other * _AHelper(
             scale_factor=self.scale_factor,
             scale_exponent=-self.scale_exponent,
@@ -2791,7 +2791,7 @@ class _AHelper(object):
             comoving=self._comoving,
         )
 
-    def __pow__(self, exponent: int | float) -> "_AHelper":
+    def __pow__(self, exponent: int | float) -> Self:
         return _AHelper(
             scale_factor=self.scale_factor,
             scale_exponent=self.scale_exponent * exponent,
@@ -2800,7 +2800,7 @@ class _AHelper(object):
         )
 
     @property
-    def comoving(self) -> "_AHelper":
+    def comoving(self) -> Self:
         return _AHelper(
             scale_factor=self.scale_factor,
             scale_exponent=self.scale_exponent,
@@ -2809,7 +2809,7 @@ class _AHelper(object):
         )
 
     @property
-    def physical(self) -> "_AHelper":
+    def physical(self) -> Self:
         return _AHelper(
             scale_factor=self.scale_factor,
             scale_exponent=self.scale_exponent,

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -2414,6 +2414,7 @@ class cosmo_array(unyt_array):
         result = _ensure_result_is_cosmo_array_or_quantity(super().__array_ufunc__)(
             ufunc, method, *helper_result["args"], **helper_result["kwargs"]
         )
+        raise RuntimeError
         # if we get a tuple we have multiple return values to deal with
         if isinstance(result, tuple):
             for r in result:

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -2517,7 +2517,8 @@ class cosmo_array(unyt_array):
         return function_to_invoke(*args, **kwargs)
 
     def __mul__(
-        self, b: "int | float | np.ndarray | unyt.unit_object.Unit | _AHelper"
+        self,
+        b: "int | float | np.ndarray | unyt.unit_object.Unit | cosmo_array | _AHelper",
     ) -> "cosmo_array":
         """
         Multiply this :class:`~swiftsimio.objects.cosmo_array`.
@@ -2528,8 +2529,9 @@ class cosmo_array(unyt_array):
 
         Parameters
         ----------
-        b : :class:`~numpy.ndarray`, :obj:`int`, :obj:`float`, \
-        :class:`~unyt.unit_object.Unit` or :class:`~swiftsimio.objects._AHelper`
+        b : :class:`~numpy.ndarray`, :obj:`int`, :obj:`float` or \
+        :class:`~unyt.unit_object.Unit` or :class:`~swiftsimio.objects.cosmo_array` or \
+        :class:`~swiftsimio.objects._AHelper`
             The object to multiply with this one.
 
         Returns
@@ -2552,7 +2554,8 @@ class cosmo_array(unyt_array):
             return super().__mul__(b)
 
     def __rmul__(
-        self, b: int | float | np.ndarray | unyt.unit_object.Unit
+        self,
+        b: "int | float | np.ndarray | unyt.unit_object.Unit | cosmo_array | _AHelper",
     ) -> "cosmo_array":
         """
         Multiply this :class:`~swiftsimio.objects.cosmo_array` (as the right argument).
@@ -2563,7 +2566,8 @@ class cosmo_array(unyt_array):
         Parameters
         ----------
         b : :class:`~numpy.ndarray`, :obj:`int`, :obj:`float` or \
-        :class:`~unyt.unit_object.Unit`
+        :class:`~unyt.unit_object.Unit` or :class:`~swiftsimio.objects.cosmo_array` or \
+        :class:`~swiftsimio.objects._AHelper`
             The object to multiply with this one.
 
         Returns
@@ -2575,6 +2579,70 @@ class cosmo_array(unyt_array):
             return self.__mul__(b)
         else:
             return super().__rmul__(b)
+
+    def __truediv__(
+        self,
+        b: "int | float | np.ndarray | unyt.unit_object.Unit | cosmo_array | _AHelper",
+    ) -> "cosmo_array":
+        """
+        Divide this :class:`~swiftsimio.objects.cosmo_array`.
+
+        We delegate most cases to :mod:`unyt`, but we need to handle the case where the
+        second argument is a :class:`~unyt.unit_object.Unit` and the case where the
+        second argument is a :class:`~swiftsimio.objects._AHelper`.
+
+        Parameters
+        ----------
+        b : :class:`~numpy.ndarray`, :obj:`int`, :obj:`float` or \
+        :class:`~unyt.unit_object.Unit` or :class:`~swiftsimio.objects.cosmo_array` or \
+        :class:`~swiftsimio.objects._AHelper`
+            The object to divide this one by.
+
+        Returns
+        -------
+        ~swiftsimio.objects.cosmo_array
+            The result of the division.
+        """
+        if getattr(b, "is_Unit", False):
+            return _copy_cosmo_array_attributes_if_present(
+                self,
+                _ensure_result_is_cosmo_array_or_quantity((b**-1).__mul__)(
+                    self.view(unyt_quantity)
+                    if self.shape == ()
+                    else self.view(unyt_array)
+                ),
+            )
+        elif isinstance(b, _AHelper):
+            return (b**-1).__mul__(self)
+        else:
+            return super().__truediv__(b)
+
+    def __rtruediv__(
+        self,
+        b: "int | float | np.ndarray | unyt.unit_object.Unit | cosmo_array | _AHelper",
+    ) -> "cosmo_array":
+        """
+        Divide by this :class:`~swiftsimio.objects.cosmo_array` (as the right argument).
+
+        We delegate most cases to :mod:`unyt`, but we need to handle the case where the
+        second argument is a :class:`~unyt.unit_object.Unit`.
+
+        Parameters
+        ----------
+        b : :class:`~numpy.ndarray`, :obj:`int`, :obj:`float` or \
+        :class:`~unyt.unit_object.Unit` or :class:`~swiftsimio.objects.cosmo_array` or \
+        :class:`~swiftsimio.objects._AHelper`
+            The object to divide by this one.
+
+        Returns
+        -------
+        ~swiftsimio.objects.cosmo_array
+            The result of the division.
+        """
+        if getattr(b, "is_Unit", False):
+            return (1 / self).__mul__(b)
+        else:
+            return super().__rtruediv__(b)
 
 
 class cosmo_quantity(cosmo_array, unyt_quantity):
@@ -2915,6 +2983,8 @@ class _AHelper(object):
         dict
             The now prepared kwargs for the ufunc.
         """
+        if ufunc not in (np.multiply, np, divide):
+            return NotImplemented
         prepared_inputs = tuple(
             unyt_quantity(
                 1,
@@ -2989,7 +3059,8 @@ class _AHelper(object):
                 result,
                 comoving=a_helper_input._comoving,
                 scale_factor=a_helper_input.scale_factor,
-                scale_exponent=a_helper_input.scale_exponent,
+                scale_exponent={np.divide: -1}.get(ufunc, 1)
+                * a_helper_input.scale_exponent,
             )
 
     def __array_ufunc__(
@@ -3308,14 +3379,15 @@ class _AHelper(object):
         ~swiftsimio.objects._AHelper or ~swiftsimio.objects.cosmo_aray
             The result of applying the helper to the other operand.
         """
-        return (
-            _AHelper(
+        # avoid using other ** -1, e.g. integers raise on this
+        return 1 / (
+            other
+            * _AHelper(
                 scale_factor=self._scale_factor,
-                scale_exponent=self.scale_exponent,
+                scale_exponent=-self.scale_exponent,
                 units=self.units,
                 comoving=self._comoving,
             )
-            * other**-1
         )
 
     def __rtruediv__(

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -2983,7 +2983,6 @@ class _AHelper(object):
                 result.cosmo_factor = result.cosmo_factor * cosmo_factor.create(
                     a_helper_input.scale_factor, a_helper_input.scale_exponent
                 )
-            # raise RuntimeError
             return result
         else:
             return (cosmo_array if result.ndim else cosmo_quantity)(
@@ -3052,7 +3051,6 @@ class _AHelper(object):
         NotImplemented
             This operation is not defined.
         """
-        # keep message generic, we might get here through __truediv__ also
         return NotImplemented
 
     def _ndarray_or_number_mul(self, other: numeric_type | np.ndarray) -> cosmo_array:
@@ -3133,7 +3131,7 @@ class _AHelper(object):
             ``other`` :obj:`tuple` or :obj:`list`.
         """
         # the two registered functions calling this can be merged into one with
-        # type hint `other: numeric_type | np.ndarray` once python3.10 support is
+        # type hint `other: tuple | list` once python3.10 support is
         # dropped
 
         # leave other arguments implicit, could pick up values from content of other:

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -2580,6 +2580,27 @@ class cosmo_array(unyt_array):
         else:
             return super().__rmul__(b)
 
+    def __imul__(
+        self,
+        b: "int | float | np.ndarray | unyt.unit_object.Unit | cosmo_array | _AHelper",
+    ) -> Self:
+        """
+        Multiply this :class:`~swiftsimio.objects.cosmo_array` (in-place).
+
+        Parameters
+        ----------
+        b : :class:`~numpy.ndarray`, :obj:`int`, :obj:`float` or \
+        :class:`~unyt.unit_object.Unit` or :class:`~swiftsimio.objects.cosmo_array` or \
+        :class:`~swiftsimio.objects._AHelper`
+            The object to multiply with this one.
+
+        Returns
+        -------
+        ~swiftsimio.objects.cosmo_array
+            The result of the multiplication.
+        """
+        return self.__mul__(b)
+
     def __truediv__(
         self,
         b: "int | float | np.ndarray | unyt.unit_object.Unit | cosmo_array | _AHelper",
@@ -2643,6 +2664,27 @@ class cosmo_array(unyt_array):
             return (1 / self).__mul__(b)
         else:
             return super().__rtruediv__(b)
+
+    def __itruediv__(
+        self,
+        b: "int | float | np.ndarray | unyt.unit_object.Unit | cosmo_array | _AHelper",
+    ) -> Self:
+        """
+        Divide this :class:`~swiftsimio.objects.cosmo_array` (in-place).
+
+        Parameters
+        ----------
+        b : :class:`~numpy.ndarray`, :obj:`int`, :obj:`float` or \
+        :class:`~unyt.unit_object.Unit` or :class:`~swiftsimio.objects.cosmo_array` or \
+        :class:`~swiftsimio.objects._AHelper`
+            The object to divide this one by.
+
+        Returns
+        -------
+        ~swiftsimio.objects.cosmo_array
+            The result of the division.
+        """
+        return self.__truediv__(b)
 
 
 class cosmo_quantity(cosmo_array, unyt_quantity):
@@ -3443,6 +3485,75 @@ class _AHelper(object):
             scale_exponent=self.scale_exponent * exponent,
             units=self.units**exponent,
             comoving=self._comoving,
+        )
+
+    def __imul__(
+        self, other: numeric_type | tuple | list | np.ndarray | unyt_array | cosmo_array
+    ) -> None:
+        """
+        Do not support in-place multiplication as left operand.
+
+        Parameters
+        ----------
+        other : numeric_type or tuple or list or np.ndarray or ~unyt.array.unyt_array or \
+        ~swiftsimio.objects.cosmo_array
+            The other object to multiply with this one.
+
+        Raises
+        ------
+        TypeError
+            In-place operations with :class:`~swiftsimio.objects._AHelper` as left
+            argument are not supported.
+        """
+        raise TypeError(
+            "In-place operations with :class:`~swiftsimio.objects._AHelper` as left "
+            "argument are not supported."
+        )
+
+    def __ipow__(
+        self, other: numeric_type | tuple | list | np.ndarray | unyt_array | cosmo_array
+    ) -> None:
+        """
+        Do not support in-place exponentiation as left operand.
+
+        Parameters
+        ----------
+        other : numeric_type or tuple or list or np.ndarray or ~unyt.array.unyt_array or \
+        ~swiftsimio.objects.cosmo_array
+            The exponent to raise this to.
+
+        Raises
+        ------
+        TypeError
+            In-place operations with :class:`~swiftsimio.objects._AHelper` as left
+            argument are not supported.
+        """
+        raise TypeError(
+            "In-place operations with :class:`~swiftsimio.objects._AHelper` as left "
+            "argument are not supported."
+        )
+
+    def __itruediv__(
+        self, other: numeric_type | tuple | list | np.ndarray | unyt_array | cosmo_array
+    ) -> None:
+        """
+        Do not support in-place division as left operand.
+
+        Parameters
+        ----------
+        other : numeric_type or tuple or list or np.ndarray or ~unyt.array.unyt_array or \
+        ~swiftsimio.objects.cosmo_array
+            The other object to divide this one by.
+
+        Raises
+        ------
+        TypeError
+            In-place operations with :class:`~swiftsimio.objects._AHelper` as left
+            argument are not supported.
+        """
+        raise TypeError(
+            "In-place operations with :class:`~swiftsimio.objects._AHelper` as left "
+            "argument are not supported."
         )
 
     @property

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -378,7 +378,12 @@ class cosmo_factor:
             pass
         else:
             # for an _AHelper complain that .comoving or .physical was accessed
-            raise InvalidCosmoUnit("...")
+            raise InvalidCosmoUnit(
+                "Initialize cosmo_array (or cosmo_quantity, or cosmo_factor) with e.g. "
+                "`scale_factor=metadata.scale_factor`, not e.g. "
+                "`scale_factor=metadata.a.comoving` or "
+                "`scale_factor=metadata.a.physical`."
+            )
         # If we got an `_AHelper`, get its `_scale_factor` attribute, bypassing the
         # checks that happen when accessing its `scale_factor` attribute: this is an
         # intentional exception to the rule.
@@ -3001,7 +3006,10 @@ class _AHelper:
             If access is attempted when physical or comoving has not been specified.
         """
         if self._comoving_state is None:
-            raise InvalidCosmoUnit("...")
+            raise InvalidCosmoUnit(
+                "Cannot use scale factor helper as `a` alone, use `a.comoving` or "
+                "`a.physical`."
+            )
         return self._scale_factor
 
     @property
@@ -3030,7 +3038,10 @@ class _AHelper:
             If access is attempted when physical or comoving has not been specified.
         """
         if self._comoving_state is None:
-            raise InvalidCosmoUnit("...")
+            raise InvalidCosmoUnit(
+                "Cannot use scale factor helper as `a` alone, use `a.comoving` or "
+                "`a.physical`."
+            )
         return self._comoving_state
 
     @property

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -2969,7 +2969,8 @@ class _AHelper(object):
         for inp in inputs:
             if isinstance(inp, _AHelper):
                 a_helper_input = inp
-        if isinstance(result, cosmo_array):
+
+        if isinstance(result, cosmo_array):  # -- UNUSED, REMOVE?
             if result.comoving is None:
                 result.comoving = a_helper_input._comoving
             else:
@@ -2982,7 +2983,7 @@ class _AHelper(object):
             else:
                 result.cosmo_factor = result.cosmo_factor * cosmo_factor.create(
                     a_helper_input.scale_factor, a_helper_input.scale_exponent
-                )
+                )  # --
             return result
         else:
             return (cosmo_array if result.ndim else cosmo_quantity)(
@@ -3213,7 +3214,7 @@ class _AHelper(object):
             comoving=self._comoving,
         )
 
-    @__mul__.register
+    @__mul__.register  # -- UNUSED, REMOVE? OR JUST UNTESTED SO FAR?
     def _(self, other: unyt.unyt_array) -> cosmo_array:
         """
         Multiply with a :class:`~unyt.array.unyt_array`.

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -3055,8 +3055,7 @@ class _AHelper(object):
         # keep message generic, we might get here through __truediv__ also
         return NotImplemented
 
-    @__mul__.register
-    def _(self, other: numeric_type | np.ndarray) -> cosmo_array:
+    def _ndarray_or_number_mul(self, other: numeric_type | np.ndarray) -> cosmo_array:
         """
         Multiply with a number or :mod:`numpy` array.
 
@@ -3071,6 +3070,9 @@ class _AHelper(object):
             A cosmo array or quantity based on the content of this helper and the
             ``other`` number or array.
         """
+        # the two registered functions calling this can be merged into one with
+        # type hint `other: numeric_type | np.ndarray` once python3.10 support is
+        # dropped
         return (cosmo_quantity if np.isscalar(other) else cosmo_array)(
             other,
             units=self.units,
@@ -3080,7 +3082,42 @@ class _AHelper(object):
         )
 
     @__mul__.register
-    def _(self, other: tuple | list) -> cosmo_array:
+    def _(self, other: numeric_type) -> cosmo_array:
+        """
+        Multiply with a number.
+
+        Parameters
+        ----------
+        other : numeric_type
+            The quantity to multiply with.
+
+        Returns
+        -------
+        ~swiftsimio.objects.cosmo_array
+            A cosmo array or quantity based on the content of this helper and the
+            ``other`` number.
+        """
+        return self._ndarray_or_number_mul(other)
+
+    @__mul__.register
+    def _(self, other: np.ndarray) -> cosmo_array:
+        """
+        Multiply with a :mod:`numpy` array.
+
+        Parameters
+        ----------
+        other : np.ndarray
+            The quantity to multiply with.
+
+        Returns
+        -------
+        ~swiftsimio.objects.cosmo_array
+            A cosmo array or quantity based on the content of this helper and the
+            ``other`` array.
+        """
+        return self._ndarray_or_number_mul(other)
+
+    def _tuple_or_list_mul(self, other: tuple | list) -> cosmo_array:
         """
         Multiply with a :obj:`list` or :obj:`tuple`.
 
@@ -3095,7 +3132,11 @@ class _AHelper(object):
             A cosmo array or quantity based on the content of this helper and the
             ``other`` :obj:`tuple` or :obj:`list`.
         """
-        # leave the rest implicit, could pick up values from content of other:
+        # the two registered functions calling this can be merged into one with
+        # type hint `other: numeric_type | np.ndarray` once python3.10 support is
+        # dropped
+
+        # leave other arguments implicit, could pick up values from content of other:
         ret = cosmo_array(other)
         # now modify attributes:
         if ret.comoving is not None:
@@ -3112,6 +3153,42 @@ class _AHelper(object):
                 self.scale_factor, self.scale_exponent
             )
         return ret
+
+    @__mul__.register
+    def _(self, other: tuple) -> cosmo_array:
+        """
+        Multiply with a :obj:`tuple`.
+
+        Parameters
+        ----------
+        other : tuple
+            The quantity to multiply with.
+
+        Returns
+        -------
+        ~swiftsimio.objects.cosmo_array
+            A cosmo array or quantity based on the content of this helper and the
+            ``other`` :obj:`tuple`.
+        """
+        return self._tuple_or_list_mul(other)
+
+    @__mul__.register
+    def _(self, other: list) -> cosmo_array:
+        """
+        Multiply with a :obj:`list` or :obj:`tuple`.
+
+        Parameters
+        ----------
+        other : tuple or list
+            The quantity to multiply with.
+
+        Returns
+        -------
+        ~swiftsimio.objects.cosmo_array
+            A cosmo array or quantity based on the content of this helper and the
+            ``other`` :obj:`tuple` or :obj:`list`.
+        """
+        return self._tuple_or_list_mul(other)
 
     @__mul__.register
     def _(self, other: unyt.Unit) -> Self:

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -261,8 +261,6 @@ class InvalidCosmoUnit(Exception):
     """
     Generated when a :class:`~swiftsimio.objects._AHelper` encounters an incompatibility.
 
-    For example, trying to multiply with a bare scalar.
-
     Parameters
     ----------
     message : str, optional

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -2414,7 +2414,6 @@ class cosmo_array(unyt_array):
         result = _ensure_result_is_cosmo_array_or_quantity(super().__array_ufunc__)(
             ufunc, method, *helper_result["args"], **helper_result["kwargs"]
         )
-        raise RuntimeError
         # if we get a tuple we have multiple return values to deal with
         if isinstance(result, tuple):
             for r in result:

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -15,7 +15,12 @@ import unyt
 from unyt import unyt_array, unyt_quantity, Unit
 from unyt.array import multiple_output_operators, _iterable, POWER_MAPPING
 from numbers import Number as numeric_type
-from typing import Iterable, Callable, Any, Self
+from typing import Iterable, Callable, Any
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self  # in python 3.10
 from collections.abc import Collection
 from functools import singledispatchmethod
 

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -12,6 +12,7 @@ helpers, wrappers and implementations that enable most :mod:`numpy` and
 """
 
 import unyt
+from unyt.array import _ufunc_prepare_and_finalize
 from unyt import unyt_array, unyt_quantity, Unit
 from unyt.array import multiple_output_operators, _iterable, POWER_MAPPING
 from numbers import Number as numeric_type
@@ -1456,6 +1457,63 @@ class cosmo_array(unyt_array):
     ua = property(_propagate_cosmo_array_attributes_to_result(np.ones_like))
     unit_array = property(_propagate_cosmo_array_attributes_to_result(np.ones_like))
 
+    def convert_to(
+        self,
+        units: unyt.Unit | str | None = None,
+        *,
+        comoving: bool | None = None,
+        equivalence: str | None = None,
+        **kwargs: dict[str, Any],
+    ) -> None:
+        """
+        Convert the internal data in-place to desired units and comoving status.
+
+        Optionally, an equivalence can be specified to convert to an equivalent quantity
+        which is not in the same dimensions.
+
+        Parameters
+        ----------
+        units : ~unyt.Unit or str, optional
+            The desired units for the converted array. If omitted the units are preserved.
+
+        comoving : bool, optional
+            The desired comoving state for the converted array. If omitted the comoving
+            state is preserved.
+
+        equivalence : str, optional
+            The equivalence to use. To see which equivalences are supported for this
+            quantity, try the :meth:`~unyt.array.unyt_array.list_equivalencies` method.
+
+        **kwargs : dict
+            Any additional keyword arguments are supplied to the equivalence.
+
+        Returns
+        -------
+        ~swiftsimio.objects.cosmo_array
+            This array in the requested comoving units, transformed in place.
+
+        Raises
+        ------
+        UnitConversionError
+            If the provided ``units`` does not have the same dimensions as the array and
+            cannot be converted via a provided ``equivalence``.
+
+        See Also
+        --------
+        ~swiftsimio.objects.cosmo_array.convert_to_physical
+        ~swiftsimio.objects.cosmo_array.convert_to_comoving
+        ~swiftsimio.objects.cosmo_array.to_physical
+        ~swiftsimio.objects.cosmo_array.to_comoving
+        ~swiftsimio.objects.cosmo_array.to
+        ~swiftsimio.objects.cosmo_array.to_physical_value
+        ~swiftsimio.objects.cosmo_array.to_comoving_value
+        ~swiftsimio.objects.cosmo_array.to_value
+        """
+        if comoving:
+            self.convert_to_comoving(units, equivalence=equivalence, **kwargs)
+        elif comoving is False:
+            self.convert_to_physical(units, equivalence=equivalence, **kwargs)
+
     def convert_to_comoving(
         self,
         units: unyt.Unit | str | None = None,
@@ -1466,7 +1524,7 @@ class cosmo_array(unyt_array):
         """
         Convert the internal data in-place to be in comoving units.
 
-        Optionaly, an equivalence can be specified to convert to an equivalent quantity
+        Optionally, an equivalence can be specified to convert to an equivalent quantity
         which is not in the same dimensions.
 
         Parameters
@@ -1491,6 +1549,17 @@ class cosmo_array(unyt_array):
         UnitConversionError
             If the provided ``units`` does not have the same dimensions as the array and
             cannot be converted via a provided ``equivalence``.
+
+        See Also
+        --------
+        ~swiftsimio.objects.cosmo_array.convert_to_physical
+        ~swiftsimio.objects.cosmo_array.convert_to
+        ~swiftsimio.objects.cosmo_array.to_physical
+        ~swiftsimio.objects.cosmo_array.to_comoving
+        ~swiftsimio.objects.cosmo_array.to
+        ~swiftsimio.objects.cosmo_array.to_physical_value
+        ~swiftsimio.objects.cosmo_array.to_comoving_value
+        ~swiftsimio.objects.cosmo_array.to_value
         """
         if units is not None:
             self.convert_to_units(units, equivalence=equivalence, **kwargs)
@@ -1514,7 +1583,7 @@ class cosmo_array(unyt_array):
         """
         Convert the internal data in-place to be in physical units.
 
-        Optionaly, an equivalence can be specified to convert to an equivalent quantity
+        Optionally, an equivalence can be specified to convert to an equivalent quantity
         which is not in the same dimensions.
 
         Parameters
@@ -1539,6 +1608,17 @@ class cosmo_array(unyt_array):
         UnitConversionError
             If the provided ``units`` does not have the same dimensions as the array and
             cannot be converted via a provided ``equivalence``.
+
+        See Also
+        --------
+        ~swiftsimio.objects.cosmo_array.convert_to_comoving
+        ~swiftsimio.objects.cosmo_array.convert_to
+        ~swiftsimio.objects.cosmo_array.to_physical
+        ~swiftsimio.objects.cosmo_array.to_comoving
+        ~swiftsimio.objects.cosmo_array.to
+        ~swiftsimio.objects.cosmo_array.to_physical_value
+        ~swiftsimio.objects.cosmo_array.to_comoving_value
+        ~swiftsimio.objects.cosmo_array.to_value
         """
         if units is not None:
             self.convert_to_units(units, equivalence=equivalence, **kwargs)
@@ -1585,6 +1665,17 @@ class cosmo_array(unyt_array):
         UnitConversionError
             If the provided ``units`` does not have the same dimensions as the array and
             cannot be converted via a provided ``equivalence``.
+
+        See Also
+        --------
+        ~swiftsimio.objects.cosmo_array.convert_to_physical
+        ~swiftsimio.objects.cosmo_array.convert_to_comoving
+        ~swiftsimio.objects.cosmo_array.convert_to
+        ~swiftsimio.objects.cosmo_array.to_comoving
+        ~swiftsimio.objects.cosmo_array.to
+        ~swiftsimio.objects.cosmo_array.to_physical_value
+        ~swiftsimio.objects.cosmo_array.to_comoving_value
+        ~swiftsimio.objects.cosmo_array.to_value
         """
         if not self.valid_transform and self.comoving:
             raise InvalidConversionError
@@ -1627,6 +1718,17 @@ class cosmo_array(unyt_array):
         UnitConversionError
             If the provided ``units`` does not have the same dimensions as the array and
             cannot be converted via a provided ``equivalence``.
+
+        See Also
+        --------
+        ~swiftsimio.objects.cosmo_array.convert_to_physical
+        ~swiftsimio.objects.cosmo_array.convert_to_comoving
+        ~swiftsimio.objects.cosmo_array.convert_to
+        ~swiftsimio.objects.cosmo_array.to_physical
+        ~swiftsimio.objects.cosmo_array.to
+        ~swiftsimio.objects.cosmo_array.to_physical_value
+        ~swiftsimio.objects.cosmo_array.to_comoving_value
+        ~swiftsimio.objects.cosmo_array.to_value
         """
         if not self.valid_transform and self.comoving is not False:
             raise InvalidConversionError
@@ -1683,6 +1785,17 @@ class cosmo_array(unyt_array):
             If the provided ``units`` does not have the same dimensions as the array and
             cannot be converted via a provided ``equivalence``.
         
+        See Also
+        --------
+        ~swiftsimio.objects.cosmo_array.convert_to_physical
+        ~swiftsimio.objects.cosmo_array.convert_to_comoving
+        ~swiftsimio.objects.cosmo_array.convert_to
+        ~swiftsimio.objects.cosmo_array.to_physical
+        ~swiftsimio.objects.cosmo_array.to_comoving
+        ~swiftsimio.objects.cosmo_array.to_physical_value
+        ~swiftsimio.objects.cosmo_array.to_comoving_value
+        ~swiftsimio.objects.cosmo_array.to_value
+
         Examples
         --------
         .. code-block:: python
@@ -1772,6 +1885,17 @@ class cosmo_array(unyt_array):
             If the provided ``units`` does not have the same dimensions as the array and
             cannot be converted via a provided ``equivalence``.
 
+        See Also
+        --------
+        ~swiftsimio.objects.cosmo_array.convert_to_physical
+        ~swiftsimio.objects.cosmo_array.convert_to_comoving
+        ~swiftsimio.objects.cosmo_array.convert_to
+        ~swiftsimio.objects.cosmo_array.to_physical
+        ~swiftsimio.objects.cosmo_array.to_comoving
+        ~swiftsimio.objects.cosmo_array.to
+        ~swiftsimio.objects.cosmo_array.to_physical_value
+        ~swiftsimio.objects.cosmo_array.to_comoving_value
+
         Examples
         --------
         .. code-block:: python
@@ -1830,6 +1954,17 @@ class cosmo_array(unyt_array):
         UnitConversionError
             If the provided ``units`` does not have the same dimensions as the array and
             cannot be converted via a provided ``equivalence``.
+
+        See Also
+        --------
+        ~swiftsimio.objects.cosmo_array.convert_to_physical
+        ~swiftsimio.objects.cosmo_array.convert_to_comoving
+        ~swiftsimio.objects.cosmo_array.convert_to
+        ~swiftsimio.objects.cosmo_array.to_physical
+        ~swiftsimio.objects.cosmo_array.to_comoving
+        ~swiftsimio.objects.cosmo_array.to
+        ~swiftsimio.objects.cosmo_array.to_comoving_value
+        ~swiftsimio.objects.cosmo_array.to_value
         """
         return self.to_value(units, equivalence=equivalence, comoving=False, **kwargs)
 
@@ -1872,6 +2007,17 @@ class cosmo_array(unyt_array):
         UnitConversionError
             If the provided ``units`` does not have the same dimensions as the array and
             cannot be converted via a provided ``equivalence``.
+
+        See Also
+        --------
+        ~swiftsimio.objects.cosmo_array.convert_to_physical
+        ~swiftsimio.objects.cosmo_array.convert_to_comoving
+        ~swiftsimio.objects.cosmo_array.convert_to
+        ~swiftsimio.objects.cosmo_array.to_physical
+        ~swiftsimio.objects.cosmo_array.to_comoving
+        ~swiftsimio.objects.cosmo_array.to
+        ~swiftsimio.objects.cosmo_array.to_physical_value
+        ~swiftsimio.objects.cosmo_array.to_value
         """
         return self.to_value(units, equivalence=equivalence, comoving=True, **kwargs)
 
@@ -2041,11 +2187,11 @@ class cosmo_array(unyt_array):
 
         Parameters
         ----------
-        ufunc : np.ufunc
+        ufunc : ~numpy.ufunc
             The ufunc that is about to be called.
 
         method : str
-            The call method for the ufunc (for example `"call"` or `"reduce"`).
+            The call method for the ufunc (for example ``"call"`` or ``"reduce"``).
 
         *inputs : tuple
             The ufunc arguments.
@@ -2055,7 +2201,7 @@ class cosmo_array(unyt_array):
 
         Returns
         -------
-        np.ufunc
+        ~numpy.ufunc
             The ufunc that is about to be called.
 
         str
@@ -2082,21 +2228,21 @@ class cosmo_array(unyt_array):
         """
         Finalize results after a ufunc call.
 
-        This function gives us the opportunity to post-process return value(s) from a ufunc
-        when we get control back from :mod:`unyt`. We check that the return type is
+        This function gives us the opportunity to post-process return value(s) from a
+        ufunc when we get control back from :mod:`unyt`. We check that the return type is
         consistent with its shape (i.e. a :class:`~swiftsimio.objects.cosmo_array` or
         :class:`~swiftsimio.objects.cosmo_quantity`) and attach our cosmo attributes.
 
         Parameters
         ----------
-        result : :class:`~unyt.array.unyt_array` or tuple
+        result : ~unyt.array.unyt_array or tuple
             The return value of the called ufunc.
 
-        ufunc : np.ufunc
+        ufunc : ~numpy.ufunc
             The ufunc that was called.
 
         method : str
-            The call method for the ufunc (for example `"call"` or `"reduce"`).
+            The call method for the ufunc (for example ``"call"`` or ``"reduce"``).
 
         *inputs : tuple
             The ufunc arguments.
@@ -2107,7 +2253,8 @@ class cosmo_array(unyt_array):
         Returns
         -------
         tuple or comso_array
-            The result of the ufunc call, with the appropriate type and cosmo attributes attached.
+            The result of the ufunc call, with the appropriate type and cosmo attributes
+            attached.
         """
         # wonder if we could cache helper_result during __unyt_ufunc_prepare__ to use here?
         helper_result = _prepare_array_func_args(*inputs, **kwargs)
@@ -2660,7 +2807,7 @@ class _AHelper(object):
         self,
         scale_factor: float,
         scale_exponent: int | float = 1,
-        units: unyt.Unit | None = None,
+        units: unyt.Unit = unyt.dimensionless,
         comoving: bool | None = None,
     ) -> None:
         self.scale_factor = scale_factor
@@ -2678,12 +2825,151 @@ class _AHelper(object):
         str
             The state, either ``"comoving"``, ``"physical"`` or ``"None"``.
         """
-        if self.comoving:
+        if self._comoving:
             return "comoving"
-        elif self.comoving is False:
+        elif self._comoving is False:
             return "physical"
         else:
             return "None"
+
+    @classmethod
+    def __unyt_ufunc_prepare__(
+        cls, ufunc: np.ufunc, method: str, *inputs: tuple, **kwargs: dict[str, Any]
+    ) -> tuple[np.ufunc, str, tuple, dict]:
+        """
+        Prepare arguments for a ufunc call.
+
+        This function gives us the opportunity to pre-process arguments to a ufunc call
+        before handing control off to :mod:`unyt`. We strip away any cosmo attributes
+        to be restored in :meth:`~swiftsimio.objects._AHelper.__unyt_ufunc_finalize__`.
+
+        Parameters
+        ----------
+        ufunc : ~numpy.ufunc
+            The ufunc that is about to be called.
+
+        method : str
+            The call method for the ufunc (for example ``"call"`` or ``"reduce"``).
+
+        *inputs : tuple
+            The ufunc arguments.
+
+        **kwargs : dict
+            The ufunc kwargs.
+
+        Returns
+        -------
+        ~numpy.ufunc
+            The ufunc that is about to be called.
+
+        str
+            The call method for the ufunc.
+
+        tuple
+            The now prepared arguments for the ufunc.
+
+        dict
+            The now prepared kwargs for the ufunc.
+        """
+        prepared_inputs = tuple(
+            unyt_quantity(
+                1,
+                inp.units,
+            )
+            if isinstance(inp, _AHelper)
+            else inp
+            for inp in inputs
+        )
+        return (ufunc, method, prepared_inputs, kwargs)
+
+    @classmethod
+    def __unyt_ufunc_finalize__(
+        cls,
+        result: tuple | unyt_array,
+        ufunc: np.ufunc,
+        method: str,
+        *inputs: tuple,
+        **kwargs: dict[str, Any],
+    ) -> cosmo_array:
+        """
+        Finalize results after a ufunc call.
+
+        This function gives us the opportunity to post-process return value(s) from a
+        ufunc when we get control back from :mod:`unyt`. We turn it into a
+        :class:`~swiftsimio.objects.cosmo_array` or
+        :class:`~swiftsimio.objects.cosmo_quantity` and set its attributes.
+
+        Parameters
+        ----------
+        result : ~unyt.array.unyt_array or tuple
+            The return value of the called ufunc.
+
+        ufunc : ~numpy.ufunc
+            The ufunc that was called.
+
+        method : str
+            The call method for the ufunc (for example ``"call"`` or ``"reduce"``).
+
+        *inputs : tuple
+            The ufunc arguments.
+
+        **kwargs : dict
+            The ufunc kwargs.
+
+        Returns
+        -------
+        tuple or comso_array
+            The result of the ufunc call, with the appropriate type and cosmo attributes
+            attached.
+        """
+        for inp in inputs:
+            if isinstance(inp, _AHelper):
+                a_helper_input = inp
+        ret = (cosmo_array if result.ndim else cosmo_quantity)(
+            result,
+            comoving=a_helper_input._comoving,
+            scale_factor=a_helper_input.scale_factor,
+            scale_exponent=a_helper_input.scale_exponent,
+        )
+        return ret
+
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        """
+        Handle :mod:`numpy` ufunc calls on :class:`~swiftsimio.objects.cosmo_array` input.
+
+        :mod:`numpy` facilitates wrapping array classes by handing off to this function
+        when a function of :class:`numpy.ufunc` type is called with arguments from an
+        inheriting array class. Since we inherit from :class:`~unyt.array.unyt_array`,
+        we let :mod:`unyt` handle what to do with the units and take care of processing
+        the cosmology information via our helper functions.
+
+        Parameters
+        ----------
+        ufunc : numpy.ufunc
+            The numpy function being called.
+
+        method : str, optional
+            Some ufuncs have methods accessed as attributes, such as ``"reduce"``.
+            If using such a method, this argument receives its name.
+
+        *inputs : tuple
+            Arguments to the ufunc.
+
+        **kwargs : dict
+            Keyword arguments to the ufunc.
+
+        Returns
+        -------
+        object
+            The result of the ufunc call, with our cosmology attribute processing applied.
+        """
+        prepared_ufunc, prepared_method, prepared_inputs, prepared_kwargs = (
+            self.__unyt_ufunc_prepare__(ufunc, method, *inputs, **kwargs)
+        )
+        result = getattr(prepared_ufunc, prepared_method)(
+            *prepared_inputs, **prepared_kwargs
+        )
+        return self.__unyt_ufunc_finalize__(result, ufunc, method, *inputs, **kwargs)
 
     @singledispatchmethod
     def __mul__(self, other) -> None:  # noqa: ANN001
@@ -2696,16 +2982,44 @@ class _AHelper(object):
             When something that we cannot multiply with is encountered.
         """
         # keep message generic, we might get here through __truediv__ also
-        raise NotImplementedError(
-            f"Cannot combine `a.{self._comoving_str}` with {other} of type {type(other)}"
+        return NotImplemented
+
+    @__mul__.register
+    def _(self, other: numeric_type | np.ndarray) -> cosmo_array:
+        return (cosmo_quantity if np.isscalar(other) else cosmo_array)(
+            other,
+            units=self.units,
+            comoving=self._comoving,
+            scale_factor=self.scale_factor,
+            scale_exponent=self.scale_exponent,
         )
+
+    @__mul__.register
+    def _(self, other: tuple | list) -> cosmo_array:
+        # leave the rest implicit, could pick up values from content of other:
+        ret = cosmo_array(other)
+        # now modify attributes:
+        if ret.comoving is not None:
+            ret.convert_to(ret.units, comoving=self._comoving)
+        else:
+            ret.comoving = self._comoving
+        ret.units = ret.units * self.units
+        if ret.cosmo_factor == cosmo_factor(None, None):
+            ret.cosmo_factor = cosmo_factor.create(
+                self.scale_factor, self.scale_exponent
+            )
+        else:
+            ret.cosmo_factor = ret.cosmo_factor * cosmo_factor.create(
+                self.scale_factor, self.scale_exponent
+            )
+        return ret
 
     @__mul__.register
     def _(self, other: unyt.Unit) -> Self:
         return _AHelper(
             scale_factor=self.scale_factor,
             scale_exponent=self.scale_exponent,
-            units=other.units if self.units is None else other.units * self.units,
+            units=other.units * self.units,
             comoving=self._comoving,
         )
 
@@ -2715,7 +3029,7 @@ class _AHelper(object):
             cosmo_quantity if isinstance(other, unyt.unyt_quantity) else cosmo_array
         )(
             other.ndview,
-            units=other.units * self.units if self.units is not None else other.units,
+            units=other.units * self.units,
             comoving=self._comoving,
             cosmo_factor=cosmo_factor.create(self.scale_factor, self.scale_exponent),
         )
@@ -2728,13 +3042,12 @@ class _AHelper(object):
             other.convert_to_physical()  # no-op if already physical
         return other.__class__(
             other.ndview,
-            units=other.units * self.units if self.units is not None else other.units,
+            units=other.units * self.units,
             comoving=self._comoving,
             cosmo_factor=other.cosmo_factor
             * cosmo_factor.create(self.scale_factor, self.scale_exponent),
         )
 
-    @singledispatchmethod
     def __rmul__(
         self, other: unyt.Unit | unyt.unyt_array | cosmo_array
     ) -> Self | cosmo_array:
@@ -2755,18 +3068,6 @@ class _AHelper(object):
             When something that we cannot multiply with is encountered.
         """
         return self.__mul__(other)
-
-    # @__rmul__.register
-    # def _(self, other: unyt.Unit) -> Self:
-    #     raise RuntimeError("HOORAY")
-
-    # @__rmul__.register
-    # def _(self, other: unyt.unyt_array) -> cosmo_array:
-    #     raise RuntimeError("HOORAY")
-
-    # @__rmul__.register
-    # def _(self, other: cosmo_array) -> cosmo_array:
-    #     raise RuntimeError("HOORAY")
 
     def __truediv__(
         self, other: unyt.Unit | unyt.unyt_array | cosmo_array
@@ -2795,7 +3096,7 @@ class _AHelper(object):
         return _AHelper(
             scale_factor=self.scale_factor,
             scale_exponent=self.scale_exponent * exponent,
-            units=None if self.units is None else self.units**exponent,
+            units=self.units**exponent,
             comoving=self._comoving,
         )
 

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -301,7 +301,7 @@ class cosmo_factor(object):
     ----------
     expr : sympy.Expr
         Expression used to convert between comoving and physical coordinates.
-    scale_factor : float
+    scale_factor : float or ~swiftsimio.objects._AHelper
         The scale factor (a).
 
     Attributes
@@ -335,10 +335,17 @@ class cosmo_factor(object):
         cosmo_factor(expr=a, scale_factor=0.5)
     """
 
-    def __init__(self, expr: sympy.Expr, scale_factor: float) -> None:
+    def __init__(self, expr: sympy.Expr, scale_factor: "float | _AHelper") -> None:
         self.expr = expr
-        self.scale_factor = scale_factor
-        pass
+        if getattr(scale_factor, "_comoving", None) is not None:
+            # We got an `_AHelper` that had its `comoving` or `physical` attribute
+            # accessed, this is not the backwards-compatible case that we want to support
+            # and leads to ambiguity: raise.
+            raise InvalidCosmoUnit("...")
+        # If we got an `_AHelper`, get its `_scale_factor` attribute, bypassing the
+        # checks that happen when accessing its `scale_factor` attribute: this is an
+        # intentional exception to the rule.
+        self.scale_factor = getattr(scale_factor, "_scale_factor", scale_factor)
 
     @classmethod
     def create(cls, scale_factor: float, exponent: numeric_type) -> "cosmo_factor":
@@ -2810,13 +2817,42 @@ class _AHelper(object):
         self,
         scale_factor: float,
         scale_exponent: int | float = 1,
-        units: unyt.Unit = unyt.dimensionless,
+        units: unyt.Unit = unyt.Unit("1"),  # auto-simplifies unlike unyt.dimensionless
         comoving: bool | None = None,
     ) -> None:
-        self.scale_factor = scale_factor
+        self._scale_factor = scale_factor
         self.scale_exponent = scale_exponent
         self.units = units
         self._comoving = comoving
+
+    @property
+    def scale_factor(self) -> float:
+        """
+        Get the scale factor.
+
+        The scale factor should always be accessed through this property. This ensures
+        that the :class:`~swiftsimio.objects._AHelper` cannot be used when its
+        ``_comoving`` attribute is ``None``, i.e. ``10 * metadata.a * u.kpc`` is invalid
+        but ``10 * metadata.a.physical * u.kpc`` is valid (the ``comoving`` and
+        ``physical`` properties return a copy with ``_comoving is not None``).
+
+        The exception is when creating new :class:`~swiftsimio.objects._AHelper` objects
+        from old ones, then ``_AHelper(scale_factor=self._scale_factor, ...)`` is
+        needed.
+
+        Returns
+        -------
+        float
+            The scale factor.
+
+        Raises
+        ------
+        InvalidCosmoUnit
+            If access is attempted when physical or comoving has not been specified.
+        """
+        if self._comoving is None:
+            raise InvalidCosmoUnit("...")
+        return self._scale_factor
 
     @property
     def _comoving_str(self) -> str:
@@ -2952,7 +2988,13 @@ class _AHelper(object):
                 scale_exponent=a_helper_input.scale_exponent,
             )
 
-    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs) -> cosmo_array:
+    def __array_ufunc__(
+        self,
+        ufunc: np.ufunc,
+        method: str,
+        *inputs: tuple[Any],
+        **kwargs: dict[str, Any],
+    ) -> cosmo_array:
         """
         Handle :mod:`numpy` ufunc calls on :class:`~swiftsimio.objects.cosmo_array` input.
 
@@ -3036,7 +3078,7 @@ class _AHelper(object):
     @__mul__.register
     def _(self, other: unyt.Unit) -> Self:
         return _AHelper(
-            scale_factor=self.scale_factor,
+            scale_factor=self._scale_factor,
             scale_exponent=self.scale_exponent,
             units=other.units * self.units,
             comoving=self._comoving,
@@ -3093,7 +3135,7 @@ class _AHelper(object):
     ) -> Self | cosmo_array:
         return (
             _AHelper(
-                scale_factor=self.scale_factor,
+                scale_factor=self._scale_factor,
                 scale_exponent=self.scale_exponent,
                 units=self.units,
                 comoving=self._comoving,
@@ -3105,7 +3147,7 @@ class _AHelper(object):
         self, other: unyt.Unit | unyt.unyt_array | cosmo_array
     ) -> Self | cosmo_array:
         return other * _AHelper(
-            scale_factor=self.scale_factor,
+            scale_factor=self._scale_factor,
             scale_exponent=-self.scale_exponent,
             units=self.units,
             comoving=self._comoving,
@@ -3113,7 +3155,7 @@ class _AHelper(object):
 
     def __pow__(self, exponent: int | float) -> Self:
         return _AHelper(
-            scale_factor=self.scale_factor,
+            scale_factor=self._scale_factor,
             scale_exponent=self.scale_exponent * exponent,
             units=self.units**exponent,
             comoving=self._comoving,
@@ -3122,7 +3164,7 @@ class _AHelper(object):
     @property
     def comoving(self) -> Self:
         return _AHelper(
-            scale_factor=self.scale_factor,
+            scale_factor=self._scale_factor,
             scale_exponent=self.scale_exponent,
             units=self.units,
             comoving=True,
@@ -3131,7 +3173,7 @@ class _AHelper(object):
     @property
     def physical(self) -> Self:
         return _AHelper(
-            scale_factor=self.scale_factor,
+            scale_factor=self._scale_factor,
             scale_exponent=self.scale_exponent,
             units=self.units,
             comoving=False,

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -3008,7 +3008,8 @@ class _AHelper:
         if self._comoving_state is None:
             raise InvalidCosmoUnit(
                 "Cannot use scale factor helper as `a` alone, use `a.comoving` or "
-                "`a.physical`."
+                "`a.physical`. For the scale factor as a number, use "
+                "`metadata.scale_factor` instead of `metadata.a`."
             )
         return self._scale_factor
 
@@ -3040,7 +3041,8 @@ class _AHelper:
         if self._comoving_state is None:
             raise InvalidCosmoUnit(
                 "Cannot use scale factor helper as `a` alone, use `a.comoving` or "
-                "`a.physical`."
+                "`a.physical`. For the scale factor as a number, use "
+                "`metadata.scale_factor` instead of `metadata.a`."
             )
         return self._comoving_state
 
@@ -3715,3 +3717,9 @@ class _AHelper:
             units=self.units,
             comoving=False,
         )
+
+    # provide aliases:
+    com = comoving
+    phys = physical
+    c = comoving
+    p = physical

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -2411,27 +2411,13 @@ class cosmo_array(unyt_array):
         if isinstance(result, tuple):
             for r in result:
                 if isinstance(r, cosmo_array):  # also recognizes cosmo_quantity
-                    r.comoving = (
-                        helper_result["comoving"] if r.comoving is None else r.comoving
-                    )
-                    r.cosmo_factor = (
-                        ret_cf
-                        if r.cosmo_factor == cosmo_factor(None, None)
-                        else ret_cf * r.cosmo_factor
-                    )
+                    r.comoving = helper_result["comoving"]
+                    r.cosmo_factor = ret_cf
                     r.valid_transform = helper_result["valid_transform"]
                     r.compression = helper_result["compression"]
         elif isinstance(result, cosmo_array):  # also recognizes cosmo_quantity
-            result.comoving = (
-                helper_result["comoving"]
-                if result.comoving is None
-                else result.comoving
-            )
-            result.cosmo_factor = (
-                ret_cf
-                if result.cosmo_factor == cosmo_factor(None, None)
-                else ret_cf * result.cosmo_factor
-            )
+            result.comoving = helper_result["comoving"]
+            result.cosmo_factor = ret_cf
             result.valid_transform = helper_result["valid_transform"]
             result.compression = helper_result["compression"]
         if "out" in kwargs:
@@ -2439,31 +2425,15 @@ class cosmo_array(unyt_array):
             if ufunc not in multiple_output_operators:
                 out = out[0]
                 if isinstance(out, cosmo_array):  # also recognizes cosmo_quantity
-                    out.comoving = (
-                        helper_result["comoving"]
-                        if result.comoving is None
-                        else result.comoving
-                    )
-                    out.cosmo_factor = (
-                        ret_cf
-                        if result.cosmo_factor == cosmo_factor(None, None)
-                        else ret_cf * result.cosmo_factor
-                    )
+                    out.comoving = helper_result["comoving"]
+                    out.cosmo_factor = ret_cf
                     out.valid_transform = helper_result["valid_transform"]
                     out.compression = helper_result["compression"]
             else:
                 for o, r in zip(out, result):
                     if isinstance(o, cosmo_array):  # also recognizes cosmo_quantity
-                        o.comoving = (
-                            helper_result["comoving"]
-                            if r.comoving is None
-                            else r.comoving
-                        )
-                        o.cosmo_factor = (
-                            ret_cf
-                            if r.cosmo_factor == cosmo_factor(None, None)
-                            else ret_cf * r.cosmo_factor
-                        )
+                        o.comoving = helper_result["comoving"]
+                        o.cosmo_factor = ret_cf
                         o.valid_transform = helper_result["valid_transform"]
                         o.compression = helper_result["compression"]
 
@@ -2535,18 +2505,19 @@ class cosmo_array(unyt_array):
         return function_to_invoke(*args, **kwargs)
 
     def __mul__(
-        self, b: int | float | np.ndarray | unyt.unit_object.Unit
+        self, b: "int | float | np.ndarray | unyt.unit_object.Unit | _AHelper"
     ) -> "cosmo_array":
         """
         Multiply this :class:`~swiftsimio.objects.cosmo_array`.
 
         We delegate most cases to :mod:`unyt`, but we need to handle the case where the
-        second argument is a :class:`~unyt.unit_object.Unit`.
+        second argument is a :class:`~unyt.unit_object.Unit` and the case where the
+        second argument is a :class:`~swiftsimio.objects._AHelper`.
 
         Parameters
         ----------
-        b : :class:`~numpy.ndarray`, :obj:`int`, :obj:`float` or \
-        :class:`~unyt.unit_object.Unit`
+        b : :class:`~numpy.ndarray`, :obj:`int`, :obj:`float`, \
+        :class:`~unyt.unit_object.Unit` or :class:`~swiftsimio.objects._AHelper`
             The object to multiply with this one.
 
         Returns
@@ -2563,6 +2534,8 @@ class cosmo_array(unyt_array):
                     else self.view(unyt_array)
                 ),
             )
+        elif isinstance(b, _AHelper):
+            return b.__mul__(self)
         else:
             return super().__mul__(b)
 

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -14,7 +14,6 @@ helpers, wrappers and implementations that enable most :mod:`numpy` and
 import unyt
 from unyt import unyt_array, unyt_quantity, Unit
 from unyt.array import multiple_output_operators, _iterable, POWER_MAPPING
-from numbers import Number as numeric_type
 from typing import Iterable, Callable, Any
 
 try:
@@ -84,8 +83,6 @@ from numpy import (
     minimum,
     fmax,
     fmin,
-    isreal,
-    iscomplex,
     isfinite,
     isinf,
     isnan,
@@ -107,11 +104,10 @@ from numpy import (
     matmul,
     vecdot,
 )
-from numpy._core.umath import _ones_like, clip
 from ._array_functions import (
     _propagate_cosmo_array_attributes_to_result,
     _ensure_result_is_cosmo_array_or_quantity,
-    _copy_cosmo_array_attributes_if_present,
+    _copy_cosmo_array_attributes,
     _sqrt_cosmo_factor,
     _multiply_cosmo_factor,
     _preserve_cosmo_factor,
@@ -140,6 +136,8 @@ except ImportError:
 
 # The scale factor!
 a = sympy.symbols("a")
+
+numeric_type = int | float | np.number | complex
 
 
 def _verify_valid_transform_validity(obj: "cosmo_array") -> None:
@@ -210,11 +208,11 @@ class InvalidScaleFactor(Exception):
     message : str, optional
         Message to print in case of invalid scale factor.
 
-    *args : tuple[Any]
+    *args : Any
         Arbitrary arguments.
     """
 
-    def __init__(self, message: str | None = None, *args: tuple[Any]) -> None:
+    def __init__(self, message: str | None = None, *args: Any) -> None:
         self.message = message
 
     def __str__(self) -> str:
@@ -240,11 +238,11 @@ class InvalidSnapshot(Exception):
     message : str, optional
         Message to print in case of invalid snapshot.
 
-    *args : tuple[Any]
+    *args : Any
         Arbitrary arguments.
     """
 
-    def __init__(self, message: str | None = None, *args: tuple[Any]) -> None:
+    def __init__(self, message: str | None = None, *args: Any) -> None:
         self.message = message
 
     def __str__(self) -> str:
@@ -270,11 +268,11 @@ class InvalidCosmoUnit(Exception):
     message : str, optional
         Message to print in case of incompatible input.
 
-    *args : tuple[Any]
+    *args : Any
         Arbitrary arguments.
     """
 
-    def __init__(self, message: str | None = None, *args: tuple[Any]) -> None:
+    def __init__(self, message: str | None = None, *args: Any) -> None:
         self.message = message
 
     def __str__(self) -> str:
@@ -289,7 +287,7 @@ class InvalidCosmoUnit(Exception):
         return f"{self.__class__}: {self.message}"
 
 
-class cosmo_factor(object):
+class cosmo_factor:
     r"""
     Cosmology factor class.
 
@@ -306,7 +304,7 @@ class cosmo_factor(object):
     ----------
     expr : sympy.Expr
         Expression used to convert between comoving and physical coordinates.
-    scale_factor : float or ~swiftsimio.objects._AHelper
+    scale_factor : int or float or ~swiftsimio.objects._AHelper
         The scale factor (a).
 
     Attributes
@@ -314,7 +312,7 @@ class cosmo_factor(object):
     expr : sympy.Expr
         Expression used to convert between comoving and physical coordinates.
 
-    scale_factor : float
+    scale_factor : int or float
         The scale factor (a).
 
     See Also
@@ -340,8 +338,36 @@ class cosmo_factor(object):
         cosmo_factor(expr=a, scale_factor=0.5)
     """
 
-    def __init__(self, expr: sympy.Expr, scale_factor: "float | _AHelper") -> None:
+    def __init__(
+        self, expr: sympy.Expr | None, scale_factor: numeric_type | None
+    ) -> None:
         self.expr = expr
+        self.scale_factor = scale_factor
+
+    @classmethod
+    def create(
+        cls,
+        scale_factor: "numeric_type | _AHelper | None",
+        exponent: numeric_type | None,
+    ) -> "cosmo_factor":
+        """
+        Create :class:`~swiftsimio.objects.cosmo_factor` from scale factor and exponent.
+
+        Parameters
+        ----------
+        scale_factor : int or float or ~swiftsimio.objects._AHelper
+            The scale factor.
+
+        exponent : int or float
+            The exponent defining the scaling with the scale factor.
+
+        Examples
+        --------
+        ::
+
+            >>> cosmo_factor.create(0.5, 2)
+            cosmo_factor(expr=a**2, scale_factor=0.5)
+        """
         try:
             getattr(scale_factor, "_comoving")
         except AttributeError:
@@ -356,28 +382,11 @@ class cosmo_factor(object):
         # If we got an `_AHelper`, get its `_scale_factor` attribute, bypassing the
         # checks that happen when accessing its `scale_factor` attribute: this is an
         # intentional exception to the rule.
-        self.scale_factor = getattr(scale_factor, "_scale_factor", scale_factor)
-
-    @classmethod
-    def create(cls, scale_factor: float, exponent: int | float) -> "cosmo_factor":
-        """
-        Create :class:`~swiftsimio.objects.cosmo_factor` from scale factor and exponent.
-
-        Parameters
-        ----------
-        scale_factor : :obj:`float`
-            The scale factor.
-
-        exponent : :obj:`int` or :obj:`float`
-            The exponent defining the scaling with the scale factor.
-
-        Examples
-        --------
-        ::
-
-            >>> cosmo_factor.create(0.5, 2)
-            cosmo_factor(expr=a**2, scale_factor=0.5)
-        """
+        scale_factor = (
+            scale_factor._scale_factor
+            if isinstance(scale_factor, _AHelper)
+            else scale_factor
+        )
         obj = cls(a**exponent, scale_factor)
 
         return obj
@@ -394,7 +403,7 @@ class cosmo_factor(object):
         return str(self.expr) + f" at a={self.scale_factor}"
 
     @property
-    def a_factor(self) -> float:
+    def a_factor(self) -> float | None:
         """
         The multiplicative factor for conversion from comoving to physical.
 
@@ -407,10 +416,11 @@ class cosmo_factor(object):
         """
         if (self.expr is None) or (self.scale_factor is None):
             return None
-        return float(self.expr.subs(a, self.scale_factor))
+        else:
+            return float(self.expr.subs(a, self.scale_factor))
 
     @property
-    def redshift(self) -> float:
+    def redshift(self) -> numeric_type | None:
         r"""
         The redshift computed from the scale factor.
 
@@ -424,7 +434,8 @@ class cosmo_factor(object):
         """
         if self.scale_factor is None:
             return None
-        return (1.0 / self.scale_factor) - 1.0
+        else:
+            return (1.0 / self.scale_factor) - 1.0
 
     def __add__(self, b: "cosmo_factor") -> "cosmo_factor":
         """
@@ -540,19 +551,16 @@ class cosmo_factor(object):
                 "Attempting to multiply two cosmo_factors with different scale factors "
                 f"{self.scale_factor} and {b.scale_factor}"
             )
-
-        if ((self.expr is None) and (b.expr is not None)) or (
-            (self.expr is not None) and (b.expr is None)
-        ):
+        if (self.expr is None) and (b.expr is None):
+            # let's be permissive and allow two uninitialized cosmo_factors through
+            return cosmo_factor(expr=None, scale_factor=self.scale_factor)
+        elif self.expr is None or b.expr is None:
             raise InvalidScaleFactor(
                 "Attempting to multiply an initialized cosmo_factor with an "
                 f"uninitialized cosmo_factor {self} and {b}."
             )
-        if (self.expr is None) and (b.expr is None):
-            # let's be permissive and allow two uninitialized cosmo_factors through
-            return cosmo_factor(expr=None, scale_factor=self.scale_factor)
-
-        return cosmo_factor(expr=self.expr * b.expr, scale_factor=self.scale_factor)
+        else:
+            return cosmo_factor(expr=self.expr * b.expr, scale_factor=self.scale_factor)
 
     def __truediv__(self, b: "cosmo_factor") -> "cosmo_factor":
         """
@@ -585,18 +593,16 @@ class cosmo_factor(object):
                 f"{self.scale_factor} and {b.scale_factor}"
             )
 
-        if ((self.expr is None) and (b.expr is not None)) or (
-            (self.expr is not None) and (b.expr is None)
-        ):
+        if (self.expr is None) and (b.expr is None):
+            # let's be permissive and allow two uninitialized cosmo_factors through
+            return cosmo_factor(expr=None, scale_factor=self.scale_factor)
+        elif self.expr is None or b.expr is None:
             raise InvalidScaleFactor(
                 "Attempting to divide an initialized cosmo_factor with an "
                 f"uninitialized cosmo_factor {self} and {b}."
             )
-        if (self.expr is None) and (b.expr is None):
-            # let's be permissive and allow two uninitialized cosmo_factors through
-            return cosmo_factor(expr=None, scale_factor=self.scale_factor)
-
-        return cosmo_factor(expr=self.expr / b.expr, scale_factor=self.scale_factor)
+        else:
+            return cosmo_factor(expr=self.expr / b.expr, scale_factor=self.scale_factor)
 
     def __radd__(self, b: "cosmo_factor") -> "cosmo_factor":
         """
@@ -741,7 +747,11 @@ class cosmo_factor(object):
             If the object to compare is not a :class:`~swiftsimio.objects.cosmo_factor`.
         """
         if not isinstance(b, cosmo_factor):
-            raise ValueError("Can only compare cosmo_factor with another cosmo_factor.")
+            return NotImplemented
+        if self.a_factor is None or b.a_factor is None:
+            raise ValueError(
+                "Cannot compare cosmo_factors when one has unset a_factor."
+            )
         return self.a_factor < b.a_factor
 
     def __gt__(self, b: "cosmo_factor") -> bool:
@@ -767,7 +777,11 @@ class cosmo_factor(object):
             If the object to compare is not a :class:`~swiftsimio.objects.cosmo_factor`.
         """
         if not isinstance(b, cosmo_factor):
-            raise ValueError("Can only compare cosmo_factor with another cosmo_factor.")
+            return NotImplemented
+        if self.a_factor is None or b.a_factor is None:
+            raise ValueError(
+                "Cannot compare cosmo_factors when one has unset a_factor."
+            )
         return self.a_factor > b.a_factor
 
     def __le__(self, b: "cosmo_factor") -> bool:
@@ -793,7 +807,11 @@ class cosmo_factor(object):
             If the object to compare is not a :class:`~swiftsimio.objects.cosmo_factor`.
         """
         if not isinstance(b, cosmo_factor):
-            raise ValueError("Can only compare cosmo_factor with another cosmo_factor.")
+            return NotImplemented
+        if self.a_factor is None or b.a_factor is None:
+            raise ValueError(
+                "Cannot compare cosmo_factors when one has unset a_factor."
+            )
         return self.a_factor <= b.a_factor
 
     def __ge__(self, b: "cosmo_factor") -> bool:
@@ -819,10 +837,14 @@ class cosmo_factor(object):
             If the object to compare is not a :class:`~swiftsimio.objects.cosmo_factor`.
         """
         if not isinstance(b, cosmo_factor):
-            raise ValueError("Can only compare cosmo_factor with another cosmo_factor.")
+            return NotImplemented
+        if self.a_factor is None or b.a_factor is None:
+            raise ValueError(
+                "Cannot compare cosmo_factors when one has unset a_factor."
+            )
         return self.a_factor >= b.a_factor
 
-    def __eq__(self, b: "cosmo_factor") -> bool:
+    def __eq__(self, b: object) -> bool:
         """
         Compare the expressions and values of two scale factor expressions for equality.
 
@@ -849,7 +871,7 @@ class cosmo_factor(object):
             If the object to compare is not a :class:`~swiftsimio.objects.cosmo_factor`.
         """
         if not isinstance(b, cosmo_factor):
-            raise ValueError("Can only compare cosmo_factor with another cosmo_factor.")
+            return NotImplemented
         scale_factor_match = self.scale_factor == b.scale_factor
         if self.a_factor is None and b.a_factor is None:
             # guards passing None to isclose
@@ -863,7 +885,7 @@ class cosmo_factor(object):
             a_factor_match = False
         return scale_factor_match and a_factor_match
 
-    def __ne__(self, b: "cosmo_factor") -> bool:
+    def __ne__(self, b: object) -> bool:
         """
         Compare the expressions and values of two scale factor expressions for inequality.
 
@@ -903,14 +925,11 @@ class cosmo_factor(object):
         return f"cosmo_factor(expr={self.expr}, scale_factor={self.scale_factor})"
 
 
-NULL_CF = cosmo_factor(None, None)  # helps avoid name collisions with kwargs below
-
-
 def _parse_cosmo_factor_args(
-    cf: cosmo_factor = None,
-    scale_factor: float = None,
-    scale_exponent: numeric_type = None,
-) -> cosmo_factor:
+    cf: cosmo_factor | None = None,
+    scale_factor: numeric_type | None = None,
+    scale_exponent: numeric_type | None = None,
+) -> cosmo_factor | None:
     """
     Decide what provided cosmology information to use, or raise an error.
 
@@ -926,7 +945,7 @@ def _parse_cosmo_factor_args(
     cf : swiftsimio.objects.cosmo_factor
         The :class:`~swiftsimio.objects.cosmo_factor` passed as an explicit argument.
 
-    scale_factor : numeric_type
+    scale_factor : int or float
         The scale factor passed as a kwarg.
 
     scale_exponent : float
@@ -970,6 +989,9 @@ def _parse_cosmo_factor_args(
             return NULL_CF
         else:
             return cosmo_factor.create(scale_factor, scale_exponent)
+
+
+NULL_CF = cosmo_factor(None, None)  # helps avoid name collisions with kwargs below
 
 
 class cosmo_array(unyt_array):
@@ -1046,7 +1068,7 @@ class cosmo_array(unyt_array):
                valid_transform='True')
     """
 
-    _cosmo_factor_ufunc_registry = {
+    _cosmo_factor_ufunc_registry: dict[np.ufunc, Callable] = {
         add: _preserve_cosmo_factor,
         subtract: _preserve_cosmo_factor,
         multiply: _multiply_cosmo_factor,
@@ -1112,8 +1134,6 @@ class cosmo_array(unyt_array):
         minimum: _passthrough_cosmo_factor,
         fmax: _preserve_cosmo_factor,
         fmin: _preserve_cosmo_factor,
-        isreal: _return_without_cosmo_factor,
-        iscomplex: _return_without_cosmo_factor,
         isfinite: _return_without_cosmo_factor,
         isinf: _return_without_cosmo_factor,
         isnan: _return_without_cosmo_factor,
@@ -1131,9 +1151,7 @@ class cosmo_array(unyt_array):
         divmod_: _passthrough_cosmo_factor,
         isnat: _return_without_cosmo_factor,
         heaviside: _preserve_cosmo_factor,
-        _ones_like: _preserve_cosmo_factor,
         matmul: _multiply_cosmo_factor,
-        clip: _passthrough_cosmo_factor,
         vecdot: _multiply_cosmo_factor,
     }
 
@@ -1142,14 +1160,14 @@ class cosmo_array(unyt_array):
         input_array: Iterable,
         units: "str | unyt.unit_object.Unit | astropy.units.core.Unit | None" = None,
         *,
-        registry: unyt.unit_registry.UnitRegistry = None,
+        registry: unyt.unit_registry.UnitRegistry | None = None,
         dtype: np.dtype | str | None = None,
         bypass_validation: bool = False,
-        name: str = None,
-        cosmo_factor: cosmo_factor = None,
-        scale_factor: float | None = None,
-        scale_exponent: float | None = None,
-        comoving: bool = None,
+        name: str | None = None,
+        cosmo_factor: cosmo_factor | None = None,
+        scale_factor: numeric_type | None = None,
+        scale_exponent: numeric_type | None = None,
+        comoving: bool | None = None,
         valid_transform: bool = True,
         compression: str | None = None,
     ) -> "cosmo_array":
@@ -1190,7 +1208,7 @@ class cosmo_array(unyt_array):
         cosmo_factor : swiftsimio.objects.cosmo_factor
             Object to store conversion data between comoving and physical coordinates.
 
-        scale_factor : float
+        scale_factor : int or float
             The scale factor associated to the data. Also provide a value for
             ``scale_exponent``.
 
@@ -1224,7 +1242,9 @@ class cosmo_array(unyt_array):
             obj.comoving = comoving
             obj.cosmo_factor = cosmo_factor if cosmo_factor is not None else NULL_CF
             if scale_factor is not None:  # ambiguity, but this is `bypass_validation`
-                obj.cosmo_factor = cosmo_factor.create(scale_factor, scale_exponent)
+                obj.cosmo_factor = NULL_CF.__class__.create(
+                    scale_factor, scale_exponent
+                )
             obj.valid_transform = valid_transform
             obj.compression = compression
 
@@ -1480,7 +1500,7 @@ class cosmo_array(unyt_array):
         *,
         comoving: bool | None = None,
         equivalence: str | None = None,
-        **kwargs: dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         """
         Convert the internal data in-place to desired units and comoving status.
@@ -1501,7 +1521,7 @@ class cosmo_array(unyt_array):
             The equivalence to use. To see which equivalences are supported for this
             quantity, try the :meth:`~unyt.array.unyt_array.list_equivalencies` method.
 
-        **kwargs : dict
+        **kwargs : Any
             Any additional keyword arguments are supplied to the equivalence.
 
         Returns
@@ -1536,7 +1556,7 @@ class cosmo_array(unyt_array):
         units: unyt.Unit | str | None = None,
         *,
         equivalence: str | None = None,
-        **kwargs: dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         """
         Convert the internal data in-place to be in comoving units.
@@ -1553,7 +1573,7 @@ class cosmo_array(unyt_array):
             The equivalence to use. To see which equivalences are supported for this
             quantity, try the :meth:`~unyt.array.unyt_array.list_equivalencies` method.
 
-        **kwargs : dict
+        **kwargs : Any
             Any additional keyword arguments are supplied to the equivalence.
 
         Returns
@@ -1595,7 +1615,7 @@ class cosmo_array(unyt_array):
         units: unyt.Unit | str | None = None,
         *,
         equivalence: str | None = None,
-        **kwargs: dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         """
         Convert the internal data in-place to be in physical units.
@@ -1612,7 +1632,7 @@ class cosmo_array(unyt_array):
             The equivalence to use. To see which equivalences are supported for this
             quantity, try the :meth:`~unyt.array.unyt_array.list_equivalencies` method.
 
-        **kwargs : dict
+        **kwargs : Any
             Any additional keyword arguments are supplied to the equivalence.
 
         Returns
@@ -1655,7 +1675,7 @@ class cosmo_array(unyt_array):
         units: unyt.Unit | str | None = None,
         *,
         equivalence: str | None = None,
-        **kwargs: dict[str, Any],
+        **kwargs: Any,
     ) -> "cosmo_array":
         """
         Create a copy of the data in physical units.
@@ -1669,7 +1689,7 @@ class cosmo_array(unyt_array):
             The equivalence to use. To see which equivalences are supported for this
             quantity, try the :meth:`~unyt.array.unyt_array.list_equivalencies` method.
 
-        **kwargs : dict
+        **kwargs : Any
             Any additional keyword arguments are supplied to the equivalence.
 
         Returns
@@ -1708,7 +1728,7 @@ class cosmo_array(unyt_array):
         units: unyt.Unit | str | None = None,
         *,
         equivalence: str | None = None,
-        **kwargs: dict[str, Any],
+        **kwargs: Any,
     ) -> "cosmo_array":
         """
         Create a copy of the data in comoving units.
@@ -1722,7 +1742,7 @@ class cosmo_array(unyt_array):
             The equivalence to use. To see which equivalences are supported for this
             quantity, try the :meth:`~unyt.array.unyt_array.list_equivalencies` method.
 
-        **kwargs : dict
+        **kwargs : Any
             Any additional keyword arguments are supplied to the equivalence.
 
         Returns
@@ -1762,7 +1782,7 @@ class cosmo_array(unyt_array):
         *,
         equivalence: str | None = None,
         comoving: bool | None = None,
-        **kwargs: dict[str, Any],
+        **kwargs: Any,
     ) -> "cosmo_array":
         """
         Create a copy of the data in specified comoving or physical units.
@@ -1788,7 +1808,7 @@ class cosmo_array(unyt_array):
             If ``True``, the result is comoving, if ``False`` it is physical. By default
             the ``comoving`` status of the array is preserved.
 
-        **kwargs : dict
+        **kwargs : Any
             Any additional keyword arguments are supplied to the equivalence.
 
         Returns
@@ -1838,7 +1858,7 @@ class cosmo_array(unyt_array):
         if units is None:
             arr_copy = self.copy()
         else:
-            arr_copy = _copy_cosmo_array_attributes_if_present(
+            arr_copy = _copy_cosmo_array_attributes(
                 self,
                 _ensure_result_is_cosmo_array_or_quantity(super().to)(
                     units, equivalence=equivalence, **kwargs
@@ -1860,7 +1880,7 @@ class cosmo_array(unyt_array):
         *,
         equivalence: str | None = None,
         comoving: bool | None = None,
-        **kwargs: dict[str, Any],
+        **kwargs: Any,
     ) -> np.ndarray:
         """
         Create a copy of the data in specified comoving or physical units.
@@ -1888,7 +1908,7 @@ class cosmo_array(unyt_array):
             If ``True``, the result is comoving, if ``False`` it is physical. By default
             the ``comoving`` status of the array is preserved.
 
-        **kwargs : dict
+        **kwargs : Any
             Any additional keyword arguments are supplied to the equivalence.
 
         Returns
@@ -1936,7 +1956,7 @@ class cosmo_array(unyt_array):
         self,
         units: Unit | str,
         equivalence: str | None = None,
-        **kwargs: dict[str, Any],
+        **kwargs: Any,
     ) -> np.ndarray:
         """
         Return a copy of the array values in the specified physical units.
@@ -1958,7 +1978,7 @@ class cosmo_array(unyt_array):
             The equivalence to use. To see which equivalences are supported for this
             quantity, try the :meth:`~unyt.array.unyt_array.list_equivalencies` method.
 
-        **kwargs : dict
+        **kwargs : Any
             Any additional keyword arguments are supplied to the equivalence.
 
         Returns
@@ -1989,7 +2009,7 @@ class cosmo_array(unyt_array):
         self,
         units: Unit | str,
         equivalence: str | None = None,
-        **kwargs: dict[str, Any],
+        **kwargs: Any,
     ) -> np.ndarray:
         """
         Return a copy of the array values in the specified comoving units.
@@ -2011,7 +2031,7 @@ class cosmo_array(unyt_array):
             The equivalence to use. To see which equivalences are supported for this
             quantity, try the :meth:`~unyt.array.unyt_array.list_equivalencies` method.
 
-        **kwargs : dict
+        **kwargs : Any
             Any additional keyword arguments are supplied to the equivalence.
 
         Returns
@@ -2073,9 +2093,9 @@ class cosmo_array(unyt_array):
         cls,
         arr: "astropy.units.quantity.Quantity",
         unit_registry: unyt.unit_registry.UnitRegistry = None,
-        comoving: bool = None,
-        cosmo_factor: cosmo_factor = cosmo_factor(None, None),
-        compression: str = None,
+        comoving: bool | None = None,
+        cosmo_factor: cosmo_factor = NULL_CF,
+        compression: str | None = None,
         valid_transform: bool = True,
     ) -> "cosmo_array":
         """
@@ -2133,9 +2153,9 @@ class cosmo_array(unyt_array):
         cls,
         arr: "pint.registry.Quantity",
         unit_registry: unyt.unit_registry.UnitRegistry = None,
-        comoving: bool = None,
-        cosmo_factor: cosmo_factor = cosmo_factor(None, None),
-        compression: str = None,
+        comoving: bool | None = None,
+        cosmo_factor: cosmo_factor = NULL_CF,
+        compression: str | None = None,
         valid_transform: bool = True,
     ) -> "cosmo_array":
         """
@@ -2192,7 +2212,7 @@ class cosmo_array(unyt_array):
 
     @classmethod
     def __unyt_ufunc_prepare__(
-        cls, ufunc: np.ufunc, method: str, *inputs: tuple, **kwargs: dict[str, Any]
+        cls, ufunc: np.ufunc, method: str, *inputs: Any, **kwargs: Any
     ) -> tuple[np.ufunc, str, tuple, dict]:
         """
         Prepare arguments for a ufunc call.
@@ -2210,10 +2230,10 @@ class cosmo_array(unyt_array):
         method : str
             The call method for the ufunc (for example ``"call"`` or ``"reduce"``).
 
-        *inputs : tuple
+        *inputs : Any
             The ufunc arguments.
 
-        **kwargs : dict
+        **kwargs : Any
             The ufunc kwargs.
 
         Returns
@@ -2239,8 +2259,8 @@ class cosmo_array(unyt_array):
         result: tuple | unyt_array,
         ufunc: np.ufunc,
         method: str,
-        *inputs: tuple,
-        **kwargs: dict[str, Any],
+        *inputs: Any,
+        **kwargs: Any,
     ) -> "tuple | cosmo_array":
         """
         Finalize results after a ufunc call.
@@ -2261,10 +2281,10 @@ class cosmo_array(unyt_array):
         method : str
             The call method for the ufunc (for example ``"call"`` or ``"reduce"``).
 
-        *inputs : tuple
+        *inputs : Any
             The ufunc arguments.
 
-        **kwargs : dict
+        **kwargs : Any
             The ufunc kwargs.
 
         Returns
@@ -2277,6 +2297,7 @@ class cosmo_array(unyt_array):
         # here?
         helper_result = _prepare_array_func_args(*inputs, **kwargs)
         cfs = helper_result["cfs"]
+        ret_cf: cosmo_factor | None
         # make sure we evaluate the cosmo_factor_ufunc_registry function:
         # might raise/warn even if we're not returning a cosmo_array
         if ufunc in (multiply, divide) and method == "reduce":
@@ -2328,20 +2349,20 @@ class cosmo_array(unyt_array):
             result.valid_transform = helper_result["valid_transform"]
             result.compression = helper_result["compression"]
         if "out" in kwargs:
-            out = kwargs.pop("out")
+            out: tuple | unyt_array = kwargs.pop("out")
             if ufunc not in multiple_output_operators:
-                out = out[0]
-                if isinstance(out, unyt_array) and not isinstance(out, cosmo_array):
-                    out = (
-                        out.view(cosmo_quantity)
-                        if out.shape == ()
-                        else out.view(cosmo_array)
+                aout = out[0]
+                if isinstance(aout, unyt_array) and not isinstance(aout, cosmo_array):
+                    aout = (
+                        aout.view(cosmo_quantity)
+                        if aout.shape == ()
+                        else aout.view(cosmo_array)
                     )
-                if isinstance(out, cosmo_array):  # also recognizes cosmo_quantity
-                    out.comoving = helper_result["comoving"]
-                    out.cosmo_factor = ret_cf
-                    out.valid_transform = helper_result["valid_transform"]
-                    out.compression = helper_result["compression"]
+                if isinstance(aout, cosmo_array):  # also recognizes cosmo_quantity
+                    aout.comoving = helper_result["comoving"]
+                    aout.cosmo_factor = ret_cf
+                    aout.valid_transform = helper_result["valid_transform"]
+                    aout.compression = helper_result["compression"]
             else:
                 out = tuple(
                     (
@@ -2367,8 +2388,8 @@ class cosmo_array(unyt_array):
         self,
         ufunc: np.ufunc,
         method: str,
-        *inputs: tuple[Any],
-        **kwargs: dict[str, Any],
+        *inputs: Any,
+        **kwargs: Any,
     ) -> object:
         """
         Handle :mod:`numpy` ufunc calls on :class:`~swiftsimio.objects.cosmo_array` input.
@@ -2388,10 +2409,10 @@ class cosmo_array(unyt_array):
             Some ufuncs have methods accessed as attributes, such as ``"reduce"``.
             If using such a method, this argument receives its name.
 
-        *inputs : tuple
+        *inputs : Any
             Arguments to the ufunc.
 
-        **kwargs : dict
+        **kwargs : Any
             Keyword arguments to the ufunc.
 
         Returns
@@ -2418,7 +2439,8 @@ class cosmo_array(unyt_array):
             ufunc in (logical_and, logical_or, logical_xor, logical_not)
             and method == "reduce"
         ):
-            ret_cf = _return_without_cosmo_factor(cfs[0])
+            _return_without_cosmo_factor(cfs[0])  # check validity
+            ret_cf = None
         else:
             ret_cf = self._cosmo_factor_ufunc_registry[ufunc](*cfs, inputs=inputs)
 
@@ -2439,7 +2461,7 @@ class cosmo_array(unyt_array):
             result.valid_transform = helper_result["valid_transform"]
             result.compression = helper_result["compression"]
         if "out" in kwargs:
-            out = kwargs.pop("out")
+            out: tuple | unyt_array = kwargs.pop("out")
             if ufunc not in multiple_output_operators:
                 out = out[0]
                 if isinstance(out, cosmo_array):  # also recognizes cosmo_quantity
@@ -2458,7 +2480,11 @@ class cosmo_array(unyt_array):
         return result
 
     def __array_function__(
-        self, func: Callable, types: Collection, args: tuple, kwargs: dict
+        self,
+        func: Callable,
+        types: Collection,
+        args: tuple[Any],
+        kwargs: dict[str, Any],
     ) -> object:
         """
         Handle :mod:`numpy` functions for :class:`~swiftsimio.objects.cosmo_array` input.
@@ -2519,13 +2545,16 @@ class cosmo_array(unyt_array):
             function_to_invoke = _UNYT_HANDLED_FUNCTIONS[func]
         else:
             # default to numpy's private implementation
-            function_to_invoke = func._implementation
+            if hasattr(func, "_implementation"):
+                function_to_invoke = getattr(func, "_implementation")
+            else:
+                raise ValueError(f"Unsupported function {func}, please report this.")
         return function_to_invoke(*args, **kwargs)
 
     def __mul__(
         self,
-        b: "int | float | np.ndarray | unyt.unit_object.Unit | cosmo_array | _AHelper",
-    ) -> "cosmo_array":
+        b: "numeric_type | np.ndarray | unyt.unit_object.Unit | cosmo_array | _AHelper",
+    ) -> "cosmo_array | _AHelper":
         """
         Multiply this :class:`~swiftsimio.objects.cosmo_array`.
 
@@ -2546,7 +2575,7 @@ class cosmo_array(unyt_array):
             The result of the multiplication.
         """
         if getattr(b, "is_Unit", False):
-            return _copy_cosmo_array_attributes_if_present(
+            return _copy_cosmo_array_attributes(
                 self,
                 _ensure_result_is_cosmo_array_or_quantity(b.__mul__)(
                     self.view(unyt_quantity)
@@ -2561,8 +2590,8 @@ class cosmo_array(unyt_array):
 
     def __rmul__(
         self,
-        b: "int | float | np.ndarray | unyt.unit_object.Unit | cosmo_array | _AHelper",
-    ) -> "cosmo_array":
+        b: "numeric_type | np.ndarray | unyt.unit_object.Unit | cosmo_array | _AHelper",
+    ) -> "cosmo_array | _AHelper":
         """
         Multiply this :class:`~swiftsimio.objects.cosmo_array` (as the right argument).
 
@@ -2588,8 +2617,8 @@ class cosmo_array(unyt_array):
 
     def __imul__(
         self,
-        b: "int | float | np.ndarray | unyt.unit_object.Unit | cosmo_array | _AHelper",
-    ) -> "cosmo_array":
+        b: "numeric_type | np.ndarray | unyt.unit_object.Unit | cosmo_array | _AHelper",
+    ) -> "cosmo_array | _AHelper":
         """
         Multiply this :class:`~swiftsimio.objects.cosmo_array` (in-place).
 
@@ -2609,8 +2638,8 @@ class cosmo_array(unyt_array):
 
     def __truediv__(
         self,
-        b: "int | float | np.ndarray | unyt.unit_object.Unit | cosmo_array | _AHelper",
-    ) -> "cosmo_array":
+        b: "numeric_type | np.ndarray | unyt.unit_object.Unit | cosmo_array | _AHelper",
+    ) -> "cosmo_array | _AHelper":
         """
         Divide this :class:`~swiftsimio.objects.cosmo_array`.
 
@@ -2631,7 +2660,7 @@ class cosmo_array(unyt_array):
             The result of the division.
         """
         if getattr(b, "is_Unit", False):
-            return _copy_cosmo_array_attributes_if_present(
+            return _copy_cosmo_array_attributes(
                 self,
                 _ensure_result_is_cosmo_array_or_quantity((1 / b).__mul__)(
                     self.view(unyt_quantity)
@@ -2646,8 +2675,8 @@ class cosmo_array(unyt_array):
 
     def __rtruediv__(
         self,
-        b: "int | float | np.ndarray | unyt.unit_object.Unit | cosmo_array | _AHelper",
-    ) -> "cosmo_array":
+        b: "numeric_type | np.ndarray | unyt.unit_object.Unit | cosmo_array | _AHelper",
+    ) -> "cosmo_array | _AHelper":
         """
         Divide by this :class:`~swiftsimio.objects.cosmo_array` (as the right argument).
 
@@ -2667,14 +2696,14 @@ class cosmo_array(unyt_array):
             The result of the division.
         """
         if getattr(b, "is_Unit", False):
-            return (1 / self).__mul__(b)
+            return (self.__rtruediv__(1)).__mul__(b)
         else:
             return super().__rtruediv__(b)
 
     def __itruediv__(
         self,
-        b: "int | float | np.ndarray | unyt.unit_object.Unit | cosmo_array | _AHelper",
-    ) -> "cosmo_array":
+        b: "numeric_type | np.ndarray | unyt.unit_object.Unit | cosmo_array | _AHelper",
+    ) -> "cosmo_array | _AHelper":
         """
         Divide this :class:`~swiftsimio.objects.cosmo_array` (in-place).
 
@@ -2728,7 +2757,7 @@ class cosmo_quantity(cosmo_array, unyt_quantity):
 
     def __new__(
         cls,
-        input_scalar: numeric_type,
+        input_scalar: numeric_type | unyt.unyt_quantity,
         units: "str | unyt.unit_object.Unit | astropy.units.core.Unit | None" = None,
         # *,
         registry: unyt.unit_registry.UnitRegistry | None = None,
@@ -2736,8 +2765,8 @@ class cosmo_quantity(cosmo_array, unyt_quantity):
         bypass_validation: bool = False,
         name: str | None = None,
         cosmo_factor: cosmo_factor | None = None,
-        scale_factor: float | None = None,
-        scale_exponent: float | None = None,
+        scale_factor: numeric_type | None = None,
+        scale_exponent: numeric_type | None = None,
         comoving: bool | None = None,
         valid_transform: bool = True,
         compression: str | None = None,
@@ -2747,7 +2776,7 @@ class cosmo_quantity(cosmo_array, unyt_quantity):
 
         Parameters
         ----------
-        input_scalar : float or unyt.array.unyt_quantity
+        input_scalar : int or float or unyt.array.unyt_quantity
             A tuple, list, or array to attach units and cosmology information to.
 
         units : str, unyt.unit_object.Unit or astropy.units.core.Unit, optional
@@ -2818,7 +2847,7 @@ class cosmo_quantity(cosmo_array, unyt_quantity):
                 compression=compression,
             )
 
-        if not isinstance(input_scalar, (numeric_type, np.number, np.ndarray)):
+        if not isinstance(input_scalar, (numeric_type, np.ndarray)):
             raise RuntimeError("cosmo_quantity values must be numeric")
 
         # Use values from kwargs, if None use values from input_scalar
@@ -2866,7 +2895,7 @@ class cosmo_quantity(cosmo_array, unyt_quantity):
     )
 
 
-class _AHelper(object):
+class _AHelper:
     """
     Offer an easy way to initialize cosmo scalars and arrays.
 
@@ -2929,25 +2958,25 @@ class _AHelper(object):
         Whether to create comoving or physical objects.
     """
 
-    _scale_factor: float
-    scale_exponent: int | float
+    _scale_factor: numeric_type
+    scale_exponent: numeric_type
     units: unyt.Unit
-    __comoving: bool | None
+    _comoving_state: bool | None
 
     def __init__(
         self,
-        scale_factor: float,
-        scale_exponent: int | float = 1,
+        scale_factor: numeric_type,
+        scale_exponent: numeric_type = 1,
         units: unyt.Unit = unyt.Unit("1"),  # auto-simplifies unlike unyt.dimensionless
         comoving: bool | None = None,
     ) -> None:
         self._scale_factor = scale_factor
         self.scale_exponent = scale_exponent
         self.units = units
-        self.__comoving = comoving
+        self._comoving_state = comoving
 
     @property
-    def scale_factor(self) -> float:
+    def scale_factor(self) -> numeric_type:
         """
         Get the scale factor.
 
@@ -2971,7 +3000,7 @@ class _AHelper(object):
         InvalidCosmoUnit
             If access is attempted when physical or comoving has not been specified.
         """
-        if self.__comoving is None:
+        if self._comoving_state is None:
             raise InvalidCosmoUnit("...")
         return self._scale_factor
 
@@ -2987,7 +3016,7 @@ class _AHelper(object):
         ``physical`` properties return a copy with ``_comoving is not None``).
 
         The exception is when creating new :class:`~swiftsimio.objects._AHelper` objects
-        from old ones, then ``_AHelper(comoving=self.__comoving, ...)`` is
+        from old ones, then ``_AHelper(comoving=self._comoving_state, ...)`` is
         needed.
 
         Returns
@@ -3000,9 +3029,9 @@ class _AHelper(object):
         InvalidCosmoUnit
             If access is attempted when physical or comoving has not been specified.
         """
-        if self.__comoving is None:
+        if self._comoving_state is None:
             raise InvalidCosmoUnit("...")
-        return self.__comoving
+        return self._comoving_state
 
     @property
     def _comoving_str(self) -> str:
@@ -3023,7 +3052,7 @@ class _AHelper(object):
 
     @classmethod
     def __unyt_ufunc_prepare__(
-        cls, ufunc: np.ufunc, method: str, *inputs: tuple, **kwargs: dict[str, Any]
+        cls, ufunc: np.ufunc, method: str, *inputs: Any, **kwargs: Any
     ) -> tuple[np.ufunc, str, tuple, dict]:
         """
         Prepare arguments for a ufunc call.
@@ -3040,10 +3069,10 @@ class _AHelper(object):
         method : str
             The call method for the ufunc (for example ``"call"`` or ``"reduce"``).
 
-        *inputs : tuple
+        *inputs : Any
             The ufunc arguments.
 
-        **kwargs : dict
+        **kwargs : Any
             The ufunc kwargs.
 
         Returns
@@ -3076,11 +3105,11 @@ class _AHelper(object):
     @classmethod
     def __unyt_ufunc_finalize__(
         cls,
-        result: tuple | unyt_array,
+        result: unyt_array,
         ufunc: np.ufunc,
         method: str,
-        *inputs: tuple,
-        **kwargs: dict[str, Any],
+        *inputs: Any,
+        **kwargs: Any,
     ) -> cosmo_array:
         """
         Finalize results after a ufunc call.
@@ -3090,9 +3119,12 @@ class _AHelper(object):
         :class:`~swiftsimio.objects.cosmo_array` or
         :class:`~swiftsimio.objects.cosmo_quantity` and set its attributes.
 
+        We only support ``multiply`` and ``divide`` ufuncs so result is a
+        :class:`~unyt.array.unyt_array` (never a ``tuple``).
+
         Parameters
         ----------
-        result : ~unyt.array.unyt_array or tuple
+        result : ~unyt.array.unyt_array
             The return value of the called ufunc.
 
         ufunc : ~numpy.ufunc
@@ -3101,10 +3133,10 @@ class _AHelper(object):
         method : str
             The call method for the ufunc (for example ``"call"`` or ``"reduce"``).
 
-        *inputs : tuple
+        *inputs : Any
             The ufunc arguments.
 
-        **kwargs : dict
+        **kwargs : Any
             The ufunc kwargs.
 
         Returns
@@ -3117,36 +3149,20 @@ class _AHelper(object):
             if isinstance(inp, _AHelper):
                 a_helper_input: _AHelper = inp
 
-        if isinstance(result, cosmo_array):  # -- UNUSED, REMOVE?
-            if result.comoving is None:
-                result.comoving = a_helper_input._comoving
-            else:
-                result.convert_to(result.units, comoving=a_helper_input._comoving)
-            result.units = result.units * a_helper_input.units
-            if result.cosmo_factor == NULL_CF:
-                result.cosmo_factor = cosmo_factor.create(
-                    a_helper_input.scale_factor, a_helper_input.scale_exponent
-                )
-            else:
-                result.cosmo_factor = result.cosmo_factor * cosmo_factor.create(
-                    a_helper_input.scale_factor, a_helper_input.scale_exponent
-                )  # --
-            return result
-        else:
-            return (cosmo_array if np.asarray(result).ndim else cosmo_quantity)(
-                result,
-                comoving=a_helper_input._comoving,
-                scale_factor=a_helper_input.scale_factor,
-                scale_exponent=(-1 if ufunc is np.divide else 1)
-                * a_helper_input.scale_exponent,
-            )
+        return (cosmo_array if np.asarray(result).ndim else cosmo_quantity)(
+            result,
+            comoving=a_helper_input._comoving,
+            scale_factor=a_helper_input.scale_factor,
+            scale_exponent=(-1 if ufunc is np.divide else 1)
+            * a_helper_input.scale_exponent,
+        )
 
     def __array_ufunc__(
         self,
         ufunc: np.ufunc,
         method: str,
-        *inputs: tuple[Any],
-        **kwargs: dict[str, Any],
+        *inputs: Any,
+        **kwargs: Any,
     ) -> cosmo_array:
         """
         Handle :mod:`numpy` ufunc calls on :class:`~swiftsimio.objects.cosmo_array` input.
@@ -3166,10 +3182,10 @@ class _AHelper(object):
             Some ufuncs have methods accessed as attributes, such as ``"reduce"``.
             If using such a method, this argument receives its name.
 
-        *inputs : tuple
+        *inputs : Any
             Arguments to the ufunc.
 
-        **kwargs : dict
+        **kwargs : Any
             Keyword arguments to the ufunc.
 
         Returns
@@ -3186,7 +3202,7 @@ class _AHelper(object):
         return self.__unyt_ufunc_finalize__(result, ufunc, method, *inputs, **kwargs)
 
     @singledispatchmethod
-    def __mul__(self, other) -> None:  # noqa: ANN001
+    def __mul__(self, other: object) -> "cosmo_array | _AHelper":
         """
         Default implementation for invalid multiplications.
 
@@ -3202,49 +3218,103 @@ class _AHelper(object):
         """
         return NotImplemented
 
-    def _ndarray_or_number_mul(self, other: numeric_type | np.ndarray) -> cosmo_array:
+    @__mul__.register
+    def _(self, other: int) -> cosmo_quantity:
         """
-        Multiply with a number or :mod:`numpy` array.
+        Multiply with a number.
 
         Parameters
         ----------
-        other : numeric_type or np.ndarray
+        other : int
             The quantity to multiply with.
 
         Returns
         -------
-        ~swiftsimio.objects.cosmo_array
-            A cosmo array or quantity based on the content of this helper and the
-            ``other`` number or array.
+        ~swiftsimio.objects.cosmo_quantity
+            A :class:`~swiftsimio.objects.cosmo_quantity` based on the content of this
+            helper and the ``other`` number.
         """
-        # the two registered functions calling this can be merged into one with
-        # type hint `other: numeric_type | np.ndarray` once python3.10 support is
+        return self._mul_numeric_type(other)
+
+    @__mul__.register
+    def _(self, other: float) -> cosmo_quantity:
+        """
+        Multiply with a number.
+
+        Parameters
+        ----------
+        other : float
+            The quantity to multiply with.
+
+        Returns
+        -------
+        ~swiftsimio.objects.cosmo_quantity
+            A :class:`~swiftsimio.objects.cosmo_quantity` based on the content of this
+            helper and the ``other`` number.
+        """
+        return self._mul_numeric_type(other)
+
+    @__mul__.register
+    def _(self, other: np.number) -> cosmo_quantity:
+        """
+        Multiply with a number.
+
+        Parameters
+        ----------
+        other : np.number
+            The quantity to multiply with.
+
+        Returns
+        -------
+        ~swiftsimio.objects.cosmo_quantity
+            A :class:`~swiftsimio.objects.cosmo_quantity` based on the content of this
+            helper and the ``other`` number.
+        """
+        return self._mul_numeric_type(other)
+
+    @__mul__.register
+    def _(self, other: complex) -> cosmo_quantity:
+        """
+        Multiply with a number.
+
+        Parameters
+        ----------
+        other : complex
+            The quantity to multiply with.
+
+        Returns
+        -------
+        ~swiftsimio.objects.cosmo_quantity
+            A :class:`~swiftsimio.objects.cosmo_quantity` based on the content of this
+            helper and the ``other`` number.
+        """
+        return self._mul_numeric_type(other)
+
+    def _mul_numeric_type(self, other: numeric_type) -> cosmo_quantity:
+        """
+        Multiply with a number.
+
+        Parameters
+        ----------
+        other : int or float or np.number or complex
+            The quantity to multiply with.
+
+        Returns
+        -------
+        ~swiftsimio.objects.cosmo_quantity
+            A :class:`~swiftsimio.objects.cosmo_quantity` based on the content of this
+            helper and the ``other`` number.
+        """
+        # the four registered functions calling this can be merged into one with
+        # type hint `other: numeric_type` once python3.10 support is
         # dropped
-        return (cosmo_quantity if np.isscalar(other) else cosmo_array)(
+        return cosmo_quantity(
             other,
             units=self.units,
             comoving=self._comoving,
             scale_factor=self.scale_factor,
             scale_exponent=self.scale_exponent,
         )
-
-    @__mul__.register
-    def _(self, other: numeric_type) -> cosmo_array:
-        """
-        Multiply with a number.
-
-        Parameters
-        ----------
-        other : numeric_type
-            The quantity to multiply with.
-
-        Returns
-        -------
-        ~swiftsimio.objects.cosmo_array
-            A cosmo array or quantity based on the content of this helper and the
-            ``other`` number.
-        """
-        return self._ndarray_or_number_mul(other)
 
     @__mul__.register
     def _(self, other: np.ndarray) -> cosmo_array:
@@ -3262,7 +3332,13 @@ class _AHelper(object):
             A cosmo array or quantity based on the content of this helper and the
             ``other`` array.
         """
-        return self._ndarray_or_number_mul(other)
+        return (cosmo_array if other.ndim else cosmo_quantity)(
+            other,
+            units=self.units,
+            comoving=self._comoving,
+            scale_factor=self.scale_factor,
+            scale_exponent=self.scale_exponent,
+        )
 
     def _tuple_or_list_mul(self, other: tuple | list) -> cosmo_array:
         """
@@ -3291,7 +3367,7 @@ class _AHelper(object):
         else:
             ret.comoving = self._comoving
         ret.units = ret.units * self.units
-        if ret.cosmo_factor == cosmo_factor(None, None):
+        if ret.cosmo_factor == NULL_CF:
             ret.cosmo_factor = cosmo_factor.create(
                 self.scale_factor, self.scale_exponent
             )
@@ -3338,7 +3414,7 @@ class _AHelper(object):
         return self._tuple_or_list_mul(other)
 
     @__mul__.register
-    def _(self, other: unyt.Unit) -> Self:
+    def _(self, other: unyt.unit_object.Unit) -> Self:
         """
         Multiply with a :class:`unyt.unit_object.Unit`.
 
@@ -3355,36 +3431,16 @@ class _AHelper(object):
         ~swiftsimio.objects._AHelper
             A helper updated with the provided units.
         """
-        return _AHelper(
+        # Ideally want to set the return type to `"_AHelper"` or even `_AHelper` but this
+        # isn't possible in python<3.15, see github.com/python/cpython/issues/86153.
+        # Best workaround found is to set return type to `Self`, but this forces us
+        # to `return self.__class__(...)` instead of `return _AHelper(...)` (a subclass
+        # could otherwise invalidate the return type).
+        return self.__class__(
             scale_factor=self._scale_factor,
             scale_exponent=self.scale_exponent,
             units=other.units * self.units,
-            comoving=self.__comoving,
-        )
-
-    @__mul__.register  # -- UNUSED, REMOVE? OR JUST UNTESTED SO FAR?
-    def _(self, other: unyt.unyt_array) -> cosmo_array:
-        """
-        Multiply with a :class:`~unyt.array.unyt_array`.
-
-        Parameters
-        ----------
-        other : ~unyt.array.unyt_array
-            The quantity to multiply with.
-
-        Returns
-        -------
-        ~swiftsimio.objects.cosmo_array
-            A cosmo array or quantity based on the content of this helper and the
-            ``other`` :class:`~unyt.array.unyt_array`.
-        """
-        return (
-            cosmo_quantity if isinstance(other, unyt.unyt_quantity) else cosmo_array
-        )(
-            other.ndview,
-            units=other.units * self.units,
-            comoving=self._comoving,
-            cosmo_factor=cosmo_factor.create(self.scale_factor, self.scale_exponent),
+            comoving=self._comoving_state,
         )
 
     @__mul__.register
@@ -3458,15 +3514,13 @@ class _AHelper(object):
             The result of applying the helper to the other operand.
         """
         # avoid using other ** -1, e.g. integers raise on this
-        return 1 / (
-            other
-            * _AHelper(
-                scale_factor=self._scale_factor,
-                scale_exponent=-self.scale_exponent,
-                units=self.units,
-                comoving=self.__comoving,
-            )
+        inv: "_AHelper | cosmo_array" = other * _AHelper(
+            scale_factor=self._scale_factor,
+            scale_exponent=-self.scale_exponent,
+            units=self.units,
+            comoving=self._comoving_state,
         )
+        return 1 / inv
 
     def __rtruediv__(
         self, other: unyt.Unit | unyt.unyt_array | cosmo_array
@@ -3492,10 +3546,10 @@ class _AHelper(object):
             scale_factor=self._scale_factor,
             scale_exponent=-self.scale_exponent,
             units=self.units,
-            comoving=self.__comoving,
+            comoving=self._comoving_state,
         )
 
-    def __pow__(self, exponent: int | float) -> "_AHelper":
+    def __pow__(self, exponent: numeric_type) -> "_AHelper":
         """
         Raise this helper to a power.
 
@@ -3520,17 +3574,17 @@ class _AHelper(object):
             scale_factor=self._scale_factor,
             scale_exponent=self.scale_exponent * exponent,
             units=self.units**exponent,
-            comoving=self.__comoving,
+            comoving=self._comoving_state,
         )
 
     @singledispatchmethod
-    def __imul__(self, other) -> None:  # noqa: ANN001
+    def __imul__(self, other: object) -> None:
         """
         Do not support in-place multiplication as left operand.
 
         Parameters
         ----------
-        other : numeric_type or tuple or list or np.ndarray or ~unyt.array.unyt_array or \
+        other : int or float or tuple or list or np.ndarray or ~unyt.array.unyt_array or \
         ~swiftsimio.objects.cosmo_array
             The other object to multiply with this one.
 
@@ -3545,7 +3599,7 @@ class _AHelper(object):
             "argument are not supported."
         )
 
-    def __ipow__(self, exponent: int | float) -> None:
+    def __ipow__(self, exponent: numeric_type) -> None:
         """
         Do not support in-place exponentiation as left operand.
 
@@ -3566,14 +3620,15 @@ class _AHelper(object):
         )
 
     def __itruediv__(
-        self, other: numeric_type | tuple | list | np.ndarray | unyt_array | cosmo_array
+        self,
+        other: numeric_type | tuple | list | np.ndarray | unyt_array | cosmo_array,
     ) -> None:
         """
         Do not support in-place division as left operand.
 
         Parameters
         ----------
-        other : numeric_type or tuple or list or np.ndarray or ~unyt.array.unyt_array or \
+        other : int or float or tuple or list or np.ndarray or ~unyt.array.unyt_array or \
         ~swiftsimio.objects.cosmo_array
             The other object to divide this one by.
 

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -1506,14 +1506,14 @@ class cosmo_array(unyt_array):
 
         See Also
         --------
-        ~swiftsimio.objects.cosmo_array.convert_to_physical
-        ~swiftsimio.objects.cosmo_array.convert_to_comoving
-        ~swiftsimio.objects.cosmo_array.to_physical
-        ~swiftsimio.objects.cosmo_array.to_comoving
-        ~swiftsimio.objects.cosmo_array.to
-        ~swiftsimio.objects.cosmo_array.to_physical_value
-        ~swiftsimio.objects.cosmo_array.to_comoving_value
-        ~swiftsimio.objects.cosmo_array.to_value
+        swiftsimio.objects.cosmo_array.convert_to_physical
+        swiftsimio.objects.cosmo_array.convert_to_comoving
+        swiftsimio.objects.cosmo_array.to_physical
+        swiftsimio.objects.cosmo_array.to_comoving
+        swiftsimio.objects.cosmo_array.to
+        swiftsimio.objects.cosmo_array.to_physical_value
+        swiftsimio.objects.cosmo_array.to_comoving_value
+        swiftsimio.objects.cosmo_array.to_value
         """
         if comoving:
             self.convert_to_comoving(units, equivalence=equivalence, **kwargs)
@@ -1558,14 +1558,14 @@ class cosmo_array(unyt_array):
 
         See Also
         --------
-        ~swiftsimio.objects.cosmo_array.convert_to_physical
-        ~swiftsimio.objects.cosmo_array.convert_to
-        ~swiftsimio.objects.cosmo_array.to_physical
-        ~swiftsimio.objects.cosmo_array.to_comoving
-        ~swiftsimio.objects.cosmo_array.to
-        ~swiftsimio.objects.cosmo_array.to_physical_value
-        ~swiftsimio.objects.cosmo_array.to_comoving_value
-        ~swiftsimio.objects.cosmo_array.to_value
+        swiftsimio.objects.cosmo_array.convert_to_physical
+        swiftsimio.objects.cosmo_array.convert_to
+        swiftsimio.objects.cosmo_array.to_physical
+        swiftsimio.objects.cosmo_array.to_comoving
+        swiftsimio.objects.cosmo_array.to
+        swiftsimio.objects.cosmo_array.to_physical_value
+        swiftsimio.objects.cosmo_array.to_comoving_value
+        swiftsimio.objects.cosmo_array.to_value
         """
         if units is not None:
             self.convert_to_units(units, equivalence=equivalence, **kwargs)
@@ -1617,14 +1617,14 @@ class cosmo_array(unyt_array):
 
         See Also
         --------
-        ~swiftsimio.objects.cosmo_array.convert_to_comoving
-        ~swiftsimio.objects.cosmo_array.convert_to
-        ~swiftsimio.objects.cosmo_array.to_physical
-        ~swiftsimio.objects.cosmo_array.to_comoving
-        ~swiftsimio.objects.cosmo_array.to
-        ~swiftsimio.objects.cosmo_array.to_physical_value
-        ~swiftsimio.objects.cosmo_array.to_comoving_value
-        ~swiftsimio.objects.cosmo_array.to_value
+        swiftsimio.objects.cosmo_array.convert_to_comoving
+        swiftsimio.objects.cosmo_array.convert_to
+        swiftsimio.objects.cosmo_array.to_physical
+        swiftsimio.objects.cosmo_array.to_comoving
+        swiftsimio.objects.cosmo_array.to
+        swiftsimio.objects.cosmo_array.to_physical_value
+        swiftsimio.objects.cosmo_array.to_comoving_value
+        swiftsimio.objects.cosmo_array.to_value
         """
         if units is not None:
             self.convert_to_units(units, equivalence=equivalence, **kwargs)
@@ -1674,14 +1674,14 @@ class cosmo_array(unyt_array):
 
         See Also
         --------
-        ~swiftsimio.objects.cosmo_array.convert_to_physical
-        ~swiftsimio.objects.cosmo_array.convert_to_comoving
-        ~swiftsimio.objects.cosmo_array.convert_to
-        ~swiftsimio.objects.cosmo_array.to_comoving
-        ~swiftsimio.objects.cosmo_array.to
-        ~swiftsimio.objects.cosmo_array.to_physical_value
-        ~swiftsimio.objects.cosmo_array.to_comoving_value
-        ~swiftsimio.objects.cosmo_array.to_value
+        swiftsimio.objects.cosmo_array.convert_to_physical
+        swiftsimio.objects.cosmo_array.convert_to_comoving
+        swiftsimio.objects.cosmo_array.convert_to
+        swiftsimio.objects.cosmo_array.to_comoving
+        swiftsimio.objects.cosmo_array.to
+        swiftsimio.objects.cosmo_array.to_physical_value
+        swiftsimio.objects.cosmo_array.to_comoving_value
+        swiftsimio.objects.cosmo_array.to_value
         """
         if not self.valid_transform and self.comoving:
             raise InvalidConversionError
@@ -1727,14 +1727,14 @@ class cosmo_array(unyt_array):
 
         See Also
         --------
-        ~swiftsimio.objects.cosmo_array.convert_to_physical
-        ~swiftsimio.objects.cosmo_array.convert_to_comoving
-        ~swiftsimio.objects.cosmo_array.convert_to
-        ~swiftsimio.objects.cosmo_array.to_physical
-        ~swiftsimio.objects.cosmo_array.to
-        ~swiftsimio.objects.cosmo_array.to_physical_value
-        ~swiftsimio.objects.cosmo_array.to_comoving_value
-        ~swiftsimio.objects.cosmo_array.to_value
+        swiftsimio.objects.cosmo_array.convert_to_physical
+        swiftsimio.objects.cosmo_array.convert_to_comoving
+        swiftsimio.objects.cosmo_array.convert_to
+        swiftsimio.objects.cosmo_array.to_physical
+        swiftsimio.objects.cosmo_array.to
+        swiftsimio.objects.cosmo_array.to_physical_value
+        swiftsimio.objects.cosmo_array.to_comoving_value
+        swiftsimio.objects.cosmo_array.to_value
         """
         if not self.valid_transform and self.comoving is not False:
             raise InvalidConversionError
@@ -1793,14 +1793,14 @@ class cosmo_array(unyt_array):
         
         See Also
         --------
-        ~swiftsimio.objects.cosmo_array.convert_to_physical
-        ~swiftsimio.objects.cosmo_array.convert_to_comoving
-        ~swiftsimio.objects.cosmo_array.convert_to
-        ~swiftsimio.objects.cosmo_array.to_physical
-        ~swiftsimio.objects.cosmo_array.to_comoving
-        ~swiftsimio.objects.cosmo_array.to_physical_value
-        ~swiftsimio.objects.cosmo_array.to_comoving_value
-        ~swiftsimio.objects.cosmo_array.to_value
+        swiftsimio.objects.cosmo_array.convert_to_physical
+        swiftsimio.objects.cosmo_array.convert_to_comoving
+        swiftsimio.objects.cosmo_array.convert_to
+        swiftsimio.objects.cosmo_array.to_physical
+        swiftsimio.objects.cosmo_array.to_comoving
+        swiftsimio.objects.cosmo_array.to_physical_value
+        swiftsimio.objects.cosmo_array.to_comoving_value
+        swiftsimio.objects.cosmo_array.to_value
 
         Examples
         --------
@@ -1893,14 +1893,14 @@ class cosmo_array(unyt_array):
 
         See Also
         --------
-        ~swiftsimio.objects.cosmo_array.convert_to_physical
-        ~swiftsimio.objects.cosmo_array.convert_to_comoving
-        ~swiftsimio.objects.cosmo_array.convert_to
-        ~swiftsimio.objects.cosmo_array.to_physical
-        ~swiftsimio.objects.cosmo_array.to_comoving
-        ~swiftsimio.objects.cosmo_array.to
-        ~swiftsimio.objects.cosmo_array.to_physical_value
-        ~swiftsimio.objects.cosmo_array.to_comoving_value
+        swiftsimio.objects.cosmo_array.convert_to_physical
+        swiftsimio.objects.cosmo_array.convert_to_comoving
+        swiftsimio.objects.cosmo_array.convert_to
+        swiftsimio.objects.cosmo_array.to_physical
+        swiftsimio.objects.cosmo_array.to_comoving
+        swiftsimio.objects.cosmo_array.to
+        swiftsimio.objects.cosmo_array.to_physical_value
+        swiftsimio.objects.cosmo_array.to_comoving_value
 
         Examples
         --------
@@ -1963,14 +1963,14 @@ class cosmo_array(unyt_array):
 
         See Also
         --------
-        ~swiftsimio.objects.cosmo_array.convert_to_physical
-        ~swiftsimio.objects.cosmo_array.convert_to_comoving
-        ~swiftsimio.objects.cosmo_array.convert_to
-        ~swiftsimio.objects.cosmo_array.to_physical
-        ~swiftsimio.objects.cosmo_array.to_comoving
-        ~swiftsimio.objects.cosmo_array.to
-        ~swiftsimio.objects.cosmo_array.to_comoving_value
-        ~swiftsimio.objects.cosmo_array.to_value
+        swiftsimio.objects.cosmo_array.convert_to_physical
+        swiftsimio.objects.cosmo_array.convert_to_comoving
+        swiftsimio.objects.cosmo_array.convert_to
+        swiftsimio.objects.cosmo_array.to_physical
+        swiftsimio.objects.cosmo_array.to_comoving
+        swiftsimio.objects.cosmo_array.to
+        swiftsimio.objects.cosmo_array.to_comoving_value
+        swiftsimio.objects.cosmo_array.to_value
         """
         return self.to_value(units, equivalence=equivalence, comoving=False, **kwargs)
 
@@ -2016,14 +2016,14 @@ class cosmo_array(unyt_array):
 
         See Also
         --------
-        ~swiftsimio.objects.cosmo_array.convert_to_physical
-        ~swiftsimio.objects.cosmo_array.convert_to_comoving
-        ~swiftsimio.objects.cosmo_array.convert_to
-        ~swiftsimio.objects.cosmo_array.to_physical
-        ~swiftsimio.objects.cosmo_array.to_comoving
-        ~swiftsimio.objects.cosmo_array.to
-        ~swiftsimio.objects.cosmo_array.to_physical_value
-        ~swiftsimio.objects.cosmo_array.to_value
+        swiftsimio.objects.cosmo_array.convert_to_physical
+        swiftsimio.objects.cosmo_array.convert_to_comoving
+        swiftsimio.objects.cosmo_array.convert_to
+        swiftsimio.objects.cosmo_array.to_physical
+        swiftsimio.objects.cosmo_array.to_comoving
+        swiftsimio.objects.cosmo_array.to
+        swiftsimio.objects.cosmo_array.to_physical_value
+        swiftsimio.objects.cosmo_array.to_value
         """
         return self.to_value(units, equivalence=equivalence, comoving=True, **kwargs)
 

--- a/swiftsimio/optional_packages.py
+++ b/swiftsimio/optional_packages.py
@@ -18,7 +18,7 @@ try:
     TQDM_AVAILABLE = True
 except (ImportError, ModuleNotFoundError):
 
-    def tqdm(x: Iterable, *args: tuple[Any], **kwargs: dict[str, Any]) -> Iterable:
+    def tqdm(x: Iterable, *args: Any, **kwargs: Any) -> Iterable:
         """
         Mock the main tqdm function for use if it's unavailable.
 
@@ -27,10 +27,10 @@ except (ImportError, ModuleNotFoundError):
         x : Iterable
             The iterable whose progress would be track by tqdm.
 
-        *args : tuple[Any]
+        *args : Any
             Arbitrary additional arguments.
 
-        **kwargs : dict[str, Any]
+        **kwargs : Any
             Arbitrary additional kwargs.
 
         Returns
@@ -85,16 +85,16 @@ except (ImportError, ModuleNotFoundError):
             "(pip install numba)"
         )
 
-        def jit(*args: tuple[Any], **kwargs: dict[str, Any]) -> Callable:
+        def jit(*args: Any, **kwargs: Any) -> Callable:
             """
             Mock the numba jit function for use if not available.
 
             Parameters
             ----------
-            *args : tuple[Any]
+            *args : Any
                 Arbitrary arguments.
 
-            **kwargs : dict[str, Any]
+            **kwargs : Any
                 Arbitrary kwargs.
 
             Returns

--- a/swiftsimio/snapshot_writer.py
+++ b/swiftsimio/snapshot_writer.py
@@ -11,7 +11,7 @@ from functools import reduce
 
 from swiftsimio import metadata
 from swiftsimio.metadata.writer.unit_systems import cosmo_units
-from swiftsimio.objects import cosmo_array
+from swiftsimio.objects import cosmo_array, _AHelper
 
 
 def _ptype_str_to_int(ptype_str: str) -> int:
@@ -555,13 +555,7 @@ class SWIFTSnapshotWriter(object):
 
     .. code-block:: python
 
-       w.gas.masses = cosmo_array(
-           np.ones(n_p, dtype=float) * 1e6,
-           u.solMass,
-           comoving=True,
-           scale_factor=w.scale_factor,
-           scale_exponent=0,
-       )
+       w.gas.masses = np.ones(n_p, dtype=float) * 1e6 * u.solMass * w.a.comoving**0
 
     Parameters
     ----------
@@ -592,60 +586,44 @@ class SWIFTSnapshotWriter(object):
        import numpy as np
        import unyt as u
        from swiftsimio import Writer, cosmo_array
-       from swiftsimio.metadata.writer.unit_systems import cosmo_unit_system
+       from swiftsimio.metadata.writer.unit_systems import cosmo_units
 
        # number of gas particles
        n_p = 1000
        # scale factor of 1.0
-       a = 1.0
+       scale_factor = 1.0
        # Box is 100 Mpc
        lbox = 100
        boxsize = cosmo_array(
             [lbox, lbox, lbox],
             u.Mpc,
             comoving=True,
-            scale_factor=a,
+            scale_factor=scale_factor,
             scale_exponent=1,
        )
 
-       # Create the Writer object. cosmo_unit_system corresponds to default Gadget-like
+       # Create the Writer object. cosmo_units corresponds to default Gadget-like
        # units of 10^10 Msun, Mpc, and km/s
-       w = Writer(unit_system=cosmo_unit_system, boxsize=boxsize, scale_factor=a)
+       w = Writer(unit_system=cosmo_units, boxsize=boxsize, scale_factor=a)
 
        # Randomly spaced coordinates from 0 to lbox Mpc in each direction
-       w.gas.coordinates = cosmo_array(
-           np.random.rand(n_p, 3) * lbox,
-           u.Mpc,
-           comoving=True,
-           scale_factor=w.scale_factor,
-           scale_exponent=1,
-       )
+       w.gas.coordinates = np.random.rand(n_p, 3) * lbox * u.Mpc * w.a.comoving
 
        # Random velocities from 0 to 1 km/s
-       w.gas.velocities = cosmo_array(
-           np.random.rand(n_p, 3),
-           u.km / u.s,
-           comoving=True,
-           scale_factor=w.scale_factor,
-           scale_exponent=1,
-       )
+       w.gas.velocities = np.random.rand(n_p, 3) * u.km / u.s * w.a.comoving**0
 
        # Generate uniform masses as 10^6 solar masses for each particle
-       w.gas.masses = cosmo_array(
-           np.ones(n_p, dtype=float) * 1e6,
-           u.solMass,
-           comoving=True,
-           scale_factor=w.scale_factor,
-           scale_exponent=0,
-       )
+       w.gas.masses = np.ones(n_p, dtype=float) * 1e6 * u.solMass * w.a.comoving**0
 
        # Generate internal energy corresponding to 10^4 K
-       w.gas.internal_energy = cosmo_array(
-           np.ones(n_p, dtype=float) * 1e4 / 1e6,
-           u.kb * u.K / u.solMass,
-           comoving=True,
-           scale_factor=w.scale_factor,
-           scale_exponent=-2,
+       w.gas.internal_energy = (
+           np.ones(n_p, dtype=float)
+           * 1e4
+           / 1e6
+           * u.kb
+           * u.K
+           / u.solMass
+           * w.a.comoving**-2
        )
 
        # Generate initial guess for smoothing lengths based on mean inter-particle spacing
@@ -693,6 +671,7 @@ class SWIFTSnapshotWriter(object):
         self.create_particle_datasets()
 
         self.scale_factor = scale_factor
+        self.a = _AHelper(scale_factor=scale_factor)
 
         return
 

--- a/swiftsimio/snapshot_writer.py
+++ b/swiftsimio/snapshot_writer.py
@@ -604,7 +604,7 @@ class SWIFTSnapshotWriter(object):
 
        # Create the Writer object. cosmo_units corresponds to default Gadget-like
        # units of 10^10 Msun, Mpc, and km/s
-       w = Writer(unit_system=cosmo_units, boxsize=boxsize, scale_factor=a)
+       w = Writer(unit_system=cosmo_units, boxsize=boxsize, scale_factor=scale_factor)
 
        # Randomly spaced coordinates from 0 to lbox Mpc in each direction
        w.gas.coordinates = np.random.rand(n_p, 3) * lbox * u.Mpc * w.a.comoving

--- a/swiftsimio/visualisation/_vistools.py
+++ b/swiftsimio/visualisation/_vistools.py
@@ -6,7 +6,7 @@ from functools import reduce
 from typing import Callable, Any
 from swiftsimio.objects import cosmo_array, cosmo_quantity
 from swiftsimio.reader import __SWIFTGroupDataset
-from swiftsimio._array_functions import _copy_cosmo_array_attributes_if_present
+from swiftsimio._array_functions import _copy_cosmo_array_attributes
 
 
 def _get_projection_field(data: __SWIFTGroupDataset, field_name: str) -> cosmo_array:
@@ -192,7 +192,7 @@ def backend_strip_and_restore_cosmo_and_units(
         The wrapped function.
     """
 
-    def wrapper(*args: tuple[Any], **kwargs: dict[str, Any]) -> cosmo_array:
+    def wrapper(*args: Any, **kwargs: Any) -> cosmo_array:
         """
         Wrap function to re-attach cosmology metadata to output.
 
@@ -202,10 +202,10 @@ def backend_strip_and_restore_cosmo_and_units(
 
         Parameters
         ----------
-        *args : tuple
+        *args : Any
             Arbitrary arguments for the wrapped function.
 
-        **kwargs : dict
+        **kwargs : Any
             Arbitrary kwargs for the wrapped function.
 
         Returns
@@ -253,7 +253,7 @@ def backend_strip_and_restore_cosmo_and_units(
             for k, v in kwargs.items()
         }
         return (
-            _copy_cosmo_array_attributes_if_present(
+            _copy_cosmo_array_attributes(
                 kwargs["m"],
                 backend_func(*args, **stripped_kwargs).view(cosmo_array),
                 copy_units=True,

--- a/tests/test_a_helper.py
+++ b/tests/test_a_helper.py
@@ -1,0 +1,152 @@
+"""Test the helper to convert unyt quantities into cosmo quantities."""
+
+import pytest
+import numpy as np
+import unyt as u
+from swiftsimio import mask, cosmo_array, cosmo_quantity
+from swiftsimio.objects import _AHelper
+
+
+@pytest.mark.parametrize("scale_exponent", (-1, 0, 1, 2, None))
+@pytest.mark.parametrize("data", (10, np.array([1, 2]), [1, 2], (1, 2)))
+@pytest.mark.parametrize(
+    "order",
+    (
+        "data_units_a",
+        "data_a_units",
+        "a_data_units",
+        "units_data_a",
+        "units_a_data",
+        "a_units_data",
+    ),
+)
+@pytest.mark.parametrize("com_or_phys", ("comoving", "physical"))
+def test_multiply_unyt_with_ahelper(scale_exponent, data, order, com_or_phys):
+    """
+    Test cosmo-ifying unyt objects by multiplying with the helper object.
+
+    Covers permutations of the multiplication order, scalar, list, tuple or array input,
+    value and presence of the exponent, and comoving/physical.
+
+    This should cover all of the fundamental functionality expected of the helper.
+    """
+    scale_factor = 0.5
+    a = getattr(_AHelper(scale_factor=scale_factor), com_or_phys)
+    if scale_exponent is not None:
+        a = a**scale_exponent
+    operands = {
+        "a": a,
+        "units": u.Mpc,
+        "data": data,
+    }
+    first, second, third = [operands[i] for i in order.split("_")]
+    cosmo = first * second * third
+    if np.isscalar(data):
+        assert isinstance(cosmo, cosmo_quantity)
+    else:
+        # careful, cosmo_quantity is a subclass and therefore counts as a cosmo_array
+        assert isinstance(cosmo, cosmo_array) and not isinstance(cosmo, cosmo_quantity)
+    if com_or_phys == "comoving":
+        assert cosmo.comoving
+    else:
+        assert (
+            cosmo.comoving is False
+        )  # don't assert not cosmo.comoving in case is None
+    assert cosmo.units == u.Mpc
+    assert cosmo.cosmo_factor.a_factor == scale_factor**scale_exponent
+
+
+def test_multiply_cosmo_with_ahelper():
+    """Test that multiplying an already-cosmo object modifies the `cosmo_factor`."""
+    raise NotImplementedError
+
+
+@pytest.mark.parametrize("data", 10, np.array([1, 2]))
+@pytest.mark.parametrize("com_or_phys", ("comoving", "physical"))
+@pytest.mark.parametrize("scale_exponent", (1, None))
+def test_assign_comoving_or_physical_units_to_name(data, com_or_phys, scale_exponent):
+    """
+    Test that we can make e.g. cMpc or pMpc units and then apply them to data.
+
+    This is a documented feature so should make sure that it works.
+    """
+    scale_factor = 0.5
+    # this is either a "cMpc" or "pMpc" depending on case, label "xMpc" here:
+    a = getattr(_AHelper(scale_factor=scale_factor), com_or_phys)
+    if scale_exponent is not None:
+        a = a**scale_exponent
+    xMpc = u.Mpc * a
+    cosmo = data * xMpc
+    if np.isscalar(data):
+        assert isinstance(cosmo, cosmo_quantity)
+    else:
+        # careful, cosmo_quantity is a subclass and therefore counts as a cosmo_array
+        assert isinstance(cosmo, cosmo_array) and not isinstance(cosmo, cosmo_quantity)
+    if com_or_phys == "comoving":
+        assert cosmo.comoving
+    else:
+        assert (
+            cosmo.comoving is False
+        )  # don't assert not cosmo.comoving in case is None
+    assert cosmo.units == u.Mpc
+    assert cosmo.cosmo_factor.a_factor == scale_factor**scale_exponent
+
+
+def test_helper_available_from_metadata(cosmological_volume_only_single_local):
+    """
+    Test that the helper is available as a metadata attribute on datasets.
+
+    This serves as an integration test by making sure that we can use the helper to define
+    a region for masking, using it's comoving, physical and exponent features. We then
+    check that defining the same region the tedious way gives the same result, and that
+    the region defined with the helper is accepted by ``constrain_spatial``.
+    """
+    m = mask(cosmological_volume_only_single_local)
+    a = mask.metadata.a
+    scale_factor = mask.metadata.scale_factor
+    region = [
+        [1 * u.Mpc * a.comoving, 2 * u.Mpc * a.comoving],
+        [1 * u.Mpc * a.physical, 2 * u.Mpc * a.physical],
+        [1 * u.Mpc * a.comoving**1, 2 * u.Mpc * a.comoving**1],
+    ]
+    manual_region = [
+        [
+            cosmo_quantity(
+                1, u.Mpc, comoving=True, scale_factor=scale_factor, scale_exponent=1
+            ),
+            cosmo_quantity(
+                2, u.Mpc, comoving=True, scale_factor=scale_factor, scale_exponent=1
+            ),
+        ],
+        [
+            cosmo_quantity(
+                1, u.Mpc, comoving=False, scale_factor=scale_factor, scale_exponent=1
+            ),
+            cosmo_quantity(
+                2, u.Mpc, comoving=False, scale_factor=scale_factor, scale_exponent=1
+            ),
+        ],
+        [
+            cosmo_quantity(
+                1, u.Mpc, comoving=True, scale_factor=scale_factor, scale_exponent=1
+            ),
+            cosmo_quantity(
+                2, u.Mpc, comoving=True, scale_factor=scale_factor, scale_exponent=1
+            ),
+        ],
+    ]
+    # check that the regions are equivalent:
+    for ax_region, ax_manual_region in zip(region, manual_region):
+        for element, manual_element in zip(ax_region, ax_manual_region):
+            assert element == manual_element
+    # be a bit paranoid and make sure that constraining mask works:
+    m.constrain_spatial(region)
+
+
+def test_incorrect_usage():
+    """Should also test expected failure modes..."""
+    # `10 * a.comoving` should error, for example.
+    # That `10 * a.comoving * u.Mpc` works and `10 * u.Mpc * a.comoving` also works
+    # will rely on triggering `__multiply__` or `__rmultiply__` accordingly. Units but
+    # no data yet is allowed to enable `cMpc = ...`, but we should not be able to end up
+    # with data but no units.

--- a/tests/test_a_helper.py
+++ b/tests/test_a_helper.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 import numpy as np
 import unyt as u
 from swiftsimio import mask, cosmo_array, cosmo_quantity
-from swiftsimio.objects import _AHelper, InvalidCosmoUnit
+from swiftsimio.objects import _AHelper, InvalidCosmoUnit, cosmo_factor
 
 
 @pytest.mark.parametrize("scale_exponent", (-1, 0, 1, 2, None))
@@ -160,7 +160,7 @@ def test_helper_available_from_metadata(cosmological_volume_only_single_local):
     """
     m = mask(cosmological_volume_only_single_local)
     a = m.metadata.a
-    scale_factor = mask.metadata.scale_factor
+    scale_factor = m.metadata.scale_factor
     region = [
         [1.0 * u.Mpc * a.comoving, 2.0 * u.Mpc * a.comoving],
         [1.0 * u.Mpc * a.physical, 2.0 * u.Mpc * a.physical],
@@ -202,17 +202,67 @@ def test_helper_available_from_metadata(cosmological_volume_only_single_local):
 
 def test_comoving_or_physical_missing():
     """Test that failing to specify ``a.comoving`` or ``a.physical`` is an error."""
+    scale_factor = 0.5
+    a = _AHelper(scale_factor=scale_factor)
     with pytest.raises(InvalidCosmoUnit, match="..."):
-        # didn't specify comoving/physical, should error on use:
-        scale_factor = 0.5
-        a = _AHelper(scale_factor=scale_factor)
-        with pytest.raises(InvalidCosmoUnit, match="..."):
-            10 * u.Mpc * a
-        with pytest.raises(InvalidCosmoUnit, match="..."):
-            cosmo_quantity(
-                10, u.Mpc, comoving=True, scale_factor=0.5, scale_exponent=1
-            ) * a
+        10 * u.Mpc * a
+    with pytest.raises(InvalidCosmoUnit, match="..."):
+        cosmo_quantity(10, u.Mpc, comoving=True, scale_factor=0.5, scale_exponent=1) * a
 
 
-# also division, multiply-and-assign, divide-and-assign?
-# disallow (a**2).comoving? no reason it shouldn't work but just seems confusing
+def test_metadata_attribute_not_backwards_compatible(
+    cosmological_volume_only_single_local,
+):
+    """
+    Test that users get a clear error when metadata.a is used in old style.
+
+    The introduction of the _AHelper is a breaking API change. We want to avoid users
+    doing things like ``10 * metadata.a * u.kpc`` (even though they should probably be
+    using :class:`~swiftsimio.objects.cosmo_quantity` instead) in the way that they used
+    to and getting strange/incorrect results. Requiring that ``metadata.a.comoving``
+    or ``metadata.a.physical`` is used before multiplication or division achieves this:
+    ``10 * metadata.a * u.kpc`` is an error when ``metadata.a`` is a ``_AHelper``.
+
+    The exception is ``cosmo_array(..., scale_factor=metadata.a)``. The ``cosmo_array``
+    can handle this case safely and interpret the object as just a scale factor, offering
+    some helpful backwards compatibility. See ``test_cosmo_factor_accepts_ahelper``.
+    """
+    m = mask(cosmological_volume_only_single_local)
+    with pytest.raises(InvalidCosmoUnit, match="..."):
+        10 * m.metadata.a * u.kpc
+
+
+def test_cosmo_factor_accepts_ahelper(cosmological_volume_only_single_local):
+    """
+    Check that cosmo array/quantity accepts metadata.a as a scale factor.
+
+    This is an explicit exception to not being able to use ``metadata.a`` without using
+    ``metadata.a.comoving`` or ``metadata.a.physical``. Actually, we specifically require
+    it not to be used in this case (``metadata.a._comoving`` should be ``None``) to avoid
+    ambiguity.
+    """
+    m = mask(cosmological_volume_only_single_local)
+    scale_exponent = 2  # pick a non-default case
+    assert m.metadata.a._comoving is None
+    cq = cosmo_quantity(
+        1,
+        u.kpc**2,
+        comoving=True,
+        scale_factor=m.metadata.a,  # can use it like this (backwards compatible)
+        scale_exponent=scale_exponent,
+    )
+    assert cq.comoving
+    assert cq.cosmo_factor == cosmo_factor.create(
+        m.metadata.scale_factor, scale_exponent
+    )
+    with pytest.raises(InvalidCosmoUnit, match="..."):
+        cosmo_quantity(
+            1,
+            u.kpc**2,
+            comoving=True,
+            scale_factor=m.metadata.a.comoving,  # can't use it like this
+            scale_exponent=scale_exponent,
+        )
+
+
+# also test division, multiply-and-assign, divide-and-assign

--- a/tests/test_a_helper.py
+++ b/tests/test_a_helper.py
@@ -1,6 +1,7 @@
 """Test the helper to convert unyt quantities into cosmo quantities."""
 
 import pytest
+from copy import deepcopy
 import numpy as np
 import unyt as u
 from swiftsimio import mask, cosmo_array, cosmo_quantity
@@ -56,10 +57,7 @@ def test_multiply_unyt_with_ahelper(scale_exponent, data, order, com_or_phys):
 
 @pytest.mark.parametrize("scale_exponent", (-1, 0, 1, 2, None))
 @pytest.mark.parametrize("data", (10.0, np.array([1.0, 2.0]), [1.0, 2.0], (1.0, 2.0)))
-@pytest.mark.parametrize(
-    "order",
-    ("data_a", "a_data"),
-)
+@pytest.mark.parametrize("order", ("data_a", "a_data"))
 @pytest.mark.parametrize("com_or_phys", ("comoving", "physical"))
 @pytest.mark.parametrize("in_com_or_phys", (True, False))
 def test_multiply_cosmo_with_ahelper(
@@ -71,13 +69,13 @@ def test_multiply_cosmo_with_ahelper(
     if scale_exponent is not None:
         a = a**scale_exponent
     cosmo_in = (cosmo_quantity if np.isscalar(data) else cosmo_array)(
-        data,
+        deepcopy(data),  # beware modification in-place
         u.Mpc,
         comoving=in_com_or_phys,
         scale_factor=scale_factor,
         scale_exponent=1,
     )
-    operands = {"a": a, "data": cosmo_in}
+    operands = {"data": cosmo_in, "a": a}
     first, second = [operands[i] for i in order.split("_")]
     cosmo = first * second
     if np.isscalar(data):
@@ -91,7 +89,7 @@ def test_multiply_cosmo_with_ahelper(
         assert cosmo.comoving is False  # avoid `not cosmo.comoving` in case is None
     assert cosmo.units == u.Mpc
     assert scale_factor != 1  # else trivial
-    expected_exponent = scale_exponent + 1 if scale_exponent is not None else 2
+    expected_exponent = (scale_exponent if scale_exponent is not None else 1) + 1
     assert cosmo.cosmo_factor.a_factor == scale_factor**expected_exponent
     if com_or_phys == "comoving":
         # scale_factor**(scale_exponent) from the helper, plus another scale_factor**1

--- a/tests/test_a_helper.py
+++ b/tests/test_a_helper.py
@@ -5,8 +5,9 @@ from copy import deepcopy
 import numpy as np
 import unyt as u
 from unyt.exceptions import InvalidUnitOperation
-from swiftsimio import mask, cosmo_array, cosmo_quantity
+from swiftsimio import mask, cosmo_array, cosmo_quantity, Writer
 from swiftsimio.objects import _AHelper, InvalidCosmoUnit, cosmo_factor
+from swiftsimio.metadata.writer.unit_systems import cosmo_units
 
 
 @pytest.mark.parametrize("scale_exponent", (-1, 0, 1, 2, None))
@@ -252,6 +253,26 @@ def test_helper_available_from_metadata(cosmological_volume_only_single_local):
             assert element == manual_element
     # be a bit paranoid and make sure that constraining mask works:
     m.constrain_spatial(region)
+
+
+def test_helper_available_from_writer():
+    """Test that the helper is available as an attribute on the ``Writer``."""
+    scale_factor = 0.5
+    w = Writer(
+        unit_system=cosmo_units,
+        boxsize=cosmo_array(
+            [100, 100, 100],
+            u.Mpc,
+            comoving=True,
+            scale_factor=scale_factor,
+            scale_exponent=1,
+        ),
+        scale_factor=scale_factor,
+    )
+    a = w.a
+    assert 10 * u.Mpc * a.comoving == cosmo_quantity(
+        10, u.Mpc, comoving=True, scale_factor=scale_factor, scale_exponent=1
+    )
 
 
 def test_comoving_or_physical_missing():

--- a/tests/test_a_helper.py
+++ b/tests/test_a_helper.py
@@ -15,7 +15,9 @@ from swiftsimio.objects import _AHelper, InvalidCosmoUnit
         "data_units_a",
         "data_a_units",
         "units_a_data",
+        "units_data_a",
         "a_units_data",
+        "a_data_units",
     ),
 )
 @pytest.mark.parametrize("com_or_phys", ("comoving", "physical"))
@@ -157,7 +159,7 @@ def test_helper_available_from_metadata(cosmological_volume_only_single_local):
     the region defined with the helper is accepted by ``constrain_spatial``.
     """
     m = mask(cosmological_volume_only_single_local)
-    a = mask.metadata.a
+    a = m.metadata.a
     scale_factor = mask.metadata.scale_factor
     region = [
         [1.0 * u.Mpc * a.comoving, 2.0 * u.Mpc * a.comoving],
@@ -196,33 +198,6 @@ def test_helper_available_from_metadata(cosmological_volume_only_single_local):
             assert element == manual_element
     # be a bit paranoid and make sure that constraining mask works:
     m.constrain_spatial(region)
-
-
-@pytest.mark.parametrize("data", (10, np.array([0, 1])))
-@pytest.mark.parametrize("scale_exponent", (-1, 0, 1, 2, None))
-@pytest.mark.parametrize("com_or_phys", ("comoving", "physical"))
-def test_invalid_usage(data, scale_exponent, com_or_phys):
-    """
-    Test expected failure modes.
-
-    Because multiplications are left-to-right associative we need to be able to resolve
-    each pair-wise multiplication, and we have no mechanism to handle e.g.
-    ``scalar * a_helper``. This means that the units and helper must be adjacent in the
-    order of operations (though we can tolerate swapping them places), so
-    ``units * data * a_helper`` and ``a_helper * data * units`` are also invalid.
-    """
-    scale_factor = 0.5
-    a = getattr(_AHelper(scale_factor=scale_factor), com_or_phys)
-    if scale_exponent is not None:
-        a = a**scale_exponent
-    with pytest.raises(InvalidCosmoUnit, match="..."):
-        a * data * u.Mpc
-    with pytest.raises(InvalidCosmoUnit, match="..."):
-        u.Mpc * data * a
-    with pytest.raises(InvalidCosmoUnit, match="..."):
-        data * a
-    with pytest.raises(InvalidCosmoUnit, match="..."):
-        a * data
 
 
 def test_comoving_or_physical_missing():

--- a/tests/test_a_helper.py
+++ b/tests/test_a_helper.py
@@ -297,7 +297,9 @@ def test_cosmo_factor_accepts_ahelper(cosmological_volume_only_single_local):
     """
     m = mask(cosmological_volume_only_single_local)
     scale_exponent = 2  # pick a non-default case
-    assert m.metadata.a._comoving is None
+    with pytest.raises(InvalidCosmoUnit, match="..."):
+        # the __comoving attribute is supposed to be None so this should raise
+        m.metadata.a._comoving
     cq = cosmo_quantity(
         1,
         u.kpc**2,

--- a/tests/test_a_helper.py
+++ b/tests/test_a_helper.py
@@ -375,3 +375,16 @@ def test_inplace_operations():
     assert x.units == u.kpc
     assert x.comoving
     assert x.cosmo_factor == cosmo_factor.create(0.5, 0)
+
+
+def test_aliases():
+    """Test ``a.com``, ``a.c`` and ``a.phys``, ``a.p`` work as shorthands."""
+    a = _AHelper(scale_factor=0.5)
+    assert 10 * a.comoving == 10 * a.com
+    assert 10 * a.physical == 10 * a.phys
+    assert 10 * a.comoving != 10 * a.phys
+    assert 10 * a.physical != 10 * a.com
+    assert 10 * a.comoving == 10 * a.c
+    assert 10 * a.physical == 10 * a.p
+    assert 10 * a.comoving != 10 * a.p
+    assert 10 * a.physical != 10 * a.c

--- a/tests/test_a_helper.py
+++ b/tests/test_a_helper.py
@@ -146,7 +146,9 @@ def test_assign_comoving_or_physical_units_to_name(
             cosmo.comoving is False
         )  # don't assert not cosmo.comoving in case is None
     assert cosmo.units == u.Mpc
-    assert cosmo.cosmo_factor.a_factor == scale_factor**scale_exponent
+    assert cosmo.cosmo_factor.a_factor == scale_factor ** (
+        scale_exponent if scale_exponent is not None else 1
+    )
 
 
 def test_helper_available_from_metadata(cosmological_volume_only_single_local):

--- a/tests/test_a_helper.py
+++ b/tests/test_a_helper.py
@@ -149,6 +149,59 @@ def test_assign_comoving_or_physical_units_to_name(
     )
 
 
+@pytest.mark.parametrize(
+    "data",
+    (
+        10,
+        10.0,
+        np.array([1.0, 2.0]),
+        (1.0, 2.0),
+        [1.0, 2.0],
+        u.kpc,
+        10.0 * u.kpc,
+        [1.0, 2.0] * u.kpc,
+        cosmo_quantity(10.0, u.kpc, comoving=True, scale_factor=0.5, scale_exponent=1),
+        cosmo_array(
+            [1.0, 2.0], u.kpc, comoving=True, scale_factor=0.5, scale_exponent=1
+        ),
+    ),
+)
+@pytest.mark.parametrize("order", ("a_data", "data_a"))
+def test_division(data, order):
+    """Test that the helper can handle division by and of all supported data types."""
+    scale_factor = 0.5
+    a = _AHelper(scale_factor=scale_factor).physical
+    operands = {"a": a, "data": data}
+    first, second = [operands[i] for i in order.split("_")]
+    cosmo = first / second
+    if isinstance(first, u.Unit):
+        assert isinstance(cosmo, _AHelper)
+    elif np.asarray(data).ndim == 0:
+        assert isinstance(cosmo, cosmo_quantity)
+    else:
+        # careful, cosmo_quantity is a subclass and therefore counts as a cosmo_array
+        assert isinstance(cosmo, cosmo_array) and not isinstance(cosmo, cosmo_quantity)
+    if isinstance(cosmo, _AHelper):
+        assert cosmo._comoving == a._comoving
+    else:
+        assert cosmo.comoving == getattr(data, "comoving", a._comoving)
+    if isinstance(cosmo, _AHelper):
+        assert cosmo.scale_factor == scale_factor
+    else:
+        assert cosmo.cosmo_factor.scale_factor == scale_factor
+    assert scale_factor != 1  # else trivial
+    if hasattr(data, "cosmo_factor"):
+        expected_exponent = 0
+    else:
+        expected_exponent = 1 if isinstance(first, _AHelper) else -1
+    if isinstance(cosmo, _AHelper):
+        assert (
+            cosmo._scale_factor**cosmo.scale_exponent == scale_factor**expected_exponent
+        )
+    else:
+        assert cosmo.cosmo_factor.a_factor == scale_factor**expected_exponent
+
+
 def test_helper_available_from_metadata(cosmological_volume_only_single_local):
     """
     Test that the helper is available as a metadata attribute on datasets.

--- a/tests/test_a_helper.py
+++ b/tests/test_a_helper.py
@@ -4,6 +4,7 @@ import pytest
 from copy import deepcopy
 import numpy as np
 import unyt as u
+from unyt.exceptions import InvalidUnitOperation
 from swiftsimio import mask, cosmo_array, cosmo_quantity
 from swiftsimio.objects import _AHelper, InvalidCosmoUnit, cosmo_factor
 
@@ -316,3 +317,59 @@ def test_cosmo_factor_accepts_ahelper(cosmological_volume_only_single_local):
             scale_factor=m.metadata.a.comoving,  # can't use it like this
             scale_exponent=scale_exponent,
         )
+
+
+def test_inplace_operations():
+    """
+    Test that in-place operations work/don't as intended.
+
+    The helper should not allow in-place operations as left argument.
+    """
+    a = _AHelper(scale_factor=0.5).comoving
+    with pytest.raises(TypeError, match="In-place operations with"):
+        a *= 1
+    with pytest.raises(TypeError, match="In-place operations with"):
+        a /= 1
+    with pytest.raises(TypeError, match="In-place operations with"):
+        a **= 1
+    with pytest.raises(
+        InvalidUnitOperation,
+        match="in-place operations with unit objects are not allowed",
+    ):
+        u.kpc *= a
+    x = 10
+    x *= a
+    assert isinstance(x, cosmo_quantity)
+    assert x.units == u.Unit("")
+    assert x.comoving
+    assert x.cosmo_factor == cosmo_factor.create(0.5, 1)
+    x = u.unyt_quantity(10, u.kpc)
+    x *= a
+    assert isinstance(x, cosmo_quantity)
+    assert x.units == u.kpc
+    assert x.comoving
+    assert x.cosmo_factor == cosmo_factor.create(0.5, 1)
+    x = cosmo_quantity(10, u.kpc, comoving=True, scale_factor=0.5, scale_exponent=1)
+    x *= a
+    assert isinstance(x, cosmo_quantity)
+    assert x.units == u.kpc
+    assert x.comoving
+    assert x.cosmo_factor == cosmo_factor.create(0.5, 2)
+    x = 10
+    x /= a
+    assert isinstance(x, cosmo_quantity)
+    assert x.units == u.Unit("")
+    assert x.comoving
+    assert x.cosmo_factor == cosmo_factor.create(0.5, -1)
+    x = u.unyt_quantity(10, u.kpc)
+    x /= a
+    assert isinstance(x, cosmo_quantity)
+    assert x.units == u.kpc
+    assert x.comoving
+    assert x.cosmo_factor == cosmo_factor.create(0.5, -1)
+    x = cosmo_quantity(10, u.kpc, comoving=True, scale_factor=0.5, scale_exponent=1)
+    x /= a
+    assert isinstance(x, cosmo_quantity)
+    assert x.units == u.kpc
+    assert x.comoving
+    assert x.cosmo_factor == cosmo_factor.create(0.5, 0)

--- a/tests/test_a_helper.py
+++ b/tests/test_a_helper.py
@@ -258,9 +258,9 @@ def test_comoving_or_physical_missing():
     """Test that failing to specify ``a.comoving`` or ``a.physical`` is an error."""
     scale_factor = 0.5
     a = _AHelper(scale_factor=scale_factor)
-    with pytest.raises(InvalidCosmoUnit, match="..."):
+    with pytest.raises(InvalidCosmoUnit, match="Cannot use scale factor helper as"):
         10 * u.Mpc * a
-    with pytest.raises(InvalidCosmoUnit, match="..."):
+    with pytest.raises(InvalidCosmoUnit, match="Cannot use scale factor helper as"):
         cosmo_quantity(10, u.Mpc, comoving=True, scale_factor=0.5, scale_exponent=1) * a
 
 
@@ -282,7 +282,7 @@ def test_metadata_attribute_not_backwards_compatible(
     some helpful backwards compatibility. See ``test_cosmo_factor_accepts_ahelper``.
     """
     m = mask(cosmological_volume_only_single_local)
-    with pytest.raises(InvalidCosmoUnit, match="..."):
+    with pytest.raises(InvalidCosmoUnit, match="Cannot use scale factor helper as"):
         10 * m.metadata.a * u.kpc
 
 
@@ -297,7 +297,7 @@ def test_cosmo_factor_accepts_ahelper(cosmological_volume_only_single_local):
     """
     m = mask(cosmological_volume_only_single_local)
     scale_exponent = 2  # pick a non-default case
-    with pytest.raises(InvalidCosmoUnit, match="..."):
+    with pytest.raises(InvalidCosmoUnit, match="Cannot use scale factor helper as"):
         # the __comoving attribute is supposed to be None so this should raise
         m.metadata.a._comoving
     cq = cosmo_quantity(
@@ -311,7 +311,7 @@ def test_cosmo_factor_accepts_ahelper(cosmological_volume_only_single_local):
     assert cq.cosmo_factor == cosmo_factor.create(
         m.metadata.scale_factor, scale_exponent
     )
-    with pytest.raises(InvalidCosmoUnit, match="..."):
+    with pytest.raises(InvalidCosmoUnit, match="Initialize cosmo_array"):
         cosmo_quantity(
             1,
             u.kpc**2,

--- a/tests/test_a_helper.py
+++ b/tests/test_a_helper.py
@@ -98,21 +98,26 @@ def test_multiply_cosmo_with_ahelper(
             scale_exponent if scale_exponent is not None else 1
         ) + int(in_com_or_phys)
         assert np.allclose(
-            cosmo.to_physical_value(u.Mpc), data * scale_factor**conversion_exponent
+            cosmo.to_physical_value(u.Mpc),
+            np.asarray(data) * scale_factor**conversion_exponent,
         )
     else:  # "physical"
         # just scale_factor**1 coming from converting cosmo_in to physical if it was
         # comoving, else scale_factor**0
         conversion_exponent = int(in_com_or_phys)
         assert np.allclose(
-            cosmo.to_physical_value(u.Mpc), data * scale_factor**conversion_exponent
+            cosmo.to_physical_value(u.Mpc),
+            np.asarray(data) * scale_factor**conversion_exponent,
         )
 
 
-@pytest.mark.parametrize("data", 10.0, np.array([1.0, 2.0]))
+@pytest.mark.parametrize("data", (10.0, np.array([1.0, 2.0])))
 @pytest.mark.parametrize("com_or_phys", ("comoving", "physical"))
 @pytest.mark.parametrize("scale_exponent", (1, None))
-def test_assign_comoving_or_physical_units_to_name(data, com_or_phys, scale_exponent):
+@pytest.mark.parametrize("order", ("a_unit", "unit_a"))
+def test_assign_comoving_or_physical_units_to_name(
+    data, com_or_phys, scale_exponent, order
+):
     """
     Test that we can make e.g. cMpc or pMpc units and then apply them to data.
 
@@ -123,7 +128,9 @@ def test_assign_comoving_or_physical_units_to_name(data, com_or_phys, scale_expo
     if scale_exponent is not None:
         a = a**scale_exponent
     # this is either a "cMpc" or "pMpc" depending on case, label "xMpc" here:
-    xMpc = u.Mpc * a
+    operands = {"a": a, "unit": u.Mpc}
+    first, second = [operands[i] for i in order.split("_")]
+    xMpc = first * second
     cosmo = data * xMpc
     if np.isscalar(data):
         assert isinstance(cosmo, cosmo_quantity)
@@ -216,3 +223,21 @@ def test_invalid_usage(data, scale_exponent, com_or_phys):
         data * a
     with pytest.raises(InvalidCosmoUnit, match="..."):
         a * data
+
+
+def test_comoving_or_physical_missing():
+    """Test that failing to specify ``a.comoving`` or ``a.physical`` is an error."""
+    with pytest.raises(InvalidCosmoUnit, match="..."):
+        # didn't specify comoving/physical, should error on use:
+        scale_factor = 0.5
+        a = _AHelper(scale_factor=scale_factor)
+        with pytest.raises(InvalidCosmoUnit, match="..."):
+            10 * u.Mpc * a
+        with pytest.raises(InvalidCosmoUnit, match="..."):
+            cosmo_quantity(
+                10, u.Mpc, comoving=True, scale_factor=0.5, scale_exponent=1
+            ) * a
+
+
+# also division, multiply-and-assign, divide-and-assign?
+# disallow (a**2).comoving? no reason it shouldn't work but just seems confusing

--- a/tests/test_a_helper.py
+++ b/tests/test_a_helper.py
@@ -263,6 +263,3 @@ def test_cosmo_factor_accepts_ahelper(cosmological_volume_only_single_local):
             scale_factor=m.metadata.a.comoving,  # can't use it like this
             scale_exponent=scale_exponent,
         )
-
-
-# also test division, multiply-and-assign, divide-and-assign

--- a/tests/test_a_helper.py
+++ b/tests/test_a_helper.py
@@ -4,18 +4,16 @@ import pytest
 import numpy as np
 import unyt as u
 from swiftsimio import mask, cosmo_array, cosmo_quantity
-from swiftsimio.objects import _AHelper
+from swiftsimio.objects import _AHelper, InvalidCosmoUnit
 
 
 @pytest.mark.parametrize("scale_exponent", (-1, 0, 1, 2, None))
-@pytest.mark.parametrize("data", (10, np.array([1, 2]), [1, 2], (1, 2)))
+@pytest.mark.parametrize("data", (10.0, np.array([1.0, 2.0]), [1.0, 2.0], (1.0, 2.0)))
 @pytest.mark.parametrize(
     "order",
     (
         "data_units_a",
         "data_a_units",
-        "a_data_units",
-        "units_data_a",
         "units_a_data",
         "a_units_data",
     ),
@@ -34,11 +32,7 @@ def test_multiply_unyt_with_ahelper(scale_exponent, data, order, com_or_phys):
     a = getattr(_AHelper(scale_factor=scale_factor), com_or_phys)
     if scale_exponent is not None:
         a = a**scale_exponent
-    operands = {
-        "a": a,
-        "units": u.Mpc,
-        "data": data,
-    }
+    operands = {"a": a, "units": u.Mpc, "data": data}
     first, second, third = [operands[i] for i in order.split("_")]
     cosmo = first * second * third
     if np.isscalar(data):
@@ -49,19 +43,73 @@ def test_multiply_unyt_with_ahelper(scale_exponent, data, order, com_or_phys):
     if com_or_phys == "comoving":
         assert cosmo.comoving
     else:
-        assert (
-            cosmo.comoving is False
-        )  # don't assert not cosmo.comoving in case is None
+        assert cosmo.comoving is False  # avoid `not cosmo.comoving` in case is None
     assert cosmo.units == u.Mpc
-    assert cosmo.cosmo_factor.a_factor == scale_factor**scale_exponent
+    assert scale_factor != 1  # else trivial
+    if scale_exponent is not None:
+        assert cosmo.cosmo_factor.a_factor == scale_factor**scale_exponent
+    else:
+        assert cosmo.cosmo_factor.a_factor == scale_factor
 
 
-def test_multiply_cosmo_with_ahelper():
+@pytest.mark.parametrize("scale_exponent", (-1, 0, 1, 2, None))
+@pytest.mark.parametrize("data", (10.0, np.array([1.0, 2.0]), [1.0, 2.0], (1.0, 2.0)))
+@pytest.mark.parametrize(
+    "order",
+    ("data_a", "a_data"),
+)
+@pytest.mark.parametrize("com_or_phys", ("comoving", "physical"))
+@pytest.mark.parametrize("in_com_or_phys", (True, False))
+def test_multiply_cosmo_with_ahelper(
+    scale_exponent, data, order, com_or_phys, in_com_or_phys
+):
     """Test that multiplying an already-cosmo object modifies the `cosmo_factor`."""
-    raise NotImplementedError
+    scale_factor = 0.5
+    a = getattr(_AHelper(scale_factor=scale_factor), com_or_phys)
+    if scale_exponent is not None:
+        a = a**scale_exponent
+    cosmo_in = (cosmo_quantity if np.isscalar(data) else cosmo_array)(
+        data,
+        u.Mpc,
+        comoving=in_com_or_phys,
+        scale_factor=scale_factor,
+        scale_exponent=1,
+    )
+    operands = {"a": a, "data": cosmo_in}
+    first, second = [operands[i] for i in order.split("_")]
+    cosmo = first * second
+    if np.isscalar(data):
+        assert isinstance(cosmo, cosmo_quantity)
+    else:
+        # careful, cosmo_quantity is a subclass and therefore counts as a cosmo_array
+        assert isinstance(cosmo, cosmo_array) and not isinstance(cosmo, cosmo_quantity)
+    if com_or_phys == "comoving":
+        assert cosmo.comoving
+    else:
+        assert cosmo.comoving is False  # avoid `not cosmo.comoving` in case is None
+    assert cosmo.units == u.Mpc
+    assert scale_factor != 1  # else trivial
+    expected_exponent = scale_exponent + 1 if scale_exponent is not None else 2
+    assert cosmo.cosmo_factor.a_factor == scale_factor**expected_exponent
+    if com_or_phys == "comoving":
+        # scale_factor**(scale_exponent) from the helper, plus another scale_factor**1
+        # from cosmo_in if it was comoving, all needed to convert to physical
+        conversion_exponent = (
+            scale_exponent if scale_exponent is not None else 1
+        ) + int(in_com_or_phys)
+        assert np.allclose(
+            cosmo.to_physical_value(u.Mpc), data * scale_factor**conversion_exponent
+        )
+    else:  # "physical"
+        # just scale_factor**1 coming from converting cosmo_in to physical if it was
+        # comoving, else scale_factor**0
+        conversion_exponent = int(in_com_or_phys)
+        assert np.allclose(
+            cosmo.to_physical_value(u.Mpc), data * scale_factor**conversion_exponent
+        )
 
 
-@pytest.mark.parametrize("data", 10, np.array([1, 2]))
+@pytest.mark.parametrize("data", 10.0, np.array([1.0, 2.0]))
 @pytest.mark.parametrize("com_or_phys", ("comoving", "physical"))
 @pytest.mark.parametrize("scale_exponent", (1, None))
 def test_assign_comoving_or_physical_units_to_name(data, com_or_phys, scale_exponent):
@@ -71,10 +119,10 @@ def test_assign_comoving_or_physical_units_to_name(data, com_or_phys, scale_expo
     This is a documented feature so should make sure that it works.
     """
     scale_factor = 0.5
-    # this is either a "cMpc" or "pMpc" depending on case, label "xMpc" here:
     a = getattr(_AHelper(scale_factor=scale_factor), com_or_phys)
     if scale_exponent is not None:
         a = a**scale_exponent
+    # this is either a "cMpc" or "pMpc" depending on case, label "xMpc" here:
     xMpc = u.Mpc * a
     cosmo = data * xMpc
     if np.isscalar(data):
@@ -105,9 +153,9 @@ def test_helper_available_from_metadata(cosmological_volume_only_single_local):
     a = mask.metadata.a
     scale_factor = mask.metadata.scale_factor
     region = [
-        [1 * u.Mpc * a.comoving, 2 * u.Mpc * a.comoving],
-        [1 * u.Mpc * a.physical, 2 * u.Mpc * a.physical],
-        [1 * u.Mpc * a.comoving**1, 2 * u.Mpc * a.comoving**1],
+        [1.0 * u.Mpc * a.comoving, 2.0 * u.Mpc * a.comoving],
+        [1.0 * u.Mpc * a.physical, 2.0 * u.Mpc * a.physical],
+        [1.0 * u.Mpc * a.comoving**1, 2.0 * u.Mpc * a.comoving**1],
     ]
     manual_region = [
         [
@@ -143,10 +191,28 @@ def test_helper_available_from_metadata(cosmological_volume_only_single_local):
     m.constrain_spatial(region)
 
 
-def test_incorrect_usage():
-    """Should also test expected failure modes..."""
-    # `10 * a.comoving` should error, for example.
-    # That `10 * a.comoving * u.Mpc` works and `10 * u.Mpc * a.comoving` also works
-    # will rely on triggering `__multiply__` or `__rmultiply__` accordingly. Units but
-    # no data yet is allowed to enable `cMpc = ...`, but we should not be able to end up
-    # with data but no units.
+@pytest.mark.parametrize("data", (10, np.array([0, 1])))
+@pytest.mark.parametrize("scale_exponent", (-1, 0, 1, 2, None))
+@pytest.mark.parametrize("com_or_phys", ("comoving", "physical"))
+def test_invalid_usage(data, scale_exponent, com_or_phys):
+    """
+    Test expected failure modes.
+
+    Because multiplications are left-to-right associative we need to be able to resolve
+    each pair-wise multiplication, and we have no mechanism to handle e.g.
+    ``scalar * a_helper``. This means that the units and helper must be adjacent in the
+    order of operations (though we can tolerate swapping them places), so
+    ``units * data * a_helper`` and ``a_helper * data * units`` are also invalid.
+    """
+    scale_factor = 0.5
+    a = getattr(_AHelper(scale_factor=scale_factor), com_or_phys)
+    if scale_exponent is not None:
+        a = a**scale_exponent
+    with pytest.raises(InvalidCosmoUnit, match="..."):
+        a * data * u.Mpc
+    with pytest.raises(InvalidCosmoUnit, match="..."):
+        u.Mpc * data * a
+    with pytest.raises(InvalidCosmoUnit, match="..."):
+        data * a
+    with pytest.raises(InvalidCosmoUnit, match="..."):
+        a * data

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -24,8 +24,11 @@ def test_cosmology_metadata(cosmological_volume):
     """Test to see if we get the unpacked cosmology metadata correct."""
     data = load(cosmological_volume)
 
-    assert data.metadata.a == data.metadata.scale_factor
-    assert np.isclose(data.metadata.a, 1.0 / (1.0 + data.metadata.redshift), atol=1e-8)
+    # data.metadata.a is our helper for easier initialization of cosmo_arrays:
+    assert data.metadata.a._scale_factor == data.metadata.scale_factor
+    assert np.isclose(
+        data.metadata.scale_factor, 1.0 / (1.0 + data.metadata.redshift), atol=1e-8
+    )
 
     return
 

--- a/tests/test_physical_conversion.py
+++ b/tests/test_physical_conversion.py
@@ -11,13 +11,13 @@ def test_convert(cosmological_volume_only_single):
     coords = data.gas.coordinates
     units = u.kpc
     assert units != coords.units  # ensure we make a non-trivial conversion
-    assert data.metadata.a != 1.0  # ensure we make a non-trivial conversion
+    assert data.metadata.scale_factor != 1.0  # ensure we make a non-trivial conversion
     coords_physical = coords.to_physical()
 
     # allclose applied to cosmo_array's is aware of physical & comoving
     # make sure to compare bare arrays:
     assert np.allclose(
-        coords.to_value(units) * data.metadata.a,
+        coords.to_value(units) * data.metadata.scale_factor,
         coords_physical.to_value(units),
         rtol=1e-6,
     )
@@ -30,12 +30,16 @@ def test_convert_to_value(cosmological_volume_only_single):
     coords = data.gas.coordinates
     units = u.kpc
     assert units != coords.units  # ensure we make a non-trivial conversion
-    assert data.metadata.a != 1.0  # ensure we make a non-trivial conversion
+    assert data.metadata.scale_factor != 1.0  # ensure we make a non-trivial conversion
     coords_physical_values = coords.to_physical_value(units)
     coords_comoving_values = coords.to_comoving_value(units)
-    print(coords_physical_values / (coords_comoving_values * data.metadata.a))
+    print(
+        coords_physical_values / (coords_comoving_values * data.metadata.scale_factor)
+    )
     assert np.allclose(
-        coords_physical_values, coords_comoving_values * data.metadata.a, rtol=1e-6
+        coords_physical_values,
+        coords_comoving_values * data.metadata.scale_factor,
+        rtol=1e-6,
     )
 
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -31,7 +31,7 @@ def test_scale_factor_written(simple_snapshot_data):
     w.write(testfile)
     dat = load(testfile)
     assert w.scale_factor != 1.0  # make sure it's not just a default value
-    assert dat.metadata.a == w.scale_factor
+    assert dat.metadata.scale_factor == w.scale_factor
 
 
 def test_write_non_required_field(simple_writer):


### PR DESCRIPTION
As discussed in #297 this PR adds a new helper to make initialising `cosmo_array` and `cosmo_quantity` objects easier. It's assigned to the name `dat.metadata.a`, with the bare scale factor still available as `dat.metadata.scale_factor`. The basic usage is what we converged on in discussion, e.g.
```python
m = mask("dat.hdf5")
acom = m.metadata.a.comoving  # or whatever name you want
region = [[10 * acom * u.Mpc, 20 * acom * u.Mpc], None, None]
m.constrain_spatial(region)
```
To avoid bugs in migrating to the new system, trying to use `dat.metadata.a` as if it was still a `float` will raise an error:
```python
10 * dat.metadata.a * u.Mpc  # raises
```
This is achieved by ensuring that either `dat.metadata.a.comoving` or `dat.metadata.a.physical` has been used. The documentation will encourage people to assign to a short alias.

The one exception is that through a little clever trick the `cosmo_array` and `cosmo_quantity` (and `cosmo_factor`) constructors are backwards compatible, this still works:
```python
cosmo_quantity(1, u.Mpc, comoving=True, scale_factor=dat.metadata.a, scale_exponent=1)
```
That will hopefully help not completely break all existing scripts on upgrading `swiftsimio`.

Still to do:
- [x] Fill out error messages.
- [x] Fill out/check docstrings.
- [x] Write & update narrative docs.
- [x] Add some more tests, I haven't covered division yet.
- [x]  `*=`, `/=`, `**=` should be tested. Don't want to implement with helper as left argument, that seems dangerous/confusing (shouldn't mutate the helper attached to the metadata!), as right argument it should already work through `__rmul__`. 
- [x] Check if there is any orphaned logic in the `_AHelper` class, coverage analysis should help with this. I'm not totally sure that all of the methods are actually used & therefore needed, `numpy` is a bit cagey with redirecting things into `__array_ufunc__`.
- [ ] Also attach helper to `data.a`, in addition to `data.metadata.a`.
- [ ] This requires changes on the `unyt` that completely block us when a `unyt.Unit` or `unyt.unyt_array` is the left-hand argument, unfortunately. Tracking https://github.com/yt-project/unyt/pull/640 & https://github.com/yt-project/unyt/pull/674. This branch currently set to test with my branch of unyt, that needs reverting if/when those PRs are merged.