### PR TITLE
Easy cloning of `cosmo_array` attributes with `like` kwarg

### DIFF
--- a/docs/source/cosmo_array/index.rst
+++ b/docs/source/cosmo_array/index.rst
@@ -21,8 +21,8 @@ The cosmology information is stored in three attributes:
  + ``cosmo_factor``
  + ``valid_transform``
 
-The ``comoving`` attribute specifies whether the array is a physical (``True``) or
-comoving (``False``) quantity, while the ``cosmo_factor`` stores the expression needed
+The ``comoving`` attribute specifies whether the array is a physical (``False``) or
+comoving (``True``) quantity, while the ``cosmo_factor`` stores the expression needed
 to convert back and forth between comoving and physical quantities and the value of
 the scale factor. The conversion factors can be accessed like this:
 
@@ -122,6 +122,24 @@ class, it is helpful to know how to create your own. A good template for this lo
    # with:
    # scale_factor=data.metadata.a
 
+This can be tedious to write out, but often a new array with the same units, ``comoving``,
+and scale factor & exponent as an existing :class:`~swiftsimio.objects.cosmo_array` is
+wanted. All of the main :mod:`numpy` array creation functions such as :func:`numpy.array`,
+:func:`numpy.asarray` and several others accept a keyword argument called ``like``. Using
+this with a :class:`~swiftsimio.objects.cosmo_array` will copy over all of the metadata
+but use the new values provided, for example:
+
+.. code-block:: python
+
+   my_new_cosmo_array = np.asarray(
+      [4, 5, 6],
+      like=my_cosmo_array,
+   )
+   # has units of u.Mpc, comoving=True, scale_factor=0.5, scale_exponent=1
+
+Keep in mind that :func:`numpy.asarray` tries to avoid copying the input data when
+possible while :func:`numpy.array` usually makes a copy with a corresponding memory cost.
+
 There is also a very similar :class:`~swiftsimio.objects.cosmo_quantity` class designed
 for scalar values, analogous to the :class:`~unyt.array.unyt_quantity`. You may encounter
 this being returned by :mod:`numpy` functions. Cosmology-aware scalar values can be
@@ -139,4 +157,6 @@ initialized similarly:
        scale_factor=0.5,
        scale_exponent=1,
    )
+   # or:
+   my_cosmo_quantity = np.array(2, like=my_cosmo_array)
 

--- a/docs/source/loading_data/index.rst
+++ b/docs/source/loading_data/index.rst
@@ -66,7 +66,7 @@ our simulation:
 
    print(boxsize)
 
-This will output ``[142.24751067 142.24751067 142.24751067] Mpc`` - note
+This will output ``[142.24751067 142.24751067 142.24751067] Mpc (Comoving)`` - note
 the units that are attached. These units being attached to everything is one
 of the key advantages of using :mod:`swiftsimio`. It is really easy to convert
 between units; for instance if we want that box-size in kiloparsecs,
@@ -97,8 +97,8 @@ can find more information about :mod:`unyt` on the `unyt documentation website`_
 .. _`unyt documentation website`: https://unyt.readthedocs.io/en/stable/
 
 There is lots of metadata available through this object; the best way to see
-this is by exploring the object using ``dir()`` in an interactive shell, but
-as a summary:
+this is by exploring the object using ``dir()`` or tab completion in an
+interactive shell, but as a summary:
 
 + All metadata from the snapshot is available through many variables, for example
   the ``meta.hydro_scheme`` property.
@@ -211,7 +211,7 @@ masses per cubic megaparsec,
 
 .. code-block:: python
 
-   new_density_units = unyt.Solar_Mass / unyt.Mpc**3
+   new_density_units = unyt.solMass / unyt.Mpc**3
 
    rho_gas.convert_to_units(new_density_units)
 
@@ -275,11 +275,6 @@ in SWIFT will be automatically read.
 Reading from an open file
 -------------------------
 
-:mod:`swiftsimio` normally opens and closes the HDF5 snapshot file for
-each operation. This is convenient for interactive use and avoids
-leaving files open for long periods of time, but sometimes it might be
-desirable to minimize the number of file open and close operations.
-
 It is possible to pass an open :obj:`h5py.File` object to
 :mod:`swiftsimio.load` and :mod:`swiftsimio.mask` in place of the
 filename. In this case swiftsimio will do all file access through the
@@ -321,7 +316,10 @@ snapshots with:
    import hdfstream
    from swiftsimio import load
 
-   snap_file = hdfstream.open("cosma", "Tests/SWIFT/IOExamples/ssio_ci_04_2025/EagleSingle.hdf5")
+   snap_file = hdfstream.open(
+       "cosma",
+       "Tests/SWIFT/IOExamples/ssio_ci_04_2025/EagleSingle.hdf5"
+   )
    data = load(snap_file)
 
 Here, ``data`` will be a :obj:`swiftsimio.reader.SWIFTDataset`. It
@@ -350,7 +348,10 @@ place of the filename.
    import hdfstream
    import swiftsimio as sw
 
-   snap_file = hdfstream.open("cosma", "Tests/SWIFT/IOExamples/ssio_ci_04_2025/EagleSingle.hdf5")
+   snap_file = hdfstream.open(
+       "cosma",
+       "Tests/SWIFT/IOExamples/ssio_ci_04_2025/EagleSingle.hdf5"
+   )
 
    mask = sw.mask(snap_file)
    # The full metadata object is available from within the mask

--- a/docs/source/masking/index.rst
+++ b/docs/source/masking/index.rst
@@ -88,11 +88,9 @@ constraint should be imposed along that axis. For example, to select a 1 Mpc thi
 
 .. code-block:: python
 
-   import unyt as u
    slab_mask = sw.mask(filename)
-   scale_factor = slab_mask.metadata.scale_factor
    slab_region = [
-       cosmo_array([1, 2], u.Mpc, comoving=True, scale_factor=scale_factor, scale_exponent=1),
+       np.array([1, 2], like=slab_mask.metadata.boxsize),  # copies units, etc.
        None,
        None,
    ]
@@ -245,15 +243,16 @@ particles within a chosen density window.
    # This creates and sets up the masking object.
    mask = sw.mask("cosmological_volume.hdf5")
 
-   # This ahead-of-time creates a spatial mask based on the cell metadata.
+   # This creates a 1x1x1 Mpc spatial mask based on the cell metadata.
    mask.constrain_spatial(
        np.array(
            [
-               [0.2, 0.7],
-               [0.0, 1.0],
-               [0.0, 1.0],
-           ]
-       ) * mask.metadata.boxsize[:, np.newaxis]
+               [1.0, 2.0],
+               [1.0, 2.0],
+               [1.0, 2.0],
+           ],
+           like=mask.metadata.boxsize,  # copies units, comoving, etc.
+       )
    )
 
    # Now we also constrain the density between

--- a/docs/source/soap/index.rst
+++ b/docs/source/soap/index.rst
@@ -20,12 +20,12 @@ You can load SOAP files as follows:
 
    print(catalogue.spherical_overdensity_200_mean.total_mass)
 
-   # >>> [
-   #        591.      328.5     361.      553.      530.      507.      795.
-   #        574.      489.5     233.75      0.     1406.      367.5    2308.
-   #        ...
-   #        0.      534.        0.      191.75   1450.      600.      290.
-   #     ] 10000000000.0*Msun (Physical)
+   # [
+   #    591.      328.5     361.      553.      530.      507.      795.
+   #    574.      489.5     233.75      0.     1406.      367.5    2308.
+   #    ...
+   #    0.      534.        0.      191.75   1450.      600.      290.
+   # ] 10000000000.0*Msun (Physical)
 
 What's going on here? Under the hood, ``swiftsimio`` has a discrimination function
 between different metadata types, based upon a property stored in the HDF5 file,

--- a/docs/source/visualisation/slice.rst
+++ b/docs/source/visualisation/slice.rst
@@ -163,7 +163,7 @@ approach to rotations applied to the above example is shown below.
 
    # Specify the rotation parameters
    center = 0.5 * data.metadata.boxsize
-   rotate_vec = [0.5,0.5,1]
+   rotate_vec = [0.5, 0.5, 1]
    matrix = rotation_matrix_from_vector(rotate_vec, axis='z')
 
    # Map in msun / mpc^3

--- a/swiftsimio/_array_functions.py
+++ b/swiftsimio/_array_functions.py
@@ -2318,40 +2318,40 @@ def meshgrid(*xi, **kwargs):  # noqa numpydoc ignore=GL08
     )
 
 
-@implements(np.array)
-def array(  # noqa: ANN202
-    object,  # noqa: ANN001
-    dtype=None,  # noqa: ANN001
-    *,
-    copy=None,  # noqa: ANN001
-    order="K",  # noqa: ANN001
-    subok=False,  # noqa: ANN001
-    ndmin=0,  # noqa: ANN001
-    like=None,  # noqa: ANN001
-):  # noqa numpydoc ignore=GL08
-    arr = np.array(
-        object, dtype=dtype, copy=copy, order=order, subok=subok, ndmin=ndmin
-    )
-    cosmo = arr.view(
-        objects.cosmo_quantity if np.isscalar(arr) else objects.cosmo_array
-    )
-    _copy_cosmo_array_attributes_if_present(like, cosmo, copy_units=True)
-    return cosmo
+def _array_like_wrapper(func: Callable) -> Callable:
+
+    def wrapper(
+        *args: tuple[Any], like: "objects.cosmo_array" = None, **kwargs: dict[str, Any]
+    ) -> Callable:
+        arr = func(*args, **kwargs)
+        cosmo = arr.view(
+            objects.cosmo_quantity if arr.ndim == 0 else objects.cosmo_array
+        )
+        _copy_cosmo_array_attributes_if_present(like, cosmo, copy_units=True)
+        return cosmo
+
+    return wrapper
 
 
-@implements(np.asarray)
-def asarray(  # noqa: ANN202
-    a,  # noqa: ANN001
-    dtype=None,  # noqa: ANN001
-    order=None,  # noqa: ANN001
-    *,
-    device=None,  # noqa: ANN001
-    copy=None,  # noqa: ANN001
-    like=None,  # noqa: ANN001
-):  # noqa numpydoc ignore=GL08
-    arr = np.asarray(a, dtype=dtype, order=order, device=device, copy=copy)
-    cosmo = arr.view(
-        objects.cosmo_quantity if np.isscalar(arr) else objects.cosmo_array
-    )
-    _copy_cosmo_array_attributes_if_present(like, cosmo, copy_units=True)
-    return cosmo
+# wrap array creation functions that take a `like` kwarg
+implements(np.arange)(_array_like_wrapper(np.arange))
+implements(np.empty)(_array_like_wrapper(np.empty))
+implements(np.ones)(_array_like_wrapper(np.ones))
+implements(np.zeros)(_array_like_wrapper(np.zeros))
+implements(np.full)(_array_like_wrapper(np.full))
+implements(np.array)(_array_like_wrapper(np.array))
+implements(np.asarray)(_array_like_wrapper(np.asarray))
+implements(np.asanyarray)(_array_like_wrapper(np.asanyarray))
+implements(np.ascontiguousarray)(_array_like_wrapper(np.ascontiguousarray))
+implements(np.asfortranarray)(_array_like_wrapper(np.asfortranarray))
+implements(np.require)(_array_like_wrapper(np.require))
+implements(np.fromfunction)(_array_like_wrapper(np.fromfunction))
+implements(np.fromstring)(_array_like_wrapper(np.fromstring))
+implements(np.fromiter)(_array_like_wrapper(np.fromiter))
+implements(np.fromfile)(_array_like_wrapper(np.fromfile))
+implements(np.frombuffer)(_array_like_wrapper(np.frombuffer))
+implements(np.identity)(_array_like_wrapper(np.identity))
+implements(np.loadtxt)(_array_like_wrapper(np.loadtxt))
+implements(np.genfromtxt)(_array_like_wrapper(np.genfromtxt))
+implements(np.eye)(_array_like_wrapper(np.eye))
+implements(np.tri)(_array_like_wrapper(np.tri))

--- a/swiftsimio/_array_functions.py
+++ b/swiftsimio/_array_functions.py
@@ -1272,6 +1272,59 @@ def _default_oplist_wrapper(unyt_func: Callable) -> Callable:
     return wrapper
 
 
+def _array_like_wrapper(func: Callable) -> Callable:
+    """
+    Wrap functions accepting a ``like`` kwarg.
+
+    Several :mod:`numpy` functions allow passing a ``like`` kwarg that can be used to
+    copy attributes or otherwise handle properties from a subclass when a new array is
+    created. This wrapper lets us implement these functions easily.
+
+    Can be used as a decorator.
+
+    Parameters
+    ----------
+    func : Callable
+        The :mod:`numpy` function to be wrapped.
+
+    Returns
+    -------
+    Callable
+        The wrapped function.
+    """
+
+    def wrapper(
+        *args: tuple[Any], like: "objects.cosmo_array" = None, **kwargs: dict[str, Any]
+    ) -> Callable:
+        """
+        Create the new array, view it as a cosmo array or quantity, and attach attributes.
+
+        Parameters
+        ----------
+        *args : tuple[Any]
+            Arbitrary arguments of the wrapped function.
+
+        like : ~swiftsimio.objects.cosmo_array
+            The array that attributes are copied from.
+
+        **kwargs : dict[str, Any]
+            Arbitrary kwargs of the wrapped function.
+
+        Returns
+        -------
+        Callable
+            The wrapped function.
+        """
+        arr = func(*args, **kwargs)
+        cosmo = arr.view(
+            objects.cosmo_quantity if arr.ndim == 0 else objects.cosmo_array
+        )
+        _copy_cosmo_array_attributes_if_present(like, cosmo, copy_units=True)
+        return cosmo
+
+    return wrapper
+
+
 # Next we wrap functions from unyt and numpy. There's not much point in writing docstrings
 # or type hints for all of these.
 
@@ -2316,21 +2369,6 @@ def meshgrid(*xi, **kwargs):  # noqa numpydoc ignore=GL08
     return tuple(
         _copy_cosmo_array_attributes_if_present(x, r) for (x, r) in zip(xi, res)
     )
-
-
-def _array_like_wrapper(func: Callable) -> Callable:
-
-    def wrapper(
-        *args: tuple[Any], like: "objects.cosmo_array" = None, **kwargs: dict[str, Any]
-    ) -> Callable:
-        arr = func(*args, **kwargs)
-        cosmo = arr.view(
-            objects.cosmo_quantity if arr.ndim == 0 else objects.cosmo_array
-        )
-        _copy_cosmo_array_attributes_if_present(like, cosmo, copy_units=True)
-        return cosmo
-
-    return wrapper
 
 
 # wrap array creation functions that take a `like` kwarg

--- a/swiftsimio/_array_functions.py
+++ b/swiftsimio/_array_functions.py
@@ -287,9 +287,7 @@ def _ensure_result_is_cosmo_array_or_quantity(func: Callable) -> Callable:
         The wrapped function.
     """
 
-    def wrapped(
-        *args: tuple[Any], **kwargs: dict[str, Any]
-    ) -> object:  # # noqa numpydoc ignore=GL08
+    def wrapped(*args: tuple[Any], **kwargs: dict[str, Any]) -> object:  # noqa numpydoc ignore=GL08
         # omit docstring so that sphinx picks up docstring of wrapped function
         result = func(*args, **kwargs)
         if isinstance(result, tuple):
@@ -2318,3 +2316,42 @@ def meshgrid(*xi, **kwargs):  # noqa numpydoc ignore=GL08
     return tuple(
         _copy_cosmo_array_attributes_if_present(x, r) for (x, r) in zip(xi, res)
     )
+
+
+@implements(np.array)
+def array(  # noqa: ANN202
+    object,  # noqa: ANN001
+    dtype=None,  # noqa: ANN001
+    *,
+    copy=None,  # noqa: ANN001
+    order="K",  # noqa: ANN001
+    subok=False,  # noqa: ANN001
+    ndmin=0,  # noqa: ANN001
+    like=None,  # noqa: ANN001
+):  # noqa numpydoc ignore=GL08
+    arr = np.array(
+        object, dtype=dtype, copy=copy, order=order, subok=subok, ndmin=ndmin
+    )
+    cosmo = arr.view(
+        objects.cosmo_quantity if np.isscalar(arr) else objects.cosmo_array
+    )
+    _copy_cosmo_array_attributes_if_present(like, cosmo, copy_units=True)
+    return cosmo
+
+
+@implements(np.asarray)
+def asarray(  # noqa: ANN202
+    a,  # noqa: ANN001
+    dtype=None,  # noqa: ANN001
+    order=None,  # noqa: ANN001
+    *,
+    device=None,  # noqa: ANN001
+    copy=None,  # noqa: ANN001
+    like=None,  # noqa: ANN001
+):  # noqa numpydoc ignore=GL08
+    arr = np.asarray(a, dtype=dtype, order=order, device=device, copy=copy)
+    cosmo = arr.view(
+        objects.cosmo_quantity if np.isscalar(arr) else objects.cosmo_array
+    )
+    _copy_cosmo_array_attributes_if_present(like, cosmo, copy_units=True)
+    return cosmo

--- a/swiftsimio/masks.py
+++ b/swiftsimio/masks.py
@@ -573,6 +573,7 @@ class SWIFTMask(HandleProvider):
 
             .. code-block:: python
 
+                m = mask(data_file)
                 restrict = cosmo_array(
                     [
                         [0.5, 0.7],
@@ -581,8 +582,17 @@ class SWIFTMask(HandleProvider):
                     ],
                     u.Mpc,
                     comoving=True,
-                    scale_factor=1.0,
+                    scale_factor=m.metadata.scale_factor,
                     scale_exponent=1,
+                )
+                # or, equivalent:
+                restrict = np.array(
+                    [
+                        [0.5, 0.7],
+                        [0.1, 0.9],
+                        [0.0, 0.1]
+                    ],
+                    like=m.metadata.boxsize,  # copies units, comoving, etc.
                 )
 
         Returns
@@ -769,6 +779,15 @@ class SWIFTMask(HandleProvider):
                     comoving=True,
                     scale_factor=1.0,
                     scale_exponent=1,
+                )
+                # or, equivalent:
+                restrict = np.array(
+                    [
+                        [0.5, 0.7],
+                        [0.1, 0.9],
+                        [0.0, 0.1]
+                    ],
+                    like=m.metadata.boxsize,  # copies units, comoving, etc.
                 )
 
             If no constraint is desired along an axis, ``None`` can be given instead. For

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -11,6 +11,7 @@ helpers, wrappers and implementations that enable most :mod:`numpy` and
 :mod:`unyt` functions to work with our cosmology-aware arrays.
 """
 
+import inspect
 import unyt
 from unyt import unyt_array, unyt_quantity, Unit
 from unyt.array import multiple_output_operators, _iterable, POWER_MAPPING
@@ -2306,6 +2307,11 @@ class cosmo_array(unyt_array):
         else:
             # default to numpy's private implementation
             function_to_invoke = func._implementation
+        # check if the function has a "like" argument and if so pass self (which is where
+        # numpy puts the `like` argument that it received when dispatching to us) along
+        # as the like argument
+        if "like" in inspect.getfullargspec(function_to_invoke).kwonlyargs:
+            kwargs["like"] = self
         return function_to_invoke(*args, **kwargs)
 
     def __mul__(

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -279,6 +279,12 @@ class cosmo_factor(object):
         from swiftsimio.objects import a  # the scale factor (a sympy symbol object)
         density_cosmo_factor = cosmo_factor(a**3, scale_factor=0.97)
 
+    Or equivalently, but avoiding the extra import, with the ``create`` classmethod:
+
+    .. code-block:: python
+
+        density_cosmo_factor = cosmo_factor.create(0.97, 3)
+
     :class:`~swiftsimio.objects.cosmo_factor` supports arithmetic, for example:
 
     .. code-block:: python
@@ -1903,7 +1909,7 @@ class cosmo_array(unyt_array):
 
         Examples
         --------
-        ::
+        .. code-block:: python
 
             >>> from astropy.units import kpc
             >>> cosmo_array.from_astropy([1, 2, 3] * kpc)

--- a/swiftsimio/objects.py
+++ b/swiftsimio/objects.py
@@ -2310,8 +2310,12 @@ class cosmo_array(unyt_array):
         # check if the function has a "like" argument and if so pass self (which is where
         # numpy puts the `like` argument that it received when dispatching to us) along
         # as the like argument
-        if "like" in inspect.getfullargspec(function_to_invoke).kwonlyargs:
-            kwargs["like"] = self
+        try:
+            if "like" in inspect.getfullargspec(function_to_invoke).kwonlyargs:
+                kwargs["like"] = self
+        except TypeError:
+            # e.g. unyt raises if function_to_invoke is cumprod
+            pass
         return function_to_invoke(*args, **kwargs)
 
     def __mul__(

--- a/tests/test_cosmo_array.py
+++ b/tests/test_cosmo_array.py
@@ -1,6 +1,7 @@
 """Tests the initialisation of a cosmo_array."""
 
 from typing import Callable
+from io import StringIO
 import pytest
 import os
 import warnings
@@ -1385,6 +1386,7 @@ class TestArrayCreation:
             np.asanyarray,
             np.ascontiguousarray,
             np.asfortranarray,
+            np.require,
         ),
     )
     @pytest.mark.parametrize("inp", (1.0, [1.0]))
@@ -1454,6 +1456,191 @@ class TestArrayCreation:
         assert cosmo_out.valid_transform == cosmo_in.valid_transform
         assert cosmo_out.compression == cosmo_in.compression
 
+    def test_fromstring(self):
+        """
+        Test the fromstring function.
 
-# TODO:
-# require, fromfunction, fromstring, fromiter, fromfile, frombuffer, loadtxt genfromtxt
+        Attributes are copied from the `like` kwarg.
+        """
+        cosmo_in = cosmo_array(
+            [0],
+            u.Mpc,
+            comoving=False,
+            scale_factor=0.5,
+            scale_exponent=1,
+            valid_transform=False,
+            compression="testing",
+        )
+        cosmo_out = np.fromstring("1 2", dtype=int, sep=" ", like=cosmo_in)
+        assert isinstance(cosmo_out, cosmo_array) and not isinstance(
+            cosmo_out, cosmo_quantity
+        )
+        assert cosmo_out.units == cosmo_in.units
+        assert cosmo_out.comoving == cosmo_in.comoving
+        assert cosmo_out.cosmo_factor == cosmo_in.cosmo_factor
+        assert cosmo_out.valid_transform == cosmo_in.valid_transform
+        assert cosmo_out.compression == cosmo_in.compression
+
+    def test_fromiter(self):
+        """
+        Test the fromiter function.
+
+        Attributes are copied from the `like` kwarg.
+        """
+        cosmo_in = cosmo_array(
+            [0],
+            u.Mpc,
+            comoving=False,
+            scale_factor=0.5,
+            scale_exponent=1,
+            valid_transform=False,
+            compression="testing",
+        )
+        iterable = (x for x in range(3))
+        cosmo_out = np.fromiter(iterable, float, like=cosmo_in)
+        assert isinstance(cosmo_out, cosmo_array) and not isinstance(
+            cosmo_out, cosmo_quantity
+        )
+        assert cosmo_out.units == cosmo_in.units
+        assert cosmo_out.comoving == cosmo_in.comoving
+        assert cosmo_out.cosmo_factor == cosmo_in.cosmo_factor
+        assert cosmo_out.valid_transform == cosmo_in.valid_transform
+        assert cosmo_out.compression == cosmo_in.compression
+
+    def test_fromfunction(self):
+        """
+        Test the fromfunction function.
+
+        Attributes are copied from the `like` kwarg.
+        """
+        cosmo_in = cosmo_array(
+            [0],
+            u.Mpc,
+            comoving=False,
+            scale_factor=0.5,
+            scale_exponent=1,
+            valid_transform=False,
+            compression="testing",
+        )
+        cosmo_out = np.fromfunction(lambda i, j: i, (2, 2), dtype=float, like=cosmo_in)
+        assert isinstance(cosmo_out, cosmo_array) and not isinstance(
+            cosmo_out, cosmo_quantity
+        )
+        assert cosmo_out.units == cosmo_in.units
+        assert cosmo_out.comoving == cosmo_in.comoving
+        assert cosmo_out.cosmo_factor == cosmo_in.cosmo_factor
+        assert cosmo_out.valid_transform == cosmo_in.valid_transform
+        assert cosmo_out.compression == cosmo_in.compression
+
+    def test_frombuffer(self):
+        """
+        Test the frombuffer function.
+
+        Attributes are copied from the `like` kwarg.
+        """
+        cosmo_in = cosmo_array(
+            [0],
+            u.Mpc,
+            comoving=False,
+            scale_factor=0.5,
+            scale_exponent=1,
+            valid_transform=False,
+            compression="testing",
+        )
+        cosmo_out = np.frombuffer(b"\x01\x02", dtype=np.uint8, like=cosmo_in)
+        assert isinstance(cosmo_out, cosmo_array) and not isinstance(
+            cosmo_out, cosmo_quantity
+        )
+        assert cosmo_out.units == cosmo_in.units
+        assert cosmo_out.comoving == cosmo_in.comoving
+        assert cosmo_out.cosmo_factor == cosmo_in.cosmo_factor
+        assert cosmo_out.valid_transform == cosmo_in.valid_transform
+        assert cosmo_out.compression == cosmo_in.compression
+
+    def test_loadtxt(self):
+        """
+        Test the loadtxt function.
+
+        Attributes are copied from the `like` kwarg.
+        """
+        cosmo_in = cosmo_array(
+            [0],
+            u.Mpc,
+            comoving=False,
+            scale_factor=0.5,
+            scale_exponent=1,
+            valid_transform=False,
+            compression="testing",
+        )
+        fname = "np_arr.txt"
+        try:
+            np.savetxt(fname, [1, 2])
+            cosmo_out = np.loadtxt(fname, like=cosmo_in)
+        finally:
+            os.remove(fname)
+        assert isinstance(cosmo_out, cosmo_array) and not isinstance(
+            cosmo_out, cosmo_quantity
+        )
+        assert cosmo_out.units == cosmo_in.units
+        assert cosmo_out.comoving == cosmo_in.comoving
+        assert cosmo_out.cosmo_factor == cosmo_in.cosmo_factor
+        assert cosmo_out.valid_transform == cosmo_in.valid_transform
+        assert cosmo_out.compression == cosmo_in.compression
+
+    def test_fromfile(self):
+        """
+        Test the fromfile function.
+
+        Attributes are copied from the `like` kwarg.
+        """
+        cosmo_in = cosmo_array(
+            [0],
+            u.Mpc,
+            comoving=False,
+            scale_factor=0.5,
+            scale_exponent=1,
+            valid_transform=False,
+            compression="testing",
+        )
+        fname = "np_arr"
+        try:
+            np.array([1, 2], dtype=int).tofile(fname)
+            cosmo_out = np.fromfile(fname, dtype=int, like=cosmo_in)
+        finally:
+            os.remove(fname)
+        assert isinstance(cosmo_out, cosmo_array) and not isinstance(
+            cosmo_out, cosmo_quantity
+        )
+        assert cosmo_out.units == cosmo_in.units
+        assert cosmo_out.comoving == cosmo_in.comoving
+        assert cosmo_out.cosmo_factor == cosmo_in.cosmo_factor
+        assert cosmo_out.valid_transform == cosmo_in.valid_transform
+        assert cosmo_out.compression == cosmo_in.compression
+
+    def test_genfromtxt(self):
+        """
+        Test the genfromtxt function.
+
+        Attributes are copied from the `like` kwarg.
+        """
+        cosmo_in = cosmo_array(
+            [0],
+            u.Mpc,
+            comoving=False,
+            scale_factor=0.5,
+            scale_exponent=1,
+            valid_transform=False,
+            compression="testing",
+        )
+        s = StringIO("1,2\n3,4")
+        cosmo_out = np.genfromtxt(
+            s, dtype=[("a", int), ("b", int)], delimiter=",", like=cosmo_in
+        )
+        assert isinstance(cosmo_out, cosmo_array) and not isinstance(
+            cosmo_out, cosmo_quantity
+        )
+        assert cosmo_out.units == cosmo_in.units
+        assert cosmo_out.comoving == cosmo_in.comoving
+        assert cosmo_out.cosmo_factor == cosmo_in.cosmo_factor
+        assert cosmo_out.valid_transform == cosmo_in.valid_transform
+        assert cosmo_out.compression == cosmo_in.compression

--- a/tests/test_cosmo_array.py
+++ b/tests/test_cosmo_array.py
@@ -1372,3 +1372,88 @@ class TestPhysicalComovingConversion:
         elif starting_comoving is True:
             print(arr, arr_copy)
             assert np.allclose(arr.value, arr_copy.value * 2)
+
+
+class TestArrayCreation:
+    """Test functions that create new arrays with a `like` kwarg."""
+
+    @pytest.mark.parametrize(
+        "func",
+        (
+            np.array,
+            np.asarray,
+            np.asanyarray,
+            np.ascontiguousarray,
+            np.asfortranarray,
+        ),
+    )
+    @pytest.mark.parametrize("inp", (1.0, [1.0]))
+    def test_array_and_similar(self, func, inp):
+        """
+        Test functions that take an array-like and produce a cosmo_array.
+
+        Attributes are copied from the `like` kwarg.
+        """
+        cosmo_in = cosmo_array(
+            [0],
+            u.Mpc,
+            comoving=False,
+            scale_factor=0.5,
+            scale_exponent=1,
+            valid_transform=False,
+            compression="testing",
+        )
+        cosmo_out = func(inp, like=cosmo_in)
+        if np.isscalar(inp) and func not in (np.ascontiguousarray, np.asfortranarray):
+            assert isinstance(cosmo_out, cosmo_quantity)
+        else:
+            assert isinstance(cosmo_out, cosmo_array) and not isinstance(
+                cosmo_out, cosmo_quantity
+            )
+        assert cosmo_out.units == cosmo_in.units
+        assert cosmo_out.comoving == cosmo_in.comoving
+        assert cosmo_out.cosmo_factor == cosmo_in.cosmo_factor
+        assert cosmo_out.valid_transform == cosmo_in.valid_transform
+        assert cosmo_out.compression == cosmo_in.compression
+
+    @pytest.mark.parametrize(
+        "func",
+        (
+            np.arange,
+            np.empty,
+            np.ones,
+            np.zeros,
+            lambda x, like=None: np.full(x, fill_value=0, like=like),
+            np.identity,
+            np.eye,
+            np.tri,
+        ),
+    )
+    def test_arange_and_similar(self, func):
+        """
+        Test functions that take an integer and produce a cosmo_array.
+
+        Attributes are copied from the `like` kwarg.
+        """
+        cosmo_in = cosmo_array(
+            [0],
+            u.Mpc,
+            comoving=False,
+            scale_factor=0.5,
+            scale_exponent=1,
+            valid_transform=False,
+            compression="testing",
+        )
+        cosmo_out = func(3, like=cosmo_in)
+        assert isinstance(cosmo_out, cosmo_array) and not isinstance(
+            cosmo_out, cosmo_quantity
+        )
+        assert cosmo_out.units == cosmo_in.units
+        assert cosmo_out.comoving == cosmo_in.comoving
+        assert cosmo_out.cosmo_factor == cosmo_in.cosmo_factor
+        assert cosmo_out.valid_transform == cosmo_in.valid_transform
+        assert cosmo_out.compression == cosmo_in.compression
+
+
+# TODO:
+# require, fromfunction, fromstring, fromiter, fromfile, frombuffer, loadtxt genfromtxt


### PR DESCRIPTION
`numpy` offers the opportunity for array subclasses to intervene when creating new array through the `like` keyword argument. This PR implements this feature for `cosmo_array` (and its subclass `cosmo_quantity`) allowing us to create new arrays that copy the `units`, `comoving`, `cosmo_factor`, `compression` and `valid_transform` attributes from an existing array. In other words, this very nice (imo) syntax now works:

```python
>>> from swiftsimio import load
>>> dat = load("test_data/ColibreSingle.hdf5")
>>> distances = np.arange(3, like=dat.gas.coordinates)
>>> distances
cosmo_array([0, 1, 2], 'Mpc', comoving='True', cosmo_factor='a**1.0 at a=0.5', valid_transform='True')
```

The following functions are supported:
 - `np.asarray`
 - `np.asanyarray`
 - `np.ascontiguousarray`
 - `np.asfortranarray`
 - `np.require`
 - `np.fromfunction`
 - `np.fromstring`
 - `np.fromiter`
 - `np.fromfile`
 - `np.frombuffer`
 - `np.identity`
 - `np.loadtxt`
 - `np.genfromtxt`
 - `np.eye`
 - `np.tri`

Still to-do:
 - [x] Updated narrative documentation.
 - [x] Check some of the main docstrings for examples that could be udpated.

Helps address #297 (see also #328 for the rest of the changes discussed in that issue). Had originally implemented this in the other PR but it's a standalone change and doesn't depend on changes in `unyt` so makes sense to split it off into its own PR.