### PR TITLE
Use full commit hash in .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
 # Reformat with ruff
-a58fe9b
+a58fe9b6309dfda9591bfd4357fe9fb442cba51c


### PR DESCRIPTION
While looking at #334 I found that the "blame" option on github is not working. It complains that the .git-blame-ignore-revs file is invalid. Using a full length commit hash seems to fix it.