### PR TITLE
Ensure consistent return type in numba function

### DIFF
--- a/swiftsimio/accelerated.py
+++ b/swiftsimio/accelerated.py
@@ -83,7 +83,7 @@ def ranges_from_array(array: np.array) -> np.ndarray:
 
     if len(array) == 0:
         # the "empty" mask, from 0 to 0 gets 0 elements
-        return np.array([[0, 0]])
+        return np.array([[0, 0]], dtype=np.dtype("int"))
     start = array[0]
     stop = array[0]
 
@@ -98,7 +98,7 @@ def ranges_from_array(array: np.array) -> np.ndarray:
 
     output.append([start, stop + 1])
 
-    return np.array(output)
+    return np.array(output, dtype=np.dtype("int"))
 
 
 def read_ranges_from_file_unchunked(

--- a/tests/test_accelerated.py
+++ b/tests/test_accelerated.py
@@ -17,8 +17,9 @@ def test_ranges_from_array():
     my_array = np.array([0, 1, 2, 3, 5, 6, 7, 9, 11, 12, 13], dtype=int)
 
     out = np.array([[0, 4], [5, 8], [9, 10], [11, 14]])
-
-    assert (ranges_from_array(my_array) == out).all()
+    result = ranges_from_array(my_array)
+    assert (result == out).all()
+    assert result.dtype == np.dtype("int")
 
     return
 
@@ -36,11 +37,12 @@ def test_ranges_from_array_non_contiguous():
 
 def test_ranges_from_array_empty():
     """Tests the ranges from array function when the array is empty."""
-    my_array = np.array([], dtype=int)
+    my_array = np.array([])
 
     out = np.array([[0, 0]])
-
-    assert (ranges_from_array(my_array) == out).all()
+    result = ranges_from_array(my_array)
+    assert (result == out).all()
+    assert result.dtype == np.dtype("int")
 
 
 def test_read_ranges_from_file():


### PR DESCRIPTION
Fixes an issue where numba inferred an int-only return type in one conditional branch but a float-or-int return type in the other branch. This is an error. Since this function is returning indices for arrays I've changed it to explicitly return an int type array.