### PR TITLE
Use human-friendly time units in swiftsnap output

### DIFF
--- a/swiftsimio/swiftsnap.py
+++ b/swiftsimio/swiftsnap.py
@@ -85,6 +85,7 @@ def swiftsnap() -> None:
     """
     import swiftsimio as sw
     from swiftsimio.metadata.objects import _metadata_discriminator
+    import unyt as u
 
     from swiftsimio.metadata.particle import particle_name_underscores
     from textwrap import wrap
@@ -161,10 +162,24 @@ def swiftsnap() -> None:
 
         print()
 
+        # Units must be in descending order.
+        target_time_units = [
+            u.Gyr,
+            u.Myr,
+            u.yr,
+            u.s,
+        ]
+        # Use first units less than the internal code unit.
+        for unit in target_time_units:
+            if data.units.time > 1 * unit:
+                time_unit = unit
+                break
+        else:
+            # Nothing found? Just use the original unit then.
+            time_unit = data.units.time
+
         # Current state information
-        time_string = (
-            f"Simulation state: z={data.z:.4g}, a={data.a:.4g}, t={data.time:.4g}"
-        )
+        time_string = f"Simulation state: z={data.z:.4g}, a={data.a:.4g}, t={data.time.to(time_unit):.4g}"
         print(f"{time_string}")
         print()
         print(f"Cosmology: {data.cosmology}")

--- a/swiftsimio/swiftsnap.py
+++ b/swiftsimio/swiftsnap.py
@@ -162,24 +162,8 @@ def swiftsnap() -> None:
 
         print()
 
-        # Units must be in descending order.
-        target_time_units = [
-            u.Gyr,
-            u.Myr,
-            u.yr,
-            u.s,
-        ]
-        # Use first units less than the internal code unit.
-        for unit in target_time_units:
-            if data.units.time > 1 * unit:
-                time_unit = unit
-                break
-        else:
-            # Nothing found? Just use the original unit then.
-            time_unit = data.units.time
-
         # Current state information
-        time_string = f"Simulation state: z={data.z:.4g}, a={data.a:.4g}, t={data.time.to(time_unit):.4g}"
+        time_string = f"Simulation state: z={data.z:.4g}, a={data.a:.4g}, t={data.time.to(data.units.time.units):.4g}"
         print(f"{time_string}")
         print()
         print(f"Cosmology: {data.cosmology}")

--- a/swiftsimio/swiftsnap.py
+++ b/swiftsimio/swiftsnap.py
@@ -85,7 +85,6 @@ def swiftsnap() -> None:
     """
     import swiftsimio as sw
     from swiftsimio.metadata.objects import _metadata_discriminator
-    import unyt as u
 
     from swiftsimio.metadata.particle import particle_name_underscores
     from textwrap import wrap


### PR DESCRIPTION
Just a small quality-of-life change with swiftsnap. Since the time unit comes from the length and velocity units, the actual value of the unit can be a little inconvenient to work with. All this PR does is change the time unit to be more human-friendly when printing in swiftsnap.
For example:
`Simulation state: z=0, a=1, t=0.01437 977.79*Gyr`
becomes
`Simulation state: z=0, a=1, t=14.05 Gyr`