### PR TITLE
Masking on slice and volume render

### DIFF
--- a/docs/source/visualisation/projection.rst
+++ b/docs/source/visualisation/projection.rst
@@ -299,6 +299,65 @@ You can also provide an extra two values, the z min and max, as part of the
 generally advised that you do this on sub-loaded volumes only.
 
 
+Masking
+-------
+
+Sometimes you want to render only a subset of a snapshot's data, for example
+just particles belonging to a given friends-of-friends group.
+To achieve this, you can provide a boolean mask to
+:func:`~swiftsimio.visualisation.projection.project_pixel_grid` or
+:func:`~swiftsimio.visualisation.projection.project_gas` to render only the
+particles which the mask specifies.
+
+.. code-block:: python
+
+   from swiftsimio import load, mask, cosmo_array
+   from swiftsimio.visualisation.projection import project_gas
+
+   snapshot_filename = "cosmo_volume_example.hdf5"
+   catalog_filename = "fof_output_example.hdf5"
+
+   # Which halo are we looking at?
+   halo = 0
+
+   fof_catalog = load(catalog_filename)
+
+   fof_id = fof_catalog.fof_groups.group_ids[halo]
+   fof_radius = fof_catalog.fof_groups.radii[halo]
+   fof_centre = fof_catalog.fof_groups.centres[halo]
+
+   # Add some buffer space around the edges
+   fof_radius *= 1.1
+
+   # Define a region around the fof group
+   region = cosmo_array(
+       [
+           [fof_centre[0] - fof_radius, fof_centre[0] + fof_radius],
+           [fof_centre[1] - fof_radius, fof_centre[1] + fof_radius],
+           [fof_centre[2] - fof_radius, fof_centre[2] + fof_radius],
+       ],
+       fof_centre.units,
+       comoving=True,
+       scale_factor=fof_catalog.metadata.a,
+       scale_exponent=1,
+   )
+
+   # Only load data in our region of interest
+   data_mask = mask(snapshot_filename)
+   data_mask.constrain_spatial(region)
+
+   data = load(snapshot_filename, mask=data_mask)
+
+   halo_map = project_gas(
+       data,
+       resolution=512,
+       parallel=True,
+       region=region.ravel(),
+       periodic=True,
+       mask=data.gas.fofgroup_id == fof_id, # Only render particles in the group
+   )
+
+
 Other particle types
 --------------------
 

--- a/docs/source/visualisation/projection.rst
+++ b/docs/source/visualisation/projection.rst
@@ -189,7 +189,7 @@ The :mod:`swiftsimio.visualisation.rotation` sub-module provides routines to
 generate rotation matrices corresponding to vectors, which can then be
 provided to the ``rotation_matrix`` argument of
 :func:`~swiftsimio.visualisation.projection.project_gas` (and
-:func:`~swiftsimio.visualisation.projection.project_gas_pixel_grid`). You will also need
+:func:`~swiftsimio.visualisation.projection.project_pixel_grid`). You will also need
 to supply the ``rotation_center`` argument, as the rotation takes place around this given
 point. The example code below loads a snapshot, and a halo catalogue, and
 creates an edge-on and face-on projection using the integration in
@@ -263,7 +263,7 @@ is shown in the ``velociraptor`` section.
    data_mask.constrain_spatial(region)
    data = load(snapshot_filename, mask=data_mask)
 
-   # Use project_gas_pixel_grid to generate projected images
+   # Use project_pixel_grid to generate projected images
 
    common_arguments = dict(
        data=data,

--- a/docs/source/visualisation/slice.rst
+++ b/docs/source/visualisation/slice.rst
@@ -206,6 +206,66 @@ approach to rotations applied to the above example is shown below.
    imsave("temp_map.png", LogNorm()(temp_map.value), cmap="twilight")
 
 
+Masking
+-------
+
+Sometimes you want to render only a subset of a snapshot's data, for example
+just particles belonging to a given friends-of-friends group.
+To achieve this, you can provide a boolean mask to
+:func:`~swiftsimio.visualisation.slice.slice_pixel_grid` or
+:func:`~swiftsimio.visualisation.slice.slice_gas` to render only the
+particles which the mask specifies.
+
+.. code-block:: python
+
+   from swiftsimio import load, mask, cosmo_array
+   from swiftsimio.visualisation.slice import slice_gas
+
+   snapshot_filename = "cosmo_volume_example.hdf5"
+   catalog_filename = "fof_output_example.hdf5"
+
+   # Which halo are we looking at?
+   halo = 0
+
+   fof_catalog = load(catalog_filename)
+
+   fof_id = fof_catalog.fof_groups.group_ids[halo]
+   fof_radius = fof_catalog.fof_groups.radii[halo]
+   fof_centre = fof_catalog.fof_groups.centres[halo]
+
+   # Add some buffer space around the edges
+   fof_radius *= 1.1
+
+   # Define a region around the fof group
+   region = cosmo_array(
+       [
+           [fof_centre[0] - fof_radius, fof_centre[0] + fof_radius],
+           [fof_centre[1] - fof_radius, fof_centre[1] + fof_radius],
+           [fof_centre[2] - fof_radius, fof_centre[2] + fof_radius],
+       ],
+       fof_centre.units,
+       comoving=True,
+       scale_factor=fof_catalog.metadata.a,
+       scale_exponent=1,
+   )
+
+   # Only load data in our region of interest
+   data_mask = mask(snapshot_filename)
+   data_mask.constrain_spatial(region)
+
+   data = load(snapshot_filename, mask=data_mask)
+
+   halo_slice = slice_gas(
+       data,
+       z_slice=fof_centre[2],
+       resolution=512,
+       parallel=True,
+       region=region.ravel(),
+       periodic=True,
+       mask=data.gas.fofgroup_id == fof_id, # Only render particles in the group
+   )
+
+
 Other particle types
 --------------------
 

--- a/docs/source/visualisation/volume_render.rst
+++ b/docs/source/visualisation/volume_render.rst
@@ -159,6 +159,65 @@ approach to rotations applied to the above example is shown below.
    temp_cube = mass_weighted_temp_cube / mass_cube
 
 
+Masking
+-------
+
+Sometimes you want to render only a subset of a snapshot's data, for example
+just particles belonging to a given friends-of-friends group.
+To achieve this, you can provide a boolean mask to
+:func:`~swiftsimio.visualisation.volume_render.render_pixel_grid` or
+:func:`~swiftsimio.visualisation.volume_render.render_gas` to render only the
+particles which the mask specifies.
+
+.. code-block:: python
+
+   from swiftsimio import load, mask, cosmo_array
+   from swiftsimio.visualisation.volume_render import render_gas
+
+   snapshot_filename = "cosmo_volume_example.hdf5"
+   catalog_filename = "fof_output_example.hdf5"
+
+   # Which halo are we looking at?
+   halo = 0
+
+   fof_catalog = load(catalog_filename)
+
+   fof_id = fof_catalog.fof_groups.group_ids[halo]
+   fof_radius = fof_catalog.fof_groups.radii[halo]
+   fof_centre = fof_catalog.fof_groups.centres[halo]
+
+   # Add some buffer space around the edges
+   fof_radius *= 1.1
+
+   # Define a region around the fof group
+   region = cosmo_array(
+       [
+           [fof_centre[0] - fof_radius, fof_centre[0] + fof_radius],
+           [fof_centre[1] - fof_radius, fof_centre[1] + fof_radius],
+           [fof_centre[2] - fof_radius, fof_centre[2] + fof_radius],
+       ],
+       fof_centre.units,
+       comoving=True,
+       scale_factor=fof_catalog.metadata.a,
+       scale_exponent=1,
+   )
+
+   # Only load data in our region of interest
+   data_mask = mask(snapshot_filename)
+   data_mask.constrain_spatial(region)
+
+   data = load(snapshot_filename, mask=data_mask)
+
+   halo_render = render_gas(
+       data,
+       resolution=512,
+       parallel=True,
+       region=region.ravel(),
+       periodic=True,
+       mask=data.gas.fofgroup_id == fof_id, # Only render particles in the group
+   )
+
+
 Other particle types
 --------------------
 

--- a/swiftsimio/visualisation/slice.py
+++ b/swiftsimio/visualisation/slice.py
@@ -24,6 +24,7 @@ def slice_pixel_grid(
     region: cosmo_array | None = None,
     backend: str = "sph",
     periodic: bool = True,
+    mask: np.ndarray | None = None,
 ) -> cosmo_array:
     """
     Create a data field-weighted 2D slice through a particle dataset as a pixel grid.
@@ -79,6 +80,12 @@ def slice_pixel_grid(
         Account for periodic boundaries for the simulation box?
         Default is ``True``.
 
+    mask : np.array, optional
+        Allows only a sub-set of the particles in data to be visualised. Useful
+        in cases where you have read data out of a ``velociraptor`` catalogue,
+        or if you only want to visualise e.g. star forming particles. This boolean
+        mask is applied just before visualisation.
+
     Returns
     -------
     cosmo_array
@@ -107,14 +114,15 @@ def slice_pixel_grid(
         if rotation_center is not None
         else np.zeros_like(data.metadata.boxsize[2])
     )
+    mask = mask if mask is not None else np.s_[...]
 
     # determine the effective number of pixels for each dimension
     xres = int(np.ceil(resolution * region_info["x_range"] / region_info["max_range"]))
     yres = int(np.ceil(resolution * region_info["y_range"] / region_info["max_range"]))
 
-    normed_x = (x - region_info["x_min"]) / region_info["max_range"]
-    normed_y = (y - region_info["y_min"]) / region_info["max_range"]
-    normed_z = z / region_info["max_range"]
+    normed_x = (x[mask] - region_info["x_min"]) / region_info["max_range"]
+    normed_y = (y[mask] - region_info["y_min"]) / region_info["max_range"]
+    normed_z = z[mask] / region_info["max_range"]
     normed_z_slice = (z_slice + z_center) / region_info["max_range"]
     if periodic:
         # place everything in the region inside [0, 1], the backend will tile as needed
@@ -122,6 +130,11 @@ def slice_pixel_grid(
         normed_y %= region_info["periodic_box_y"]
         normed_z %= region_info["periodic_box_z"]
         normed_z_slice %= region_info["periodic_box_z"]
+
+    # Apply the mask to the other arrays
+    m = m[mask]
+    hsml = hsml[mask]
+
     kwargs = dict(
         x=normed_x,
         y=normed_y,
@@ -152,6 +165,7 @@ def slice_gas(
     region: cosmo_array | None = None,
     backend: str = "sph",
     periodic: bool = True,
+    mask: np.ndarray | None = None,
 ) -> cosmo_array:
     """
     Create a data field-weighted 2D slice through the gas of a SWIFT dataset as a pixel grid.
@@ -207,6 +221,12 @@ def slice_gas(
         Account for periodic boundaries for the simulation box?
         Default is ``True``.
 
+    mask : np.array, optional
+        Allows only a sub-set of the particles in data to be visualised. Useful
+        in cases where you have read data out of a ``velociraptor`` catalogue,
+        or if you only want to visualise e.g. star forming particles. This boolean
+        mask is applied just before visualisation.
+
     Returns
     -------
     cosmo_array
@@ -231,4 +251,5 @@ def slice_gas(
         region=region,
         backend=backend,
         periodic=periodic,
+        mask=mask,
     )

--- a/swiftsimio/visualisation/volume_render.py
+++ b/swiftsimio/visualisation/volume_render.py
@@ -31,6 +31,7 @@ def render_voxel_grid(
     rotation_center: cosmo_array | None = None,
     region: cosmo_array | None = None,
     periodic: bool = True,
+    mask: np.ndarray | None = None,
 ) -> cosmo_array:
     """
     Create a data-field weighted 3D render of a particle dataset as a voxel grid.
@@ -77,6 +78,12 @@ def render_voxel_grid(
         Account for periodic boundaries for the simulation box?
         Default is ``True``.
 
+    mask : np.array, optional
+        Allows only a sub-set of the particles in data to be visualised. Useful
+        in cases where you have read data out of a ``velociraptor`` catalogue,
+        or if you only want to visualise e.g. star forming particles. This boolean
+        mask is applied just before visualisation.
+
     Returns
     -------
     cosmo_array
@@ -100,20 +107,22 @@ def render_voxel_grid(
         data, rotation_matrix, rotation_center, periodic
     )
 
-    normed_x = (x - region_info["x_min"]) / region_info["x_range"]
-    normed_y = (y - region_info["y_min"]) / region_info["y_range"]
-    normed_z = (z - region_info["z_min"]) / region_info["z_range"]
+    mask = mask if mask is not None else np.s_[...]
+    normed_x = (x[mask] - region_info["x_min"]) / region_info["x_range"]
+    normed_y = (y[mask] - region_info["y_min"]) / region_info["y_range"]
+    normed_z = (z[mask] - region_info["z_min"]) / region_info["z_range"]
     if periodic:
         # place everything in the region inside [0, 1], the backend will tile as needed
         normed_x %= region_info["periodic_box_x"]
         normed_y %= region_info["periodic_box_y"]
         normed_z %= region_info["periodic_box_z"]
+
     kwargs = dict(
         x=normed_x,
         y=normed_y,
         z=normed_z,
-        m=m,
-        h=hsml / region_info["x_range"],  # cubic so x_range == y_range == z_range
+        m=m[mask],
+        h=hsml[mask] / region_info["x_range"],  # cubic so x_range == y_range == z_range
         res=resolution,
         box_x=region_info["periodic_box_x"],
         box_y=region_info["periodic_box_y"],
@@ -135,6 +144,7 @@ def render_gas(
     rotation_center: cosmo_array | None = None,
     region: cosmo_array | None = None,
     periodic: bool = True,
+    mask: np.ndarray | None = None,
 ) -> cosmo_array:
     """
     Create a data-field weighted 3D render of the gas in a SWIFT dataset as a voxel grid.
@@ -181,6 +191,12 @@ def render_gas(
         Account for periodic boundaries for the simulation box?
         Default is ``True``.
 
+    mask : np.array, optional
+        Allows only a sub-set of the particles in data to be visualised. Useful
+        in cases where you have read data out of a ``velociraptor`` catalogue,
+        or if you only want to visualise e.g. star forming particles. This boolean
+        mask is applied just before visualisation.
+
     Returns
     -------
     cosmo_array
@@ -204,6 +220,7 @@ def render_gas(
         rotation_center=rotation_center,
         region=region,
         periodic=periodic,
+        mask=mask,
     )
 
 

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -1604,3 +1604,81 @@ def test_input_region_unmutated(cosmological_volume_only_single_local):
     assert np.allclose(im_region.to_physical_value(unyt.Mpc), float_region)
     project_gas(data, 16, region=im_region, periodic=False)
     assert np.allclose(im_region.to_physical_value(unyt.Mpc), float_region)
+
+
+class TestVisualisationMask:
+    """Tests for the particle masking functionality in projections and slices."""
+
+    def test_projection(self, cosmological_volume_only_single_local):
+        """
+        Tests masking for projections.
+
+        Passing the mask parameter should be equivalent to filtering out the un-masked data and calling without a mask.
+        """
+        sd = load(cosmological_volume_only_single_local)
+        n_gas = sd.metadata.n_gas
+
+        mask = np.zeros(n_gas, dtype=np.bool)
+        mask[::2] = True
+
+        parallel = True
+        box_res = 256
+
+        with np.errstate(
+            invalid="ignore"
+        ):  # invalid value encountered in divide happens sometimes
+            masked_img = project_gas(
+                sd, resolution=box_res, parallel=parallel, periodic=True, mask=mask
+            )
+
+            # Now we just get rid of all the masked outright.
+            for f in ("coordinates", "smoothing_lengths", "masses"):
+                masked_arr = getattr(sd.gas, f)[::2]
+                setattr(sd.gas, f, masked_arr)
+
+            ref_img = project_gas(
+                sd,
+                resolution=box_res,
+                parallel=parallel,
+                periodic=True,
+            )
+            assert np.allclose(masked_img, ref_img)
+
+    def test_slice(self, cosmological_volume_only_single_local):
+        """
+        Tests masking for slices.
+
+        Passing the mask parameter should be equivalent to filtering out the un-masked data and calling without a mask.
+        """
+        sd = load(cosmological_volume_only_single_local)
+        n_gas = sd.metadata.n_gas
+
+        mask = np.zeros(n_gas, dtype=np.bool)
+        mask[::2] = True
+
+        parallel = True
+        box_res = 256
+
+        with np.errstate(
+            invalid="ignore"
+        ):  # invalid value encountered in divide happens sometimes
+            masked_img = slice_gas(
+                sd,
+                resolution=box_res,
+                parallel=parallel,
+                periodic=True,
+                mask=mask,
+            )
+
+            # Now we just get rid of all the masked outright.
+            for f in ("coordinates", "smoothing_lengths", "masses"):
+                masked_arr = getattr(sd.gas, f)[::2]
+                setattr(sd.gas, f, masked_arr)
+
+            ref_img = slice_gas(
+                sd,
+                resolution=box_res,
+                parallel=parallel,
+                periodic=True,
+            )
+            assert np.allclose(masked_img, ref_img)

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -1686,3 +1686,42 @@ class TestVisualisationMask:
                 periodic=True,
             )
             assert np.allclose(masked_img, ref_img)
+
+    def test_render(self, cosmological_volume_only_single_local):
+        """
+        Tests masking for slices.
+
+        Passing the mask parameter should be equivalent to filtering out the un-masked data and calling without a mask.
+        """
+        sd = load(cosmological_volume_only_single_local)
+        n_gas = sd.metadata.n_gas
+
+        mask = np.zeros(n_gas, dtype=np.bool)
+        mask[::2] = True
+
+        parallel = True
+        box_res = 256
+
+        with np.errstate(
+            invalid="ignore"
+        ):  # invalid value encountered in divide happens sometimes
+            masked_img = render_gas(
+                sd,
+                resolution=box_res,
+                parallel=parallel,
+                periodic=True,
+                mask=mask,
+            )
+
+            # Now we just get rid of all the un-masked data outright.
+            for f in ("coordinates", "smoothing_lengths", "masses"):
+                masked_arr = getattr(sd.gas, f)[::2]
+                setattr(sd.gas, f, masked_arr)
+
+            ref_img = render_gas(
+                sd,
+                resolution=box_res,
+                parallel=parallel,
+                periodic=True,
+            )
+            assert np.allclose(masked_img, ref_img)

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -1628,7 +1628,11 @@ class TestVisualisationMask:
             invalid="ignore"
         ):  # invalid value encountered in divide happens sometimes
             masked_img = project_gas(
-                sd, resolution=box_res, parallel=parallel, periodic=True, mask=mask
+                sd,
+                resolution=box_res,
+                parallel=parallel,
+                periodic=True,
+                mask=mask,
             )
 
             # Now we just get rid of all the un-masked data outright.

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -1647,6 +1647,7 @@ class TestVisualisationMask:
                 periodic=True,
             )
             assert np.allclose(masked_img, ref_img)
+            assert np.any(masked_img > 0.0)
 
     def test_slice(self, cosmological_volume_only_single_local):
         """
@@ -1686,6 +1687,7 @@ class TestVisualisationMask:
                 periodic=True,
             )
             assert np.allclose(masked_img, ref_img)
+            assert np.any(masked_img > 0.0)
 
     def test_render(self, cosmological_volume_only_single_local):
         """
@@ -1725,3 +1727,4 @@ class TestVisualisationMask:
                 periodic=True,
             )
             assert np.allclose(masked_img, ref_img)
+            assert np.any(masked_img > 0.0)

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -1631,7 +1631,7 @@ class TestVisualisationMask:
                 sd, resolution=box_res, parallel=parallel, periodic=True, mask=mask
             )
 
-            # Now we just get rid of all the masked outright.
+            # Now we just get rid of all the un-masked data outright.
             for f in ("coordinates", "smoothing_lengths", "masses"):
                 masked_arr = getattr(sd.gas, f)[::2]
                 setattr(sd.gas, f, masked_arr)
@@ -1670,7 +1670,7 @@ class TestVisualisationMask:
                 mask=mask,
             )
 
-            # Now we just get rid of all the masked outright.
+            # Now we just get rid of all the un-masked data outright.
             for f in ("coordinates", "smoothing_lengths", "masses"):
                 masked_arr = getattr(sd.gas, f)[::2]
                 setattr(sd.gas, f, masked_arr)


### PR DESCRIPTION
This PR adds the mask kwarg to `slice_pixel_grid` and `slice_gas`, behaving similarly to the equivalent kwarg in `project_pixel_grid` and `project_gas`. I've also added a test for the functionality. I didn't see any tests for the mask kwarg for projections, so I include a test for that as well.