### PR TITLE
Support non-gas slices and renders

### DIFF
--- a/docs/source/visualisation/slice.rst
+++ b/docs/source/visualisation/slice.rst
@@ -18,9 +18,11 @@ There is also an alternative :code:`"nearest_neighbours"` backend, which uses
 nearest-neighbour interpolation to compute the densities at each pixel.
 This backend is more suited for use with moving-mesh hydrodynamics schemes.
 
-The primary function here is
-:func:`swiftsimio.visualisation.slice.slice_gas`, which allows you to
-create a gas slice of any field. See the example below.
+The primary functions here are
+:func:`swiftsimio.visualisation.slice.slice_pixel_grid`, which allows you to
+create a slice of any field for any particle type, and the convenience wrapper
+:func:`swiftsimio.visualisation.slice.slice_gas` for gas particles. See the
+examples below.
 
 Example
 -------
@@ -202,6 +204,51 @@ approach to rotations applied to the above example is shown below.
 
    # Normalize and save
    imsave("temp_map.png", LogNorm()(temp_map.value), cmap="twilight")
+
+
+Other particle types
+--------------------
+
+Other particle types can be sliced using
+:func:`swiftsimio.visualisation.slice.slice_pixel_grid`.
+
+For particle types that do not have smoothing lengths (e.g. dark matter),
+you will need to generate them first using
+:func:`~swiftsimio.visualisation.smoothing_length.generate.generate_smoothing_lengths`.
+
+.. code-block:: python
+
+   from swiftsimio import load
+   from swiftsimio.visualisation.slice import slice_pixel_grid
+   from swiftsimio.visualisation.smoothing_length import generate_smoothing_lengths
+
+   data = load("cosmo_volume_example.hdf5")
+
+   # Generate smoothing lengths for the dark matter
+   data.dark_matter.smoothing_length = generate_smoothing_lengths(
+       data.dark_matter.coordinates,
+       data.metadata.boxsize,
+       kernel_gamma=1.8,
+       neighbours=57,
+       speedup_fac=2,
+       dimension=3,
+   )
+
+   # Slice the dark matter mass at the midplane
+   dm_mass_slice = slice_pixel_grid(
+       # Pass the dark matter dataset, not the whole data object
+       data=data.dark_matter,
+       z_slice=0.5 * data.metadata.boxsize[2],
+       resolution=1024,
+       project="masses",
+       parallel=True,
+       periodic=True,
+   )
+
+   from matplotlib.pyplot import imsave
+   from matplotlib.colors import LogNorm
+
+   imsave("dm_mass_slice.png", LogNorm()(dm_mass_slice.value), cmap="inferno")
 
 
 Lower-level API

--- a/docs/source/visualisation/volume_render.rst
+++ b/docs/source/visualisation/volume_render.rst
@@ -14,9 +14,11 @@ with :math:`\tilde{A}_i` the smoothed quantity in pixel :math:`i`, and
 :math:`j` all particles in the simulation, with :math:`W` the 3D kernel.
 Here we use the Wendland-C2 kernel.
 
-The primary function here is
-:func:`swiftsimio.visualisation.volume_render.render_gas`, which allows you
-to create a gas density grid of any field, see the example below.
+The primary functions here are
+:func:`swiftsimio.visualisation.volume_render.render_voxel_grid`, which allows
+you to create a voxel grid of any field for any particle type, and the
+convenience wrapper :func:`swiftsimio.visualisation.volume_render.render_gas`
+for gas particles. See the examples below.
 
 Example
 -------
@@ -155,6 +157,50 @@ approach to rotations applied to the above example is shown below.
 
    # A 256 x 256 x 256 cube with dimensions of temperature
    temp_cube = mass_weighted_temp_cube / mass_cube
+
+
+Other particle types
+--------------------
+
+Other particle types can be volume rendered using
+:func:`swiftsimio.visualisation.volume_render.render_voxel_grid`.
+
+For particle types that do not have smoothing lengths (e.g. dark matter),
+you will need to generate them first using
+:func:`~swiftsimio.visualisation.smoothing_length.generate.generate_smoothing_lengths`.
+
+.. code-block:: python
+
+   from swiftsimio import load
+   from swiftsimio.visualisation.volume_render import render_voxel_grid
+   from swiftsimio.visualisation.smoothing_length import generate_smoothing_lengths
+
+   data = load("cosmo_volume_example.hdf5")
+
+   # Generate smoothing lengths for the dark matter
+   data.dark_matter.smoothing_length = generate_smoothing_lengths(
+       data.dark_matter.coordinates,
+       data.metadata.boxsize,
+       kernel_gamma=1.8,
+       neighbours=57,
+       speedup_fac=2,
+       dimension=3,
+   )
+
+   # Render the dark matter mass
+   dm_mass_cube = render_voxel_grid(
+       # Pass the dark matter dataset, not the whole data object
+       data=data.dark_matter,
+       resolution=256,
+       project="masses",
+       parallel=True,
+       periodic=True,
+   )
+
+   from matplotlib.pyplot import imsave
+   from matplotlib.colors import LogNorm
+
+   imsave("dm_mass_cube_projection.png", LogNorm()(dm_mass_cube.sum(-1).value), cmap="inferno")
 
 
 Rendering

--- a/swiftsimio/visualisation/__init__.py
+++ b/swiftsimio/visualisation/__init__.py
@@ -1,8 +1,8 @@
 """Visualisation sub-module for swiftismio."""
 
 from .projection import project_gas, project_pixel_grid
-from .slice import slice_gas
-from .volume_render import render_gas
+from .slice import slice_gas, slice_pixel_grid
+from .volume_render import render_gas, render_voxel_grid
 from .smoothing_length import generate_smoothing_lengths
 from . import rotation
 
@@ -10,7 +10,9 @@ __all__ = [
     "project_gas",
     "project_pixel_grid",
     "slice_gas",
+    "slice_pixel_grid",
     "render_gas",
+    "render_voxel_grid",
     "generate_smoothing_lengths",
     "rotation",
 ]

--- a/swiftsimio/visualisation/slice.py
+++ b/swiftsimio/visualisation/slice.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 from swiftsimio import SWIFTDataset, cosmo_array, cosmo_quantity
+from swiftsimio.reader import __SWIFTGroupDataset
 from swiftsimio.visualisation.slice_backends import backends, backends_parallel
 from swiftsimio.visualisation.smoothing_length import backends_get_hsml
 from swiftsimio.visualisation._vistools import (
@@ -12,8 +13,8 @@ from swiftsimio.visualisation._vistools import (
 )
 
 
-def slice_gas(
-    data: SWIFTDataset,
+def slice_pixel_grid(
+    data: __SWIFTGroupDataset,
     resolution: int,
     z_slice: cosmo_quantity | None = None,
     project: str | None = "masses",
@@ -25,12 +26,12 @@ def slice_gas(
     periodic: bool = True,
 ) -> cosmo_array:
     """
-    Create a data field-weighted 2D slice through a SWIFT dataset as a pixel grid.
+    Create a data field-weighted 2D slice through a particle dataset as a pixel grid.
 
     Parameters
     ----------
-    data : SWIFTDataset
-        Dataset from which slice is extracted.
+    data : __SWIFTGroupDataset
+        Particle dataset to slice (e.g. ``data.gas``, ``data.dark_matter``).
 
     resolution : int
         Specifies size of return np.array.
@@ -51,12 +52,12 @@ def slice_gas(
         defaults to False, but can speed up the creation of large images
         significantly at the cost of increased memory usage.
 
-    rotation_matrix : np.np.array, optional
+    rotation_matrix : np.ndarray, optional
         Rotation matrix (3x3) that describes the rotation of the box around
         ``rotation_center``. In the default case, this provides a slice
         perpendicular to the z axis.
 
-    rotation_center : np.np.array, optional
+    rotation_center : cosmo_array, optional
         Center of the rotation. If you are trying to rotate around a galaxy, this
         should be the most bound particle.
 
@@ -86,10 +87,11 @@ def slice_gas(
 
     See Also
     --------
-    render_gas_voxel_grid
-        Creates a 3D voxel grid from a SWIFT dataset.
+    render_voxel_grid
+        Creates a 3D voxel grid from a particle dataset.
+    slice_gas
+        Convenience wrapper for slicing gas particles.
     """
-    data = data.gas
     z_slice = np.zeros_like(data.metadata.boxsize[0]) if z_slice is None else z_slice
 
     m = _get_projection_field(data, project)
@@ -135,3 +137,96 @@ def slice_gas(
     backend_func = (backends_parallel if parallel else backends)[backend]
     image = backend_strip_and_restore_cosmo_and_units(backend_func, norm=norm)(**kwargs)
     return image
+
+
+def slice_gas(
+    data: SWIFTDataset,
+    resolution: int,
+    z_slice: cosmo_quantity | None = None,
+    project: str | None = "masses",
+    parallel: bool = False,
+    rotation_matrix: np.ndarray | None = None,
+    rotation_center: cosmo_array | None = None,
+    region: cosmo_array | None = None,
+    backend: str = "sph",
+    periodic: bool = True,
+) -> cosmo_array:
+    """
+    Create a data field-weighted 2D slice through the gas of a SWIFT dataset as a pixel grid.
+
+    Parameters
+    ----------
+    data : SWIFTDataset
+        Dataset from which slice is extracted.
+
+    resolution : int
+        Specifies size of return np.array.
+
+    z_slice : cosmo_quantity
+        Specifies the location along the z-axis where the slice is to be
+        extracted, relative to the rotation center or the origin of the box
+        if no rotation center is provided. If the perspective is rotated
+        this value refers to the location along the rotated z-axis.
+
+    project : str, optional
+        Data field to be projected. Default is mass. If ``None`` then simply
+        count number of particles. The result is comoving if this is comoving,
+        else it is physical.
+
+    parallel : bool
+        Used to determine if we will create the image in parallel. This
+        defaults to False, but can speed up the creation of large images
+        significantly at the cost of increased memory usage.
+
+    rotation_matrix : np.ndarray, optional
+        Rotation matrix (3x3) that describes the rotation of the box around
+        ``rotation_center``. In the default case, this provides a slice
+        perpendicular to the z axis.
+
+    rotation_center : cosmo_array, optional
+        Center of the rotation. If you are trying to rotate around a galaxy, this
+        should be the most bound particle.
+
+    region : cosmo_array, optional
+        Determines where the image will be created
+        (this corresponds to the left and right-hand edges, and top and bottom edges)
+        if it is not None. It should have a length of four, and take the form:
+
+        [x_min, x_max, y_min, y_max]
+
+        Particles outside of this range are still considered if their
+        smoothing lengths overlap with the range.
+
+    backend : str, optional
+        Backend to use. Choices are "sph" (default) for interpolation using kernel
+        weights or "nearest_neighbours" for nearest neighbour interpolation.
+
+    periodic : bool, optional
+        Account for periodic boundaries for the simulation box?
+        Default is ``True``.
+
+    Returns
+    -------
+    cosmo_array
+        Slice image with units of project / length^2, of size ``res`` x ``res``.
+        Comoving if ``project`` data are comoving, else physical.
+
+    See Also
+    --------
+    slice_pixel_grid
+        Slices any particle type, not just gas.
+    render_voxel_grid
+        Creates a 3D voxel grid from a particle dataset.
+    """
+    return slice_pixel_grid(
+        data=data.gas,
+        resolution=resolution,
+        z_slice=z_slice,
+        project=project,
+        parallel=parallel,
+        rotation_matrix=rotation_matrix,
+        rotation_center=rotation_center,
+        region=region,
+        backend=backend,
+        periodic=periodic,
+    )

--- a/swiftsimio/visualisation/slice.py
+++ b/swiftsimio/visualisation/slice.py
@@ -87,6 +87,8 @@ def slice_pixel_grid(
 
     See Also
     --------
+    project_pixel_grid
+        Creates a 2D projection of a particle dataset.
     render_voxel_grid
         Creates a 3D voxel grid from a particle dataset.
     slice_gas

--- a/swiftsimio/visualisation/smoothing_length/nearest_neighbours.py
+++ b/swiftsimio/visualisation/smoothing_length/nearest_neighbours.py
@@ -23,13 +23,12 @@ def get_hsml(data: __SWIFTGroupDataset) -> cosmo_array:
     cosmo_array
         The extracted "smoothing lengths".
     """
-    try:
+    if hasattr(data, "volumes"):
         hsml = np.cbrt(data.volumes)
-    except AttributeError:
-        try:
-            # Try computing the volumes explicitly?
-            hsml = np.cbrt(data.masses / data.densities)
-        except AttributeError:
-            # Fall back to SPH behavior if above didn't work...
-            hsml = get_hsml_sph(data)
+    elif hasattr(data, "masses") and hasattr(data, "densities"):
+        # Try computing the volumes explicitly?
+        hsml = np.cbrt(data.masses / data.densities)
+    else:
+        # Fall back to SPH behavior if above didn't work...
+        hsml = get_hsml_sph(data)
     return hsml

--- a/swiftsimio/visualisation/smoothing_length/nearest_neighbours.py
+++ b/swiftsimio/visualisation/smoothing_length/nearest_neighbours.py
@@ -1,11 +1,12 @@
 """Tools to get nearest-neighbour smoothing lengths."""
 
 import numpy as np
-from swiftsimio import SWIFTDataset, cosmo_array
+from swiftsimio import cosmo_array
+from swiftsimio.reader import __SWIFTGroupDataset
 from swiftsimio.visualisation.smoothing_length.sph import get_hsml as get_hsml_sph
 
 
-def get_hsml(data: SWIFTDataset) -> cosmo_array:
+def get_hsml(data: __SWIFTGroupDataset) -> cosmo_array:
     """
     Compute a "smoothing length".
 
@@ -14,8 +15,8 @@ def get_hsml(data: SWIFTDataset) -> cosmo_array:
 
     Parameters
     ----------
-    data : SWIFTDataset
-        The dataset from which slice will be extracted.
+    data : __SWIFTGroupDataset
+        The particle dataset for which smoothing lengths will be computed.
 
     Returns
     -------
@@ -23,11 +24,11 @@ def get_hsml(data: SWIFTDataset) -> cosmo_array:
         The extracted "smoothing lengths".
     """
     try:
-        hsml = np.cbrt(data.gas.volumes)
+        hsml = np.cbrt(data.volumes)
     except AttributeError:
         try:
             # Try computing the volumes explicitly?
-            hsml = np.cbrt(data.gas.masses / data.gas.densities)
+            hsml = np.cbrt(data.masses / data.densities)
         except AttributeError:
             # Fall back to SPH behavior if above didn't work...
             hsml = get_hsml_sph(data)

--- a/swiftsimio/visualisation/smoothing_length/sph.py
+++ b/swiftsimio/visualisation/smoothing_length/sph.py
@@ -1,24 +1,30 @@
 """Tools to get SPH smoothing lengths."""
 
-from swiftsimio import SWIFTDataset, cosmo_array
+from swiftsimio import cosmo_array
+from swiftsimio.reader import __SWIFTGroupDataset
 
 
-def get_hsml(data: SWIFTDataset) -> cosmo_array:
+def get_hsml(data: __SWIFTGroupDataset) -> cosmo_array:
     """
-    Extract the smoothing lengths from the gas particles (used for slicing).
+    Extract the smoothing lengths from a particle dataset.
 
     Parameters
     ----------
-    data : SWIFTDataset
-        The Dataset from which slice will be extracted.
+    data : __SWIFTGroupDataset
+        The particle dataset from which smoothing lengths will be extracted.
 
     Returns
     -------
     cosmo_array
         The extracted smoothing lengths.
     """
-    return (
-        data.smoothing_lengths
-        if hasattr(data, "smoothing_lengths")
-        else data.smoothing_length  # backwards compatibility
-    )
+    if hasattr(data, "smoothing_lengths"):
+        return data.smoothing_lengths
+    elif hasattr(data, "smoothing_length"):
+        return data.smoothing_length  # backwards compatibility
+    else:
+        raise AttributeError(
+            f"Particle type {data.group_name} does not have smoothing lengths. "
+            "Use generate_smoothing_lengths from swiftsimio.visualisation.smoothing_length "
+            "to generate them before visualising."
+        )

--- a/swiftsimio/visualisation/volume_render.py
+++ b/swiftsimio/visualisation/volume_render.py
@@ -8,6 +8,7 @@ from typing import Literal
 import numpy as np
 from swiftsimio import SWIFTDataset, cosmo_array
 from swiftsimio.accelerated import jit
+from swiftsimio.reader import __SWIFTGroupDataset
 
 from swiftsimio.optional_packages import plt
 
@@ -21,8 +22,8 @@ from swiftsimio.visualisation._vistools import (
 )
 
 
-def render_gas(
-    data: SWIFTDataset,
+def render_voxel_grid(
+    data: __SWIFTGroupDataset,
     resolution: int,
     project: str | None = "masses",
     parallel: bool = False,
@@ -32,12 +33,12 @@ def render_gas(
     periodic: bool = True,
 ) -> cosmo_array:
     """
-    Create a data-field weighted 3D render of a SWIFT dataset as a voxel grid.
+    Create a data-field weighted 3D render of a particle dataset as a voxel grid.
 
     Parameters
     ----------
-    data : SWIFTDataset
-        Dataset from which render is extracted.
+    data : __SWIFTGroupDataset
+        Particle dataset to render (e.g. ``data.gas``, ``data.dark_matter``).
 
     resolution : int
         Specifies size of return np.array.
@@ -52,7 +53,7 @@ def render_gas(
         defaults to False, but can speed up the creation of large images
         significantly at the cost of increased memory usage.
 
-    rotation_matrix : np.array, optional
+    rotation_matrix : np.ndarray, optional
         Rotation matrix (3x3) that describes the rotation of the box around
         ``rotation_center``. In the default case, this provides a volume render
         viewed along the z axis.
@@ -85,11 +86,11 @@ def render_gas(
 
     See Also
     --------
-    slice_gas_pixel_grid
-        Creates a 2D slice of a SWIFT dataset.
+    slice_pixel_grid
+        Creates a 2D slice of a particle dataset.
+    render_gas
+        Convenience wrapper for volume rendering gas particles.
     """
-    data = data.gas
-
     m = _get_projection_field(data, project)
     region_info = _get_region_info(data, region, require_cubic=True, periodic=periodic)
     hsml = backends_get_hsml["sph"](data)
@@ -121,6 +122,87 @@ def render_gas(
     image = backend_strip_and_restore_cosmo_and_units(backend_func, norm=norm)(**kwargs)
 
     return image
+
+
+def render_gas(
+    data: SWIFTDataset,
+    resolution: int,
+    project: str | None = "masses",
+    parallel: bool = False,
+    rotation_matrix: np.ndarray | None = None,
+    rotation_center: cosmo_array | None = None,
+    region: cosmo_array | None = None,
+    periodic: bool = True,
+) -> cosmo_array:
+    """
+    Create a data-field weighted 3D render of the gas in a SWIFT dataset as a voxel grid.
+
+    Parameters
+    ----------
+    data : SWIFTDataset
+        Dataset from which render is extracted.
+
+    resolution : int
+        Specifies size of return np.array.
+
+    project : str, optional
+        Data field to be projected. Default is ``"mass"``. If ``None`` then simply
+        count number of particles. The result is comoving if this is comoving, else
+        it is physical.
+
+    parallel : bool
+        Used to determine if we will create the image in parallel. This
+        defaults to False, but can speed up the creation of large images
+        significantly at the cost of increased memory usage.
+
+    rotation_matrix : np.ndarray, optional
+        Rotation matrix (3x3) that describes the rotation of the box around
+        ``rotation_center``. In the default case, this provides a volume render
+        viewed along the z axis.
+
+    rotation_center : cosmo_array, optional
+        Center of the rotation. If you are trying to rotate around a galaxy, this
+        should be the most bound particle.
+
+    region : cosmo_array, optional
+        Determines where the image will be created
+        (this corresponds to the left and right-hand edges, and top and bottom
+        edges, and front and back edges) if it is not None. It should have a
+        length of six, and take the form:
+
+        [x_min, x_max, y_min, y_max, z_min, z_max]
+
+        Particles outside of this range are still considered if their
+        smoothing lengths overlap with the range.
+
+    periodic : bool, optional
+        Account for periodic boundaries for the simulation box?
+        Default is ``True``.
+
+    Returns
+    -------
+    cosmo_array
+        Voxel grid with units of project / length^3, of size ``resolution`` x
+        ``resolution`` x ``resolution``. Comoving if ``project`` data are
+        comoving, else physical.
+
+    See Also
+    --------
+    render_voxel_grid
+        Renders any particle type, not just gas.
+    slice_pixel_grid
+        Creates a 2D slice of a particle dataset.
+    """
+    return render_voxel_grid(
+        data=data.gas,
+        resolution=resolution,
+        project=project,
+        parallel=parallel,
+        rotation_matrix=rotation_matrix,
+        rotation_center=rotation_center,
+        region=region,
+        periodic=periodic,
+    )
 
 
 @jit(nopython=True, fastmath=True)

--- a/swiftsimio/visualisation/volume_render.py
+++ b/swiftsimio/visualisation/volume_render.py
@@ -86,6 +86,8 @@ def render_voxel_grid(
 
     See Also
     --------
+    project_pixel_grid
+        Creates a 2D projection of a particle dataset.
     slice_pixel_grid
         Creates a 2D slice of a particle dataset.
     render_gas

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -1167,13 +1167,26 @@ def test_nongas_smoothing_lengths(cosmological_volume_only_single_local):
     Just makes sure that we get back a unyt_array for unyt_array input, and
     a cosmo_array for cosmo_array input.
     """
-    # If project_gas runs without error the smoothing lengths seem usable.
     data = load(cosmological_volume_only_single_local)
     data.dark_matter.smoothing_length = generate_smoothing_lengths(
         data.dark_matter.coordinates, data.metadata.boxsize, kernel_gamma=1.8
     )
-    project_pixel_grid(data.dark_matter, resolution=256, project="masses")
     assert isinstance(data.dark_matter.smoothing_length, cosmo_array)
+
+    project_pixel_grid(data.dark_matter, resolution=256, project="masses")
+    assert isinstance(
+        slice_pixel_grid(
+            data.dark_matter,
+            z_slice=0.5 * data.metadata.boxsize[2],
+            resolution=256,
+            project="masses",
+        ),
+        cosmo_array,
+    )
+    assert isinstance(
+        render_voxel_grid(data.dark_matter, resolution=64, project="masses"),
+        cosmo_array,
+    )
 
     # We should also be able to use a unyt_array (rather than cosmo_array) as input,
     # and in this case get unyt_array as output.
@@ -1188,35 +1201,6 @@ def test_nongas_smoothing_lengths(cosmological_volume_only_single_local):
     assert not isinstance(hsml, cosmo_array)
 
     return
-
-
-def test_slice_pixel_grid_nongas(cosmological_volume_only_single_local):
-    """Check that slice_pixel_grid works for non-gas particle types."""
-    data = load(cosmological_volume_only_single_local)
-    data.dark_matter.smoothing_length = generate_smoothing_lengths(
-        data.dark_matter.coordinates, data.metadata.boxsize, kernel_gamma=1.8
-    )
-    result = slice_pixel_grid(
-        data.dark_matter,
-        z_slice=0.5 * data.metadata.boxsize[2],
-        resolution=256,
-        project="masses",
-    )
-    assert isinstance(result, cosmo_array)
-
-
-def test_render_voxel_grid_nongas(cosmological_volume_only_single_local):
-    """Check that render_voxel_grid works for non-gas particle types."""
-    data = load(cosmological_volume_only_single_local)
-    data.dark_matter.smoothing_length = generate_smoothing_lengths(
-        data.dark_matter.coordinates, data.metadata.boxsize, kernel_gamma=1.8
-    )
-    result = render_voxel_grid(
-        data.dark_matter,
-        resolution=64,
-        project="masses",
-    )
-    assert isinstance(result, cosmo_array)
 
 
 class TestPowerSpectrum:

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -3,8 +3,8 @@
 import pytest
 from swiftsimio import load, mask
 from swiftsimio.visualisation.projection import project_gas, project_pixel_grid
-from swiftsimio.visualisation.slice import slice_gas
-from swiftsimio.visualisation.volume_render import render_gas
+from swiftsimio.visualisation.slice import slice_gas, slice_pixel_grid
+from swiftsimio.visualisation.volume_render import render_gas, render_voxel_grid
 
 from swiftsimio.visualisation.slice_backends import (
     backends as slice_backends,
@@ -1188,6 +1188,35 @@ def test_nongas_smoothing_lengths(cosmological_volume_only_single_local):
     assert not isinstance(hsml, cosmo_array)
 
     return
+
+
+def test_slice_pixel_grid_nongas(cosmological_volume_only_single_local):
+    """Check that slice_pixel_grid works for non-gas particle types."""
+    data = load(cosmological_volume_only_single_local)
+    data.dark_matter.smoothing_length = generate_smoothing_lengths(
+        data.dark_matter.coordinates, data.metadata.boxsize, kernel_gamma=1.8
+    )
+    result = slice_pixel_grid(
+        data.dark_matter,
+        z_slice=0.5 * data.metadata.boxsize[2],
+        resolution=256,
+        project="masses",
+    )
+    assert isinstance(result, cosmo_array)
+
+
+def test_render_voxel_grid_nongas(cosmological_volume_only_single_local):
+    """Check that render_voxel_grid works for non-gas particle types."""
+    data = load(cosmological_volume_only_single_local)
+    data.dark_matter.smoothing_length = generate_smoothing_lengths(
+        data.dark_matter.coordinates, data.metadata.boxsize, kernel_gamma=1.8
+    )
+    result = render_voxel_grid(
+        data.dark_matter,
+        resolution=64,
+        project="masses",
+    )
+    assert isinstance(result, cosmo_array)
 
 
 class TestPowerSpectrum:


### PR DESCRIPTION
Ian McCarthy asked if it was possible to make slices of dark matter. We already support projections for non-gas particles via ``project_pixel_grid``, but slices and volume renders were gas-only. This PR extends both to support any particle type by introducing ``slice_pixel_grid`` and ``render_voxel_grid``. The existing ``slice_gas`` and ``render_gas functions`` are now wrappers.

The tests now call ``slice_pixel_grid`` and ``render_voxel_grid`` using dark matter. That might be overkill though since it's not testing anything different to the gas case, so I think I'll remove that.

Also fixes a silent bug in the nearest_neighbours smoothing length backend, which was always falling back to SPH smoothing lengths due to double ``.gas`` attribute access.